### PR TITLE
Support for AIX in system_call_error_spec.rb

### DIFF
--- a/core/exception/system_call_error_spec.rb
+++ b/core/exception/system_call_error_spec.rb
@@ -74,7 +74,12 @@ end
 
 describe "SystemCallError#message" do
   it "returns the default message when no message is given" do
-    SystemCallError.new(2**28).message.should =~ /Unknown error/i
+    platform_is :aix do
+      SystemCallError.new(2**28).message.should =~ /Error .*occurred/i
+    end
+    platform_is_not :aix do
+      SystemCallError.new(2**28).message.should =~ /Unknown error/i
+    end
   end
 
   it "returns the message given as an argument to new" do


### PR DESCRIPTION
The default error message for an unknown errno is system-dependent. In AIX, it is "Error <errno> occurred". (FYI, it is "Unknown error <errno>" in Linux and "Unknown error: <errno>" in Mac OS X.)