### PR TITLE
AIX does not allow Process.getsid(pid) if pid is in a different session

### DIFF
--- a/core/process/setsid_spec.rb
+++ b/core/process/setsid_spec.rb
@@ -21,13 +21,17 @@ describe "Process.setsid" do
       write.close
       read2.close
       pgid_child = read.gets
+      pgid_child = Integer(pgid_child)
       read.close
-      pgid = Process.getsid(pid)
+      platform_is_not :aix do
+        # AIX does not allow Process.getsid(pid)
+        # if pid is in a different session.
+        pgid = Process.getsid(pid)
+        pgid_child.should == pgid
+      end
       write2.close
       Process.wait pid
 
-      pgid_child = Integer(pgid_child)
-      pgid_child.should == pgid
       pgid_child.should_not == Process.getsid
     end
   end


### PR DESCRIPTION
Please push this pull request back if it is too platform-specific.