### PR TITLE
bugs.ruby-lang.org/issues/11762: Add spec for Array#dig with non-numeric index

### DIFF
--- a/core/array/dig_spec.rb
+++ b/core/array/dig_spec.rb
@@ -8,6 +8,11 @@ ruby_version_is '2.3' do
       ['a'].dig(1).should be_nil
     end
 
+    it "returns nil if given a non-numeric index" do
+      ['a'].dig(:first).should be_nil
+      ['a'].dig('first').should be_nil
+    end
+
     it "recurses array elements" do
       a = [ [ 1, [2, '3'] ] ]
       a.dig(0, 0).should == 1


### PR DESCRIPTION
This spec currently fails but will pass when [11762](https://bugs.ruby-lang.org/issues/11762) is fixed.