### PR TITLE
Fix expectations for the result of `\0`.inspect which has been changed at r40413

### DIFF
--- a/core/string/inspect_spec.rb
+++ b/core/string/inspect_spec.rb
@@ -521,6 +521,12 @@ describe "String#inspect" do
       end
     end
 
+    ruby_version_is "2.1"..."" do
+      it "returns a string with a NUL character replaced by \\000" do
+        0.chr.inspect.should == '"\\000"'
+      end
+    end
+
     describe "when default external is UTF-8" do
       before :each do
         @extenc, Encoding.default_external = Encoding.default_external, Encoding::UTF_8
@@ -598,6 +604,12 @@ describe "String#inspect" do
       ruby_version_is "2.0" do
         it "returns a string with a NUL character replaced by \\0" do
           0.chr('utf-8').inspect.should == '"\\0"'
+        end
+      end
+
+      ruby_version_is "2.1"... do
+        it "returns a string with a NUL character replaced by \\000" do
+          0.chr('utf-8').inspect.should == '"\\000"'
         end
       end
 

--- a/language/symbol_spec.rb
+++ b/language/symbol_spec.rb
@@ -83,6 +83,12 @@ describe "A Symbol literal" do
       eval(':"\0" ').inspect.should == ':"\\0"'
     end
   end
+
+  ruby_version_is "2.1"..."" do
+    it "can contain null in the string" do
+      eval(':"\0" ').inspect.should == ':"\\000"'
+    end
+  end
 end
 
 language_version __FILE__, 'symbol'


### PR DESCRIPTION
T/O
