### PR TITLE
Numeric#step now raises TypeError

### DIFF
--- a/core/numeric/step_spec.rb
+++ b/core/numeric/step_spec.rb
@@ -78,7 +78,7 @@ describe "Numeric#step" do
       1.step(5, "foo").should be_an_instance_of(enumerator_class)
     end
 
-    invalid_step = ruby_version_is("2.1".."2.3") {ArgumentError}
+    invalid_step = ruby_version_is("2.0".."2.3") {ArgumentError}
     invalid_step ||= StandardError # TypeError
     it "raises an #{invalid_step} if given a block" do
       lambda { 1.step(5, "1") {} }.should raise_error(invalid_step)

--- a/core/numeric/step_spec.rb
+++ b/core/numeric/step_spec.rb
@@ -79,7 +79,7 @@ describe "Numeric#step" do
     end
 
     invalid_step = ruby_version_is("2.0".."2.3") {ArgumentError}
-    invalid_step ||= StandardError # TypeError
+    invalid_step ||= TypeError
     it "raises an #{invalid_step} if given a block" do
       lambda { 1.step(5, "1") {} }.should raise_error(invalid_step)
       lambda { 1.step(5, "0.1") {} }.should raise_error(invalid_step)


### PR DESCRIPTION
`Numeric#step` now raises `TypeError` instead of `ArgumentError`
when step is a non-numeric object.

https://bugs.ruby-lang.org/issues/9810