### PR TITLE
AIX does not support RLIMIT_MEMLOCK

### DIFF
--- a/core/process/setrlimit_spec.rb
+++ b/core/process/setrlimit_spec.rb
@@ -74,8 +74,10 @@ platform_is_not :windows do
       end
 
       platform_is_not :solaris do
-        it "coerces :MEMLOCK into RLIMIT_MEMLOCK" do
-          Process.setrlimit(:MEMLOCK, *Process.getrlimit(Process::RLIMIT_MEMLOCK)).should be_nil
+        platform_is_not :aix do
+          it "coerces :MEMLOCK into RLIMIT_MEMLOCK" do
+            Process.setrlimit(:MEMLOCK, *Process.getrlimit(Process::RLIMIT_MEMLOCK)).should be_nil
+          end
         end
 
         it "coerces :NPROC into RLIMIT_NPROC" do
@@ -154,8 +156,10 @@ platform_is_not :windows do
       end
 
       platform_is_not :solaris do
-        it "coerces 'MEMLOCK' into RLIMIT_MEMLOCK" do
-          Process.setrlimit("MEMLOCK", *Process.getrlimit(Process::RLIMIT_MEMLOCK)).should be_nil
+        platform_is_not :aix do
+          it "coerces 'MEMLOCK' into RLIMIT_MEMLOCK" do
+            Process.setrlimit("MEMLOCK", *Process.getrlimit(Process::RLIMIT_MEMLOCK)).should be_nil
+          end
         end
 
         it "coerces 'NPROC' into RLIMIT_NPROC" do


### PR DESCRIPTION
Exempt AIX from the tests regarding RLIMIT_MEMLOCK.