### PR TITLE
Correcting a Time#gmtoff test in optional/capi/time_spec.rb

### DIFF
--- a/optional/capi/time_spec.rb
+++ b/optional/capi/time_spec.rb
@@ -274,7 +274,8 @@ describe "CApiTimeSpecs" do
 
       it "returns time object in localtime if offset given equals INT_MAX" do
         @s.rb_time_timespec_new(1447087832, 476451125, 0x7fffffff).should == Time.at(1447087832, 476451.125).localtime
-        @s.rb_time_timespec_new(1447087832, 476451125, 0x7fffffff).gmtoff.should == Time.now.gmtoff
+        t = Time.now
+        @s.rb_time_timespec_new(t.tv_sec, t.tv_nsec, 0x7fffffff).gmtoff.should == t.gmtoff
       end
 
       it "raises an ArgumentError if offset passed is not within range of -86400 and 86400 (exclusive)" do


### PR DESCRIPTION
This pull request corrects a test that can fail when performed during summer time (daylight-saving time). Time#gmtoff values match only when both or neither of the Time objects are in summer time. The original test compares Time.now.gmtoff with the gmtoff of a Time object representing "2015-11-09", so it succeeds or fails, depending on today's date, if performed in a place which observes summer time. A more robust test is to use the Time objects derived from the same time (Time.now in this case) on both sides of the comparison.