### PR TITLE
Fix for r40067

### DIFF
--- a/core/array/pack/q_spec.rb
+++ b/core/array/pack/q_spec.rb
@@ -10,7 +10,9 @@ describe "Array#pack with format 'Q'" do
   it_behaves_like :array_pack_arguments, 'Q'
   it_behaves_like :array_pack_numeric_basic, 'Q'
   it_behaves_like :array_pack_integer, 'Q'
-  it_behaves_like :array_pack_no_platform, 'Q'
+  ruby_version_is '' ... '2.0' do
+    it_behaves_like :array_pack_no_platform, 'Q'
+  end
 end
 
 describe "Array#pack with format 'q'" do
@@ -19,7 +21,9 @@ describe "Array#pack with format 'q'" do
   it_behaves_like :array_pack_arguments, 'q'
   it_behaves_like :array_pack_numeric_basic, 'q'
   it_behaves_like :array_pack_integer, 'q'
-  it_behaves_like :array_pack_no_platform, 'q'
+  ruby_version_is '' ... '2.0' do
+    it_behaves_like :array_pack_no_platform, 'q'
+  end
 end
 
 ruby_version_is "1.9.3" do

--- a/core/string/unpack/q_spec.rb
+++ b/core/string/unpack/q_spec.rb
@@ -31,12 +31,16 @@ end
 
 describe "String#unpack with format 'Q'" do
   it_behaves_like :string_unpack_basic, 'Q'
-  it_behaves_like :string_unpack_no_platform, 'Q'
+  ruby_version_is '' ... '2.1' do
+    it_behaves_like :string_unpack_no_platform, 'Q'
+  end
 end
 
 describe "String#unpack with format 'q'" do
   it_behaves_like :string_unpack_basic, 'q'
-  it_behaves_like :string_unpack_no_platform, 'q'
+  ruby_version_is '' ... '2.1' do
+    it_behaves_like :string_unpack_no_platform, 'q'
+  end
 end
 
 little_endian do


### PR DESCRIPTION
Fix these failed examples:

```
1)
Array#pack with format 'Q' raises ArgumentError when the format modifier is '_' FAILED
Expected ArgumentError but no exception was raised ( was returned)
/Users/mrkn/chkbuild/tmp/build/20130402T120332Z/rubyspec/core/array/pack/shared/basic.rb:59:in `block (2 levels) in <top (required)>'
/Users/mrkn/chkbuild/tmp/build/20130402T120332Z/rubyspec/core/array/pack/q_spec.rb:7:in `<top (required)>'

2)
Array#pack with format 'Q' raises ArgumentError when the format modifier is '!' FAILED
Expected ArgumentError but no exception was raised ( was returned)
/Users/mrkn/chkbuild/tmp/build/20130402T120332Z/rubyspec/core/array/pack/shared/basic.rb:63:in `block (2 levels) in <top (required)>'
/Users/mrkn/chkbuild/tmp/build/20130402T120332Z/rubyspec/core/array/pack/q_spec.rb:7:in `<top (required)>'

3)
Array#pack with format 'q' raises ArgumentError when the format modifier is '_' FAILED
Expected ArgumentError but no exception was raised ( was returned)
/Users/mrkn/chkbuild/tmp/build/20130402T120332Z/rubyspec/core/array/pack/shared/basic.rb:59:in `block (2 levels) in <top (required)>'
/Users/mrkn/chkbuild/tmp/build/20130402T120332Z/rubyspec/core/array/pack/q_spec.rb:16:in `<top (required)>'

4)
Array#pack with format 'q' raises ArgumentError when the format modifier is '!' FAILED
Expected ArgumentError but no exception was raised ( was returned)
/Users/mrkn/chkbuild/tmp/build/20130402T120332Z/rubyspec/core/array/pack/shared/basic.rb:63:in `block (2 levels) in <top (required)>'
/Users/mrkn/chkbuild/tmp/build/20130402T120332Z/rubyspec/core/array/pack/q_spec.rb:16:in `<top (required)>'

5)
String#unpack with format 'Q' raises an ArgumentError when the format modifier is '_' FAILED
Expected ArgumentError
but no exception was raised ([7523094288207667809] was returned)
/Users/mrkn/chkbuild/tmp/build/20130402T120332Z/rubyspec/core/string/unpack/shared/basic.rb:23:in `block (2 levels) in <top (required)>'
/Users/mrkn/chkbuild/tmp/build/20130402T120332Z/rubyspec/core/string/unpack/q_spec.rb:32:in `<top (required)>'

6)
String#unpack with format 'Q' raises an ArgumentError when the format modifier is '!' FAILED
Expected ArgumentError
but no exception was raised ([7523094288207667809] was returned)
/Users/mrkn/chkbuild/tmp/build/20130402T120332Z/rubyspec/core/string/unpack/shared/basic.rb:27:in `block (2 levels) in <top (required)>'
/Users/mrkn/chkbuild/tmp/build/20130402T120332Z/rubyspec/core/string/unpack/q_spec.rb:32:in `<top (required)>'

7)
String#unpack with format 'q' raises an ArgumentError when the format modifier is '_' FAILED
Expected ArgumentError
but no exception was raised ([7523094288207667809] was returned)
/Users/mrkn/chkbuild/tmp/build/20130402T120332Z/rubyspec/core/string/unpack/shared/basic.rb:23:in `block (2 levels) in <top (required)>'
/Users/mrkn/chkbuild/tmp/build/20130402T120332Z/rubyspec/core/string/unpack/q_spec.rb:37:in `<top (required)>'

8)
String#unpack with format 'q' raises an ArgumentError when the format modifier is '!' FAILED
Expected ArgumentError
but no exception was raised ([7523094288207667809] was returned)
/Users/mrkn/chkbuild/tmp/build/20130402T120332Z/rubyspec/core/string/unpack/shared/basic.rb:27:in `block (2 levels) in <top (required)>'
/Users/mrkn/chkbuild/tmp/build/20130402T120332Z/rubyspec/core/string/unpack/q_spec.rb:37:in `<top (required)>'
```
