### PR TITLE
Numeric#step will not raise ArgumentError

### DIFF
--- a/core/numeric/step_spec.rb
+++ b/core/numeric/step_spec.rb
@@ -78,11 +78,13 @@ describe "Numeric#step" do
       1.step(5, "foo").should be_an_instance_of(enumerator_class)
     end
 
-    it "raises an ArgumentError if given a block" do
-      lambda { 1.step(5, "1") {} }.should raise_error(ArgumentError)
-      lambda { 1.step(5, "0.1") {} }.should raise_error(ArgumentError)
-      lambda { 1.step(5, "1/3") {} }.should raise_error(ArgumentError)
-      lambda { 1.step(5, "foo") {} }.should raise_error(ArgumentError)
+    invalid_step = ruby_version_is("2.1".."2.3") {ArgumentError}
+    invalid_step ||= StandardError # TypeError
+    it "raises an #{invalid_step} if given a block" do
+      lambda { 1.step(5, "1") {} }.should raise_error(invalid_step)
+      lambda { 1.step(5, "0.1") {} }.should raise_error(invalid_step)
+      lambda { 1.step(5, "1/3") {} }.should raise_error(invalid_step)
+      lambda { 1.step(5, "foo") {} }.should raise_error(invalid_step)
     end
   end
 


### PR DESCRIPTION
`Numeric#step` will no longer raise `ArgumentError` when step is a
non-numeric object.

https://bugs.ruby-lang.org/issues/9810