### PR TITLE
Catchup ruby versions in language/regexp/character_classes_spec.rb

### DIFF
--- a/language/regexp/character_classes_spec.rb
+++ b/language/regexp/character_classes_spec.rb
@@ -149,7 +149,7 @@ describe "Regexp with character classes" do
     end
   end
 
-  ruby_version_is "2.2" do
+  ruby_version_is "2.2"..."2.4" do
     it "doesn't match Unicode Mongolian vowel seperator characters with [[:blank:]]" do
       "\u{180E}".match(/[[:blank:]]/).to_a.should == []
     end


### PR DESCRIPTION
The version specifier `ruby_version_is guard` exists in language/regexp/character_classes_spec.rb matched only before 2.3.
Current ruby trunk have version 2.4.0dev.
I extend the target version to 2.4.