### PR TITLE
Remove `rb_cFixnum` and `rb_cBignum`

### DIFF
--- a/optional/capi/constants_spec.rb
+++ b/optional/capi/constants_spec.rb
@@ -11,8 +11,10 @@ describe "C-API constant" do
     @s.rb_cArray.should == Array
   end
 
-  specify "rb_cBignum references the Bignum class" do
-    @s.rb_cBignum.should == Bignum
+  if CApiConstantsSpecs.method_defined?(:rb_cBignum)
+    specify "rb_cBignum references the Bignum class" do
+      @s.rb_cBignum.should == Bignum
+    end
   end
 
   specify "rb_cClass references the Class class" do
@@ -39,8 +41,10 @@ describe "C-API constant" do
     @s.rb_cFile.should == File
   end
 
-  specify "rb_cFixnum references the Fixnum class" do
-    @s.rb_cFixnum.should == Fixnum
+  if CApiConstantsSpecs.method_defined?(:rb_cFixnum)
+    specify "rb_cFixnum references the Fixnum class" do
+      @s.rb_cFixnum.should == Fixnum
+    end
   end
 
   specify "rb_cFloat references the Float class" do

--- a/optional/capi/ext/rubyspec.h
+++ b/optional/capi/ext/rubyspec.h
@@ -123,12 +123,16 @@
 
 /* Constants */
 #define HAVE_RB_CARRAY                     1
+#ifndef RUBY_INTEGER_UNIFICATION
 #define HAVE_RB_CBIGNUM                    1
+#endif
 #define HAVE_RB_CCLASS                     1
 #define HAVE_RB_CDATA                      1
 #define HAVE_RB_CFALSECLASS                1
 #define HAVE_RB_CFILE                      1
+#ifndef RUBY_INTEGER_UNIFICATION
 #define HAVE_RB_CFIXNUM                    1
+#endif
 #define HAVE_RB_CFLOAT                     1
 #define HAVE_RB_CHASH                      1
 #define HAVE_RB_CINTEGER                   1


### PR DESCRIPTION
Since ruby 2.4, `Fixnum` and `Bignum` are unified to `Integer`.
`rb_cFixnum` and `rb_cBignum` will not be defined in the future.
Check `RUBY_INTEGER_UNIFICATION` for these symbols.

Currently `rb_cFixnum` and `rb_cBignum` are defined as
`rb_cInteger` in `include/ruby/backward.h` for the backward
compatibilities, however, we want to try a preview without these
macros to warn library authors.


