### PR TITLE
Use ARCH_FLAG to build C extention library

### DIFF
--- a/optional/capi/spec_helper.rb
+++ b/optional/capi/spec_helper.rb
@@ -59,6 +59,7 @@ def compile_extension(name)
 
   cc        = RbConfig::CONFIG["CC"]
   cflags    = (ENV["CFLAGS"] || RbConfig::CONFIG["CFLAGS"]).dup
+  cflags   += " #{RbConfig::CONFIG["ARCH_FLAG"]}" if RbConfig::CONFIG["ARCH_FLAG"]
   cflags   += " -fPIC" unless cflags.include?("-fPIC")
   incflags  = "-I#{path} -I#{hdrdir}"
   incflags << " -I#{arch_hdrdir}" if arch_hdrdir
@@ -72,6 +73,7 @@ def compile_extension(name)
   end
 
   ldshared  = RbConfig::CONFIG["LDSHARED"]
+  ldshared += " #{RbConfig::CONFIG["ARCH_FLAG"]}" if RbConfig::CONFIG["ARCH_FLAG"]
   libpath   = "-L#{path}"
   libs      = RbConfig::CONFIG["LIBS"]
   dldflags  = "#{RbConfig::CONFIG["LDFLAGS"]} #{RbConfig::CONFIG["DLDFLAGS"]}"


### PR DESCRIPTION
This fixes errors like this:

```
/Users/mrkn/chkbuild/tmp/build/20130402T071104Z/rubyspec/optional/capi/array_spec.rb                                                In file included from /Users/mrkn/chkbuild/tmp/build/20130402T071104Z/rubyspec/optional/capi/ext/array_spec.c:1:
In file included from /Users/mrkn/chkbuild/tmp/build/20130402T071104Z/include/ruby-2.1.0/ruby.h:33:
/Users/mrkn/chkbuild/tmp/build/20130402T071104Z/include/ruby-2.1.0/ruby/ruby.h:107:37: error: 'ruby_check_sizeof_long' declared as an array with a negative size
typedef char ruby_check_sizeof_long[SIZEOF_LONG == sizeof(long) ? 1 : -1];
                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/mrkn/chkbuild/tmp/build/20130402T071104Z/include/ruby-2.1.0/i386-darwin12.3.0/ruby/config.h:48:21: note: expanded from macro 'SIZEOF_LONG'
#define SIZEOF_LONG 4
                    ^
In file included from /Users/mrkn/chkbuild/tmp/build/20130402T071104Z/rubyspec/optional/capi/ext/array_spec.c:1:
In file included from /Users/mrkn/chkbuild/tmp/build/20130402T071104Z/include/ruby-2.1.0/ruby.h:33:
/Users/mrkn/chkbuild/tmp/build/20130402T071104Z/include/ruby-2.1.0/ruby/ruby.h:111:38: error: 'ruby_check_sizeof_voidp' declared as an array with a negative size
typedef char ruby_check_sizeof_voidp[SIZEOF_VOIDP == sizeof(void*) ? 1 : -1];
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/mrkn/chkbuild/tmp/build/20130402T071104Z/include/ruby-2.1.0/i386-darwin12.3.0/ruby/config.h:52:22: note: expanded from macro 'SIZEOF_VOIDP'
#define SIZEOF_VOIDP 4
                     ^
In file included from /Users/mrkn/chkbuild/tmp/build/20130402T071104Z/rubyspec/optional/capi/ext/array_spec.c:1:
In file included from /Users/mrkn/chkbuild/tmp/build/20130402T071104Z/include/ruby-2.1.0/ruby.h:33:
In file included from /Users/mrkn/chkbuild/tmp/build/20130402T071104Z/include/ruby-2.1.0/ruby/ruby.h:1553:
In file included from /Users/mrkn/chkbuild/tmp/build/20130402T071104Z/include/ruby-2.1.0/ruby/intern.h:35:
/Users/mrkn/chkbuild/tmp/build/20130402T071104Z/include/ruby-2.1.0/ruby/st.h:54:45: error: 'st_check_for_sizeof_st_index_t' declared as an array with a negative size
typedef char st_check_for_sizeof_st_index_t[SIZEOF_VOIDP == (int)sizeof(st_index_t) ? 1 : -1];
                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/mrkn/chkbuild/tmp/build/20130402T071104Z/include/ruby-2.1.0/i386-darwin12.3.0/ruby/config.h:52:22: note: expanded from macro 'SIZEOF_VOIDP'
#define SIZEOF_VOIDP 4
                     ^
3 errors generated.
```
