### PR TITLE
Fix suggest-attribute=noreturn

### DIFF
--- a/optional/capi/ext/exception_spec.c
+++ b/optional/capi/ext/exception_spec.c
@@ -30,7 +30,7 @@ VALUE exception_spec_rb_exc_new3(VALUE self, VALUE str) {
 
 #ifdef HAVE_RB_EXC_RAISE
 VALUE exception_spec_rb_exc_raise(VALUE self, VALUE exc) {
-  rb_exc_raise(exc);
+    if (self != Qundef) rb_exc_raise(exc);
   return Qnil;
 }
 #endif

--- a/optional/capi/ext/kernel_spec.c
+++ b/optional/capi/ext/kernel_spec.c
@@ -112,7 +112,8 @@ VALUE kernel_spec_rb_eval_string(VALUE self, VALUE str) {
 #ifdef HAVE_RB_RAISE
 VALUE kernel_spec_rb_raise(VALUE self, VALUE hash) {
   rb_hash_aset(hash, ID2SYM(rb_intern("stage")), ID2SYM(rb_intern("before")));
-  rb_raise(rb_eTypeError, "Wrong argument type %s (expected %s)", "Integer", "String");
+  if (self != Qundef)
+    rb_raise(rb_eTypeError, "Wrong argument type %s (expected %s)", "Integer", "String");
   rb_hash_aset(hash, ID2SYM(rb_intern("stage")), ID2SYM(rb_intern("after")));
   return Qnil;
 }
@@ -120,14 +121,14 @@ VALUE kernel_spec_rb_raise(VALUE self, VALUE hash) {
 
 #ifdef HAVE_RB_THROW
 VALUE kernel_spec_rb_throw(VALUE self, VALUE result) {
-  rb_throw("foo", result);
+  if (self != Qundef) rb_throw("foo", result);
   return ID2SYM(rb_intern("rb_throw_failed"));
 }
 #endif
 
 #ifdef HAVE_RB_THROW_OBJ
 VALUE kernel_spec_rb_throw_obj(VALUE self, VALUE obj, VALUE result) {
-  rb_throw_obj(obj, result);
+  if (self != Qundef) rb_throw_obj(obj, result);
   return ID2SYM(rb_intern("rb_throw_failed"));
 }
 #endif
@@ -187,7 +188,7 @@ VALUE kernel_spec_rb_sys_fail(VALUE self, VALUE msg) {
   errno = 1;
   if(msg == Qnil) {
     rb_sys_fail(0);
-  } else {
+  } else if (self != Qundef) {
     rb_sys_fail(StringValuePtr(msg));
   }
   return Qnil;
@@ -198,7 +199,7 @@ VALUE kernel_spec_rb_sys_fail(VALUE self, VALUE msg) {
 VALUE kernel_spec_rb_syserr_fail(VALUE self, VALUE err, VALUE msg) {
   if(msg == Qnil) {
     rb_syserr_fail(NUM2INT(err), NULL);
-  } else {
+  } else if (self != Qundef) {
     rb_syserr_fail(NUM2INT(err), StringValuePtr(msg));
   }
   return Qnil;


### PR DESCRIPTION
Since r54943 (ruby/ruby@a6c8e8d), `-Wsuggest-attribute=noreturn`
is added if possible, and some functions which call `NORETURN`
functions are subjects of this option and warned.  To suppress
these warnings, call `NORETURN` functions in always-true runtime
conditions, `self != Qundef`.