### PR TITLE
Cannot flock DATA with LOCK_EX on AIX

### DIFF
--- a/language/predefined/data_spec.rb
+++ b/language/predefined/data_spec.rb
@@ -23,7 +23,7 @@ describe "The DATA constant" do
     str.chomp.should == "data only"
   end
 
-  platform_is_not :windows, :solaris do
+  platform_is_not :windows, :solaris, :aix do
     it "succeeds in locking the file DATA came from" do
       path = fixture(__FILE__, "data_flock.rb")
 


### PR DESCRIPTION
Ruby opens a script as read-only, but AIX does not allow a read-only-opened file to be flock'ed with LOCK_EX. This means DATA.flock(File::LOCK_EX) fails on AIX, throwing EBADF.