### PR TITLE
Fix Dir.pwd encoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ rvm:
   - 2.2.4
   - 2.3.0
   - ruby-head
+addons:
+  apt:
+    packages:
+    - libgmp-dev
 install:
   - git clone https://github.com/ruby/mspec.git ../mspec
 script:

--- a/core/dir/shared/pwd.rb
+++ b/core/dir/shared/pwd.rb
@@ -2,6 +2,9 @@ describe :dir_pwd, shared: true do
   with_feature :encoding do
     before :each do
       @fs_encoding = Encoding.find('filesystem')
+      if @fs_encoding == Encoding::US_ASCII
+        @fs_encoding = Encoding::ASCII_8BIT
+      end
     end
   end
 


### PR DESCRIPTION
If filesystem encoding is US-ASCII, the encoding of `Dir.pwd`
result is ASCII-8BIT.