### PR TITLE
get rid of blocking on Windows

### DIFF
--- a/core/process/fixtures/kill.rb
+++ b/core/process/fixtures/kill.rb
@@ -7,7 +7,7 @@ ruby_exe = ARGV.shift
 # We must do this first otherwise there will be a race with the process that
 # creates this process and the TERM signal below could go to that process
 # instead, which will likely abort the specs process.
-Process.setsid if scenario
+Process.setsid if scenario && Process.respond_to?(:setsid)
 
 signaled = false
 mutex = Mutex.new
@@ -26,7 +26,7 @@ File.open(pid_file, "wb") { |f| f.puts Process.pid }
 
 if scenario
   # We are sending a signal to ourselves or the process group
-  process = "Process.getpgid(Process.pid)"
+  process = Process.respond_to?(:getpgid) ? "Process.getpgid(Process.pid)" : "Process.pid"
 
   case scenario
   when "self"


### PR DESCRIPTION
When an exception (NotImplementedError) raises in the process, of course it is not signaled, and sleep forever.