### PR TITLE
protoize CAPI test codes

### DIFF
--- a/optional/capi/ext/array_spec.c
+++ b/optional/capi/ext/array_spec.c
@@ -264,7 +264,7 @@ static VALUE array_spec_rb_ary_subseq(VALUE self, VALUE ary, VALUE begin, VALUE 
 }
 #endif
 
-void Init_array_spec() {
+void Init_array_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiArraySpecs", rb_cObject);
 

--- a/optional/capi/ext/bignum_spec.c
+++ b/optional/capi/ext/bignum_spec.c
@@ -83,7 +83,7 @@ static VALUE bignum_spec_RBIGNUM_LEN(VALUE self, VALUE num) {
 }
 #endif
 
-void Init_bignum_spec() {
+void Init_bignum_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiBignumSpecs", rb_cObject);
 

--- a/optional/capi/ext/class_spec.c
+++ b/optional/capi/ext/class_spec.c
@@ -167,7 +167,7 @@ static VALUE class_spec_include_module(VALUE self, VALUE klass, VALUE module) {
 }
 #endif
 
-void Init_class_spec() {
+void Init_class_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiClassSpecs", rb_cObject);
 

--- a/optional/capi/ext/complex_spec.c
+++ b/optional/capi/ext/complex_spec.c
@@ -41,7 +41,7 @@ static VALUE complex_spec_rb_complex_new2(VALUE self, VALUE num, VALUE den) {
 }
 #endif
 
-void Init_complex_spec() {
+void Init_complex_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiComplexSpecs", rb_cObject);
 

--- a/optional/capi/ext/constants_spec.c
+++ b/optional/capi/ext/constants_spec.c
@@ -377,7 +377,7 @@ static VALUE constants_spec_rb_cDir(VALUE self) {
 }
 #endif
 
-void Init_constants_spec() {
+void Init_constants_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiConstantsSpecs", rb_cObject);
 

--- a/optional/capi/ext/data_spec.c
+++ b/optional/capi/ext/data_spec.c
@@ -73,7 +73,7 @@ VALUE sws_change_struct(VALUE self, VALUE obj, VALUE new_val) {
   return Qnil;
 }
 
-void Init_data_spec() {
+void Init_data_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiAllocSpecs", rb_cObject);
 

--- a/optional/capi/ext/encoding_spec.c
+++ b/optional/capi/ext/encoding_spec.c
@@ -269,7 +269,7 @@ static VALUE encoding_spec_rb_enc_codepoint_len(VALUE self, VALUE str) {
 }
 #endif
 
-void Init_encoding_spec() {
+void Init_encoding_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiEncodingSpecs", rb_cObject);
 

--- a/optional/capi/ext/enumerator_spec.c
+++ b/optional/capi/ext/enumerator_spec.c
@@ -13,7 +13,7 @@ VALUE enumerator_spec_rb_enumeratorize(int argc, VALUE *argv, VALUE self) {
 }
 #endif
 
-void Init_enumerator_spec() {
+void Init_enumerator_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiEnumeratorSpecs", rb_cObject);
 

--- a/optional/capi/ext/exception_spec.c
+++ b/optional/capi/ext/exception_spec.c
@@ -42,7 +42,7 @@ VALUE exception_spec_rb_set_errinfo(VALUE self, VALUE exc) {
 }
 #endif
 
-void Init_exception_spec() {
+void Init_exception_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiExceptionSpecs", rb_cObject);
 

--- a/optional/capi/ext/file_spec.c
+++ b/optional/capi/ext/file_spec.c
@@ -23,7 +23,7 @@ VALUE file_spec_FilePathValue(VALUE self, VALUE obj) {
 }
 #endif
 
-void Init_file_spec() {
+void Init_file_spec(void) {
   VALUE cls = rb_define_class("CApiFileSpecs", rb_cObject);
 
 #ifdef HAVE_RB_FILE_OPEN

--- a/optional/capi/ext/fixnum_spec.c
+++ b/optional/capi/ext/fixnum_spec.c
@@ -18,7 +18,7 @@ static VALUE fixnum_spec_rb_fix2int(VALUE self, VALUE value) {
 #endif
 
 
-void Init_fixnum_spec() {
+void Init_fixnum_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiFixnumSpecs", rb_cObject);
 

--- a/optional/capi/ext/float_spec.c
+++ b/optional/capi/ext/float_spec.c
@@ -31,7 +31,7 @@ static VALUE float_spec_RFLOAT_VALUE(VALUE self, VALUE float_h) {
 }
 #endif
 
-void Init_float_spec() {
+void Init_float_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiFloatSpecs", rb_cObject);
 

--- a/optional/capi/ext/gc_spec.c
+++ b/optional/capi/ext/gc_spec.c
@@ -31,7 +31,7 @@ static VALUE gc_spec_rb_gc_disable() {
 #endif
 
 
-void Init_gc_spec() {
+void Init_gc_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiGCSpecs", rb_cObject);
 

--- a/optional/capi/ext/globals_spec.c
+++ b/optional/capi/ext/globals_spec.c
@@ -121,7 +121,7 @@ static VALUE global_spec_rb_lastline_get(VALUE self) {
 }
 #endif
 
-void Init_globals_spec() {
+void Init_globals_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiGlobalSpecs", rb_cObject);
 

--- a/optional/capi/ext/hash_spec.c
+++ b/optional/capi/ext/hash_spec.c
@@ -128,7 +128,7 @@ VALUE hash_spec_rb_hash_set_ifnone(VALUE self, VALUE hash, VALUE def) {
 }
 #endif
 
-void Init_hash_spec() {
+void Init_hash_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiHashSpecs", rb_cObject);
 

--- a/optional/capi/ext/integer_spec.c
+++ b/optional/capi/ext/integer_spec.c
@@ -15,7 +15,7 @@ static VALUE integer_spec_rb_integer_pack(VALUE self, VALUE value,
 }
 #endif
 
-void Init_integer_spec() {
+void Init_integer_spec(void) {
 #ifdef HAVE_RB_INTEGER_PACK
   VALUE cls;
   cls = rb_define_class("CApiIntegerSpecs", rb_cObject);

--- a/optional/capi/ext/io_spec.c
+++ b/optional/capi/ext/io_spec.c
@@ -211,7 +211,7 @@ VALUE io_spec_rb_io_close(VALUE self, VALUE io) {
 }
 #endif
 
-void Init_io_spec() {
+void Init_io_spec(void) {
   VALUE cls = rb_define_class("CApiIOSpecs", rb_cObject);
 
 #ifdef HAVE_GET_OPEN_FILE

--- a/optional/capi/ext/kernel_spec.c
+++ b/optional/capi/ext/kernel_spec.c
@@ -288,7 +288,7 @@ static VALUE kernel_spec_rb_funcall_with_block(VALUE self, VALUE obj, VALUE meth
 }
 #endif
 
-void Init_kernel_spec() {
+void Init_kernel_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiKernelSpecs", rb_cObject);
 

--- a/optional/capi/ext/marshal_spec.c
+++ b/optional/capi/ext/marshal_spec.c
@@ -17,7 +17,7 @@ VALUE marshal_spec_rb_marshal_load(VALUE self, VALUE data) {
 }
 #endif
 
-void Init_marshal_spec() {
+void Init_marshal_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiMarshalSpecs", rb_cObject);
 

--- a/optional/capi/ext/module_spec.c
+++ b/optional/capi/ext/module_spec.c
@@ -146,7 +146,7 @@ static VALUE module_specs_rbclass2name(VALUE self, VALUE klass) {
 }
 #endif
 
-void Init_module_spec() {
+void Init_module_spec(void) {
   VALUE cls;
 
   cls = rb_define_class("CApiModuleSpecs", rb_cObject);

--- a/optional/capi/ext/mutex_spec.c
+++ b/optional/capi/ext/mutex_spec.c
@@ -52,7 +52,7 @@ VALUE mutex_spec_rb_mutex_synchronize(VALUE self, VALUE mutex, VALUE value) {
 }
 #endif
 
-void Init_mutex_spec() {
+void Init_mutex_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiMutexSpecs", rb_cObject);
 

--- a/optional/capi/ext/numeric_spec.c
+++ b/optional/capi/ext/numeric_spec.c
@@ -96,7 +96,7 @@ static VALUE numeric_spec_rb_num_coerce_relop(VALUE self, VALUE x, VALUE y, VALU
 }
 #endif
 
-void Init_numeric_spec() {
+void Init_numeric_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiNumericSpecs", rb_cObject);
 

--- a/optional/capi/ext/object_spec.c
+++ b/optional/capi/ext/object_spec.c
@@ -394,7 +394,7 @@ static VALUE object_spec_rb_class_inherited_p(VALUE self, VALUE mod, VALUE arg) 
 #endif
 
 
-void Init_object_spec() {
+void Init_object_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiObjectSpecs", rb_cObject);
 

--- a/optional/capi/ext/proc_spec.c
+++ b/optional/capi/ext/proc_spec.c
@@ -49,7 +49,7 @@ VALUE proc_spec_rb_Proc_new(VALUE self, VALUE scenario) {
   return Qnil;
 }
 
-void Init_proc_spec() {
+void Init_proc_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiProcSpecs", rb_cObject);
 

--- a/optional/capi/ext/range_spec.c
+++ b/optional/capi/ext/range_spec.c
@@ -29,7 +29,7 @@ VALUE range_spec_rb_range_values(VALUE self, VALUE range) {
 }
 #endif
 
-void Init_range_spec() {
+void Init_range_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiRangeSpecs", rb_cObject);
 

--- a/optional/capi/ext/rational_spec.c
+++ b/optional/capi/ext/rational_spec.c
@@ -53,7 +53,7 @@ static VALUE rational_spec_rb_rational_den(VALUE self, VALUE rational) {
 }
 #endif
 
-void Init_rational_spec() {
+void Init_rational_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiRationalSpecs", rb_cObject);
 

--- a/optional/capi/ext/regexp_spec.c
+++ b/optional/capi/ext/regexp_spec.c
@@ -49,7 +49,7 @@ VALUE regexp_spec_match(VALUE self, VALUE regexp, VALUE str) {
   return rb_funcall(regexp, rb_intern("match"), 1, str);
 }
 
-void Init_regexp_spec() {
+void Init_regexp_spec(void) {
   VALUE cls = rb_define_class("CApiRegexpSpecs", rb_cObject);
 
   rb_define_method(cls, "match", regexp_spec_match, 2);

--- a/optional/capi/ext/string_spec.c
+++ b/optional/capi/ext/string_spec.c
@@ -416,7 +416,7 @@ static VALUE string_spec_rb_usascii_str_new_cstr(VALUE self, VALUE str) {
 }
 #endif
 
-void Init_string_spec() {
+void Init_string_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiStringSpecs", rb_cObject);
 

--- a/optional/capi/ext/struct_spec.c
+++ b/optional/capi/ext/struct_spec.c
@@ -50,7 +50,7 @@ static VALUE struct_spec_rb_struct_new(VALUE self, VALUE klass,
 }
 #endif
 
-void Init_struct_spec() {
+void Init_struct_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiStructSpecs", rb_cObject);
 

--- a/optional/capi/ext/symbol_spec.c
+++ b/optional/capi/ext/symbol_spec.c
@@ -87,7 +87,7 @@ VALUE symbol_spec_rb_sym2str(VALUE self, VALUE sym) {
 }
 #endif
 
-void Init_symbol_spec() {
+void Init_symbol_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiSymbolSpecs", rb_cObject);
 

--- a/optional/capi/ext/thread_spec.c
+++ b/optional/capi/ext/thread_spec.c
@@ -300,7 +300,7 @@ static VALUE thread_spec_rb_thread_create(VALUE self, VALUE proc, VALUE arg) {
 #endif
 
 
-void Init_thread_spec() {
+void Init_thread_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiThreadSpecs", rb_cObject);
 

--- a/optional/capi/ext/time_spec.c
+++ b/optional/capi/ext/time_spec.c
@@ -72,7 +72,7 @@ static VALUE time_spec_TIMET2NUM(VALUE self) {
 }
 #endif
 
-void Init_time_spec() {
+void Init_time_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiTimeSpecs", rb_cObject);
 

--- a/optional/capi/ext/typed_data_spec.c
+++ b/optional/capi/ext/typed_data_spec.c
@@ -118,7 +118,7 @@ VALUE sws_typed_change_struct(VALUE self, VALUE obj, VALUE new_val) {
   return Qnil;
 }
 
-void Init_typed_data_spec() {
+void Init_typed_data_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiAllocTypedSpecs", rb_cObject);
 

--- a/optional/capi/ext/util_spec.c
+++ b/optional/capi/ext/util_spec.c
@@ -66,7 +66,7 @@ static VALUE util_spec_rb_sourceline(VALUE self) {
 }
 #endif
 
-void Init_util_spec() {
+void Init_util_spec(void) {
   VALUE cls = rb_define_class("CApiUtilSpecs", rb_cObject);
 
 #ifdef HAVE_RB_SCAN_ARGS


### PR DESCRIPTION
In C, a function declaration with bare `()` is not a prototype
declaration, but an old K&R style definition, which has no
information about the parameters.  Needs `void` in the
parentheses.