### PR TITLE
Started adding spec for coverage

### DIFF
--- a/library/coverage/fixtures/start_coverage.rb
+++ b/library/coverage/fixtures/start_coverage.rb
@@ -1,0 +1,3 @@
+2 + 2
+Coverage.start
+1 + 1

--- a/library/coverage/peek_result_spec.rb
+++ b/library/coverage/peek_result_spec.rb
@@ -1,0 +1,6 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+require 'coverage'
+
+describe 'Coverage.peek_result' do
+  it 'needs to be reviewed for spec completeness'
+end

--- a/library/coverage/result_spec.rb
+++ b/library/coverage/result_spec.rb
@@ -1,0 +1,34 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+require 'coverage'
+
+describe 'Coverage.result' do
+  before :all do
+    @config_file = fixture __FILE__, 'start_coverage.rb'
+  end
+
+  after :each do
+    $LOADED_FEATURES.delete(@config_file)
+  end
+
+  it 'gives the covered files as a hash with arrays' do
+    Coverage.start
+    require @config_file.chomp('.rb')
+    result = Coverage.result
+
+    result.should == { @config_file => [1, 1, 1] }
+  end
+
+  it 'should list coverage for the required file starting coverage' do
+    require @config_file.chomp('.rb')
+    result = Coverage.result
+
+    result.should == { @config_file => [] }
+  end
+
+  it 'should list coverage for the loaded file starting coverage' do
+    load @config_file
+    result = Coverage.result
+
+    result.should == { @config_file => [] }
+  end
+end

--- a/library/coverage/start_spec.rb
+++ b/library/coverage/start_spec.rb
@@ -1,0 +1,6 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+require 'coverage'
+
+describe 'Coverage.start' do
+  it 'needs to be reviewed for spec completeness'
+end


### PR DESCRIPTION
My first contribution to ruby/spec, so I expect to have to change a lot.

First question is that the specs seem organized around methods, but coverage is typically the interaction between the `Coverage.start` and `Coverage.result` methods.  How should the specs for this interaction be organized?
