### PR TITLE
Wrap String#rindex specs containing regexp anchors with `not_supported_on :opal`.

### DIFF
--- a/core/string/rindex_spec.rb
+++ b/core/string/rindex_spec.rb
@@ -306,9 +306,11 @@ describe "String#rindex with Regexp" do
     "blablablax".rindex(/.x/, 7).should == nil
     "blablablax".rindex(/..x/, 6).should == nil
 
-    "blablabla".rindex(/\Z/, 5).should == nil
-    "blablabla".rindex(/\z/, 5).should == nil
-    "blablabla\n".rindex(/\z/, 9).should == nil
+    not_supported_on :opal do
+      "blablabla".rindex(/\Z/, 5).should == nil
+      "blablabla".rindex(/\z/, 5).should == nil
+      "blablabla\n".rindex(/\z/, 9).should == nil
+    end
   end
 
   not_supported_on :opal do


### PR DESCRIPTION
I really don't like these `not_supported_on :opal` pieces everywhere. I know how to remove ~80% of them and I definitely should do it after https://github.com/opal/opal/pull/1465 gets merged. Can we merge this PR for now? btw, I could also extract all tests containing regexp anchors to a separate `describe` and wrap it only once with `not_supported_on`. @eregon What do you think?