### PR TITLE
setgroups() in AIX allows a non-root process to set its primary group ID

### DIFF
--- a/core/process/groups_spec.rb
+++ b/core/process/groups_spec.rb
@@ -21,18 +21,24 @@ describe "Process.groups" do
       else
         platform_is :aix do
           # setgroups() is not part of the POSIX standard,
-          # so its behavior varis from OS to OS.  AIX allows a non-root
+          # so its behavior varies from OS to OS.  AIX allows a non-root
           # process to set the supplementary group IDs, as long as
           # they are presently in its supplementary group IDs.
-          # The order of the following three tests matter.
+          # The order of the following tests matters.
           # After this process executes "Process.groups = []"
           # it should no longer be able to set any supplementary
           # group IDs, even if it originally belonged to them.
+          # It should only be able to set its primary group ID.
           Process.groups = groups
           Process.groups.sort.should == groups.sort
           Process.groups = []
           Process.groups.should == []
-          lambda { Process.groups = groups }.should raise_error(Errno::EPERM)
+          Process.groups = [ Process.gid ]
+          Process.groups.should == [ Process.gid ]
+          supplementary = groups - [ Process.gid ]
+          if supplementary.length > 0
+            lambda { Process.groups = supplementary }.should raise_error(Errno::EPERM)
+          end
         end
         platform_is_not :aix do
           lambda { Process.groups = [] }.should raise_error(Errno::EPERM)


### PR DESCRIPTION
The previous pull request was not completely correct. In AIX, a non-root process cannot "add" a supplementary group ID with setgroups(), but it can set its primary group ID.