### PR TITLE
Hash#reject returns Hash instance

### DIFF
--- a/core/hash/reject_spec.rb
+++ b/core/hash/reject_spec.rb
@@ -25,14 +25,16 @@ describe "Hash#reject" do
     h.reject { false }.to_a.should == [[1, 2]]
   end
 
-  it "returns subclass instance for subclasses" do
-    HashSpecs::MyHash[1 => 2, 3 => 4].reject { false }.should be_kind_of(HashSpecs::MyHash)
-    HashSpecs::MyHash[1 => 2, 3 => 4].reject { true }.should be_kind_of(HashSpecs::MyHash)
-  end
+  ruby_bug "extra states should not be copied", "2.1" do
+    it "returns Hash instance for subclasses" do
+      HashSpecs::MyHash[1 => 2, 3 => 4].reject { false }.should be_kind_of(Hash)
+      HashSpecs::MyHash[1 => 2, 3 => 4].reject { true }.should be_kind_of(Hash)
+    end
 
-  it "taints the resulting hash" do
-    h = new_hash(:a => 1).taint
-    h.reject {false}.tainted?.should == true
+    it "taints the resulting hash" do
+      h = new_hash(:a => 1).taint
+      h.reject {false}.tainted?.should == false
+    end
   end
 
   it "processes entries with the same order as reject!" do


### PR DESCRIPTION
Hash#reject no longer copies extra states, e.g.: subclass,
taintedness, instance variables, and default value/block.
