### PR TITLE
Restriction of private method in Delegator

### DIFF
--- a/library/delegate/delegator/send_spec.rb
+++ b/library/delegate/delegator/send_spec.rb
@@ -19,8 +19,10 @@ describe "SimpleDelegator.new" do
     lambda{ @delegate.priv }.should raise_error( NoMethodError )
   end
 
-  it "doesn't forward private method calls even via send or __send__" do
-    lambda{ @delegate.send(:priv, 42)     }.should raise_error( NoMethodError )
-    lambda{ @delegate.__send__(:priv, 42) }.should raise_error( NoMethodError )
+  ruby_version_is ""..."2.4" do
+    it "doesn't forward private method calls even via send or __send__" do
+      lambda{ @delegate.send(:priv, 42)     }.should raise_error( NoMethodError )
+      lambda{ @delegate.__send__(:priv, 42) }.should raise_error( NoMethodError )
+    end
   end
 end


### PR DESCRIPTION
Restriction that private method cannot be called from Delegator may be removed now.
https://bugs.ruby-lang.org/issues/12113