### PR TITLE
AIX does not allow mkdir(2) to set a sticky bit

### DIFF
--- a/shared/file/sticky.rb
+++ b/shared/file/sticky.rb
@@ -8,7 +8,7 @@ describe :file_sticky, shared: true do
     Dir.rmdir(@dir) if File.exist?(@dir)
   end
 
-  platform_is_not :windows, :darwin, :freebsd, :netbsd, :openbsd, :solaris do
+  platform_is_not :windows, :darwin, :freebsd, :netbsd, :openbsd, :solaris, :aix do
     it "returns true if the named file has the sticky bit, otherwise false" do
       Dir.mkdir @dir, 01755
 

--- a/shared/file/sticky.rb
+++ b/shared/file/sticky.rb
@@ -10,7 +10,7 @@ describe :file_sticky, shared: true do
 
   platform_is_not :windows, :darwin, :freebsd, :netbsd, :openbsd, :solaris do
     it "returns true if the named file has the sticky bit, otherwise false" do
-      Dir.mkdir @dir, 1755
+      Dir.mkdir @dir, 01755
 
       @object.send(@method, @dir).should == true
       @object.send(@method, '/').should == false


### PR DESCRIPTION
Exempt AIX in shared/file/sticky.rb.

Also, I think "1755" is a typo, so fixed it to "01755".  Actually, 1755 is 03333 in octal, so the sticky bit (01000) happens to be set, which means this fix does not change the intention of the test.