### PR TITLE
No more special treadment for "+(binary)" and "-(binary)" on to_sym.

### DIFF
--- a/core/string/shared/to_sym.rb
+++ b/core/string/shared/to_sym.rb
@@ -7,9 +7,11 @@ describe :string_to_sym, :shared => true do
     "abc=".send(@method).should == :abc=
   end
 
-  it "special cases +(binary) and -(binary)" do
-    "+(binary)".to_sym.should == :+
-    "-(binary)".to_sym.should == :-
+  ruby_version_is ""..."1.9" do
+    it "special cases +(binary) and -(binary)" do
+      "+(binary)".to_sym.should == :+
+        "-(binary)".to_sym.should == :-
+    end
   end
 
   ruby_version_is ""..."1.9" do


### PR DESCRIPTION
After r43413 (trunk) and r43415 (ruby_2_0_0), "+(binary)".to_sym and "-(binary)".to_sym don't treated as a special case.
