### PR TITLE
NoMethodError should not require a name 

### DIFF
--- a/core/exception/no_method_error_spec.rb
+++ b/core/exception/no_method_error_spec.rb
@@ -5,6 +5,10 @@ describe "NoMethodError.new" do
   it "allows passing method args" do
     NoMethodError.new("msg","name","args").args.should == "args"
   end
+
+  it "does not require a name" do
+    NoMethodError.new("msg").message.should == "msg"
+  end
 end
 
 describe "NoMethodError#args" do


### PR DESCRIPTION
(because underlying NameError class does not)