### PR TITLE
Add tests for Time.at with BigDecimal input

### DIFF
--- a/core/time/at_spec.rb
+++ b/core/time/at_spec.rb
@@ -30,6 +30,13 @@ describe "Time.at" do
       t2.usec.should == t.usec
       t2.nsec.should == t.nsec
     end
+
+    describe "passed BigDecimal" do
+      it "doesn't round input value" do
+        require 'bigdecimal'
+        Time.at(BigDecimal.new('1.1')).to_f.should == 1.1
+      end
+    end
   end
 
   describe "passed Time" do


### PR DESCRIPTION
I've added a test that checks if `Time.at` rounds the input when a float BigDecimal is passed.

Probably the place of the test is wrong so let me know where it should be moved and I'll be happy to do that.

This relates to https://github.com/jruby/jruby/issues/3616