### PR TITLE
Use 127.0.0.1 instead of localhost

### DIFF
--- a/library/net/ftp/fixtures/server.rb
+++ b/library/net/ftp/fixtures/server.rb
@@ -4,7 +4,7 @@ module NetFTPSpecs
     attr_reader :login_user, :login_pass, :login_acct
 
     def initialize(port = 9921)
-      @server = TCPServer.new("localhost", port)
+      @server = TCPServer.new("127.0.0.1", port)
 
       @handlers = {}
       @commands = []


### PR DESCRIPTION
OS X の環境で rubyspec を走らせると、net/ftp の spec でダミーの FTP サーバーを TCPServer で作っている箇所で localhost をうまく引けずに落ちることが頻繁に発生するようです。127.0.0.1 にすると落ちなくなるので変更してみました。
