### PR TITLE
Fix expectation for the result of "\0".inspect in MRI 2.0.0

### DIFF
--- a/core/string/inspect_spec.rb
+++ b/core/string/inspect_spec.rb
@@ -509,20 +509,8 @@ describe "String#inspect" do
       ].should be_computed_by(:inspect)
     end
 
-    ruby_version_is "1.9"..."2.0" do
+    ruby_version_is "1.9".."2.1" do
       it "returns a string with a NUL character replaced by \\x notation" do
-        0.chr.inspect.should == '"\\x00"'
-      end
-    end
-
-    ruby_version_is "2.0"..."2.1" do
-      it "returns a string with a NUL character replaced by \\0" do
-        0.chr.inspect.should == '"\\0"'
-      end
-    end
-
-    ruby_version_is "2.1" do
-      it "returns a string with a NUL character replaced by \\u0000" do
         0.chr.inspect.should == '"\\x00"'
       end
     end
@@ -595,20 +583,8 @@ describe "String#inspect" do
         ].should be_computed_by(:inspect)
       end
 
-      ruby_version_is "1.9"..."2.0" do
-        it "returns a string with a NUL character replaced by \\x notation" do
-          0.chr('utf-8').inspect.should == '"\\u0000"'
-        end
-      end
-
-      ruby_version_is "2.0"..."2.1" do
-        it "returns a string with a NUL character replaced by \\0" do
-          0.chr('utf-8').inspect.should == '"\\0"'
-        end
-      end
-
-      ruby_version_is "2.1" do
-        it "returns a string with a NUL character replaced by \\0" do
+      ruby_version_is "1.9".."2.1" do
+        it "returns a string with a NUL character replaced by \\u notation" do
           0.chr('utf-8').inspect.should == '"\\u0000"'
         end
       end

--- a/language/symbol_spec.rb
+++ b/language/symbol_spec.rb
@@ -72,19 +72,7 @@ describe "A Symbol literal" do
     end
   end
 
-  ruby_version_is "1.9"..."2.0" do
-    it "can contain null in the string" do
-      eval(':"\0" ').inspect.should == ':"\\x00"'
-    end
-  end
-
-  ruby_version_is "2.0"..."2.1" do
-    it "can contain null in the string" do
-      eval(':"\0" ').inspect.should == ':"\\0"'
-    end
-  end
-
-  ruby_version_is "2.1" do
+  ruby_version_is "1.9".."2.1" do
     it "can contain null in the string" do
       eval(':"\0" ').inspect.should == ':"\\x00"'
     end


### PR DESCRIPTION
At r40488, MRI 2.0.0 head behaves like 1.9.3 and before about String#inspect
with NUL character.
