### PR TITLE
remove wrong code

### DIFF
--- a/core/kernel/autoload_spec.rb
+++ b/core/kernel/autoload_spec.rb
@@ -100,12 +100,6 @@ describe "Kernel.autoload" do
   end
 
   ruby_version_is "1.9" do
-    it "sets the autoload constant in Object's metaclass's constant table" do
-      class << Object
-        should have_constant(:KSAutoloadBB)
-      end
-    end
-
     it "calls #to_path on non-String filenames" do
       p = mock('path')
       p.should_receive(:to_path).and_return @non_existent


### PR DESCRIPTION
remove wrong code, which is cause by `Module#constants` bug, and unrelated to `autoload` at all.
