### PR TITLE
Update case mapping related in preparation for Unicode case mapping

### DIFF
--- a/core/string/capitalize_spec.rb
+++ b/core/string/capitalize_spec.rb
@@ -17,10 +17,12 @@ describe "String#capitalize" do
     "hello".taint.capitalize.tainted?.should == true
   end
 
-  it "is locale insensitive (only upcases a-z and only downcases A-Z)" do
-    "ÄÖÜ".capitalize.should == "ÄÖÜ"
-    "ärger".capitalize.should == "ärger"
-    "BÄR".capitalize.should == "BÄr"
+  ruby_version_is ''...'2.4' do
+    it "is locale insensitive (only upcases a-z and only downcases A-Z)" do
+      "ÄÖÜ".capitalize.should == "ÄÖÜ"
+      "ärger".capitalize.should == "ärger"
+      "BÄR".capitalize.should == "BÄr"
+    end
   end
 
   it "returns subclass instances when called on a subclass" do

--- a/core/string/downcase_spec.rb
+++ b/core/string/downcase_spec.rb
@@ -8,16 +8,18 @@ describe "String#downcase" do
     "hello".downcase.should == "hello"
   end
 
-  it "is locale insensitive (only replaces A-Z)" do
-    "ÄÖÜ".downcase.should == "ÄÖÜ"
-
-    str = Array.new(256) { |c| c.chr }.join
-    expected = Array.new(256) do |i|
-      c = i.chr
-      c.between?("A", "Z") ? c.downcase : c
-    end.join
-
-    str.downcase.should == expected
+  ruby_version_is ''...'2.4' do
+    it "is locale insensitive (only replaces A-Z)" do
+      "ÄÖÜ".downcase.should == "ÄÖÜ"
+  
+      str = Array.new(256) { |c| c.chr }.join
+      expected = Array.new(256) do |i|
+        c = i.chr
+        c.between?("A", "Z") ? c.downcase : c
+      end.join
+  
+      str.downcase.should == expected
+    end
   end
 
   it "taints result when self is tainted" do

--- a/core/string/swapcase_spec.rb
+++ b/core/string/swapcase_spec.rb
@@ -14,10 +14,12 @@ describe "String#swapcase" do
     "hello".taint.swapcase.tainted?.should == true
   end
 
-  it "is locale insensitive (only upcases a-z and only downcases A-Z)" do
-    "ÄÖÜ".swapcase.should == "ÄÖÜ"
-    "ärger".swapcase.should == "äRGER"
-    "BÄR".swapcase.should == "bÄr"
+  ruby_version_is ''...'2.4' do
+    it "is locale insensitive (only upcases a-z and only downcases A-Z)" do
+      "ÄÖÜ".swapcase.should == "ÄÖÜ"
+      "ärger".swapcase.should == "äRGER"
+      "BÄR".swapcase.should == "bÄr"
+    end
   end
 
   it "returns subclass instances when called on a subclass" do

--- a/core/string/upcase_spec.rb
+++ b/core/string/upcase_spec.rb
@@ -8,16 +8,18 @@ describe "String#upcase" do
     "hello".upcase.should == "HELLO"
   end
 
-  it "is locale insensitive (only replaces a-z)" do
-    "äöü".upcase.should == "äöü"
-
-    str = Array.new(256) { |c| c.chr }.join
-    expected = Array.new(256) do |i|
-      c = i.chr
-      c.between?("a", "z") ? c.upcase : c
-    end.join
-
-    str.upcase.should == expected
+  ruby_version_is ''...'2.4' do
+    it "is locale insensitive (only replaces a-z)" do
+      "äöü".upcase.should == "äöü"
+  
+      str = Array.new(256) { |c| c.chr }.join
+      expected = Array.new(256) do |i|
+        c = i.chr
+        c.between?("a", "z") ? c.upcase : c
+      end.join
+  
+      str.upcase.should == expected
+    end
   end
 
   it "taints result when self is tainted" do

--- a/core/symbol/capitalize_spec.rb
+++ b/core/symbol/capitalize_spec.rb
@@ -10,10 +10,15 @@ describe "Symbol#capitalize" do
     :lower.capitalize.should == :Lower
   end
 
-  it "leaves the first character alone if it is not an alphabetical ASCII character" do
+  it "leaves the first character alone if it is not an alphabetical character" do
     :"£1.20".capitalize.should == :"£1.20"
-    "\u{00DE}c".to_sym.capitalize.should == :"Þc"
-    "\u{00DF}C".to_sym.capitalize.should == :"ßc"
+  end
+
+  ruby_version_is ''...'2.4' do
+    it "leaves the first character alone if it is not an alphabetical ASCII character" do
+      "\u{00DE}c".to_sym.capitalize.should == :"Þc"
+      "\u{00DF}C".to_sym.capitalize.should == :"ßc"
+    end
   end
 
   it "converts subsequent uppercase ASCII characters to their lowercase equivalents" do
@@ -28,11 +33,13 @@ describe "Symbol#capitalize" do
     :mIxEd.capitalize.should == :Mixed
   end
 
-  it "leaves uppercase Unicode characters as they were" do
-    "a\u{00DE}c".to_sym.capitalize.should == :"AÞc"
+  ruby_version_is ''...'2.4' do
+    it "leaves uppercase Unicode characters as they were" do
+      "a\u{00DE}c".to_sym.capitalize.should == :"AÞc"
+    end  
   end
 
-  it "leaves lowercase Unicode characters as they were" do
+  it "leaves lowercase Unicode characters (except in first position) as they were" do
     "a\u{00DF}C".to_sym.capitalize.should == :"Aßc"
   end
 

--- a/core/symbol/downcase_spec.rb
+++ b/core/symbol/downcase_spec.rb
@@ -11,11 +11,13 @@ describe "Symbol#downcase" do
   end
 
   it "leaves lowercase Unicode characters as they were" do
-    "\u{C0}Bc".to_sym.downcase.should == :"Àbc"
+    "\u{E0}Bc".to_sym.downcase.should == :"àbc"
   end
 
-  it "leaves uppercase Unicode characters as they were" do
-    "\u{DE}Bc".to_sym.downcase.should == :"Þbc"
+  ruby_version_is ''...'2.4' do
+    it "leaves uppercase Unicode characters as they were" do
+      "\u{DE}Bc".to_sym.downcase.should == :"Þbc"
+    end
   end
 
   it "leaves non-alphabetic ASCII characters as they were" do

--- a/core/symbol/swapcase_spec.rb
+++ b/core/symbol/swapcase_spec.rb
@@ -18,12 +18,14 @@ describe "Symbol#swapcase" do
     :mIxEd.swapcase.should == :MiXeD
   end
 
-  it "leaves uppercase Unicode characters as they were" do
-    "\u{00DE}Bc".to_sym.swapcase.should == :"ÞbC"
-  end
-
-  it "leaves lowercase Unicode characters as they were" do
-    "\u{00DF}Bc".to_sym.swapcase.should == :"ßbC"
+  ruby_version_is ''...'2.4' do
+    it "leaves uppercase Unicode characters as they were" do
+      "\u{00DE}Bc".to_sym.swapcase.should == :"ÞbC"
+    end
+  
+    it "leaves lowercase Unicode characters as they were" do
+      "\u{00DF}Bc".to_sym.swapcase.should == :"ßbC"
+    end
   end
 
   it "leaves non-alphabetic ASCII characters as they were" do

--- a/core/symbol/upcase_spec.rb
+++ b/core/symbol/upcase_spec.rb
@@ -10,8 +10,10 @@ describe "Symbol#upcase" do
     :lOwEr.upcase.should == :LOWER
   end
 
-  it "leaves lowercase Unicode characters as they were" do
-    "\u{C0}Bc".to_sym.upcase.should == :"ÀBC"
+  ruby_version_is ''...'2.4' do
+    it "leaves lowercase Unicode characters as they were" do
+      "\u{E0}Bc".to_sym.upcase.should == :"àBC"
+    end
   end
 
   it "leaves non-alphabetic ASCII characters as they were" do


### PR DESCRIPTION
Guard Unicode-related specs limiting changes to ASCII rang for
[String|Symbol]#[capitalize|downcase|swapcase|upcase]
so that they are not tested on Ruby 2.4. Also, fix two tests that
pretended "\u{C0}" (À) to be a lowercase character.