### PR TITLE
Fill spec change opal compatibility

### DIFF
--- a/core/array/fill_spec.rb
+++ b/core/array/fill_spec.rb
@@ -205,10 +205,12 @@ describe "Array#fill with (filler, index, length)" do
     lambda { [].fill('a', obj) }.should raise_error(TypeError)
   end
 
-  it "raises an ArgumentError or RangeError for too-large sizes" do
-    arr = [1, 2, 3]
-    lambda { arr.fill(10, 1, fixnum_max) }.should raise_error(ArgumentError)
-    lambda { arr.fill(10, 1, bignum_value) }.should raise_error(RangeError)
+  not_supported_on :opal do
+    it "raises an ArgumentError or RangeError for too-large sizes" do
+      arr = [1, 2, 3]
+      lambda { arr.fill(10, 1, fixnum_max) }.should raise_error(ArgumentError)
+      lambda { arr.fill(10, 1, bignum_value) }.should raise_error(RangeError)
+    end
   end
 end
 


### PR DESCRIPTION
Change fron e60792ca2fe08ff2bb2f00eff7c6d70547cfc42e crashes Opal, so don't execute on that platform