### PR TITLE
Skip OpenSSL::Random.pseudo_bytes if not defined

### DIFF
--- a/library/openssl/random/pseudo_bytes_spec.rb
+++ b/library/openssl/random/pseudo_bytes_spec.rb
@@ -1,6 +1,8 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
 require File.expand_path('../shared/random_bytes.rb', __FILE__)
 
-describe "OpenSSL::Random#pseudo_bytes" do
-  it_behaves_like :openssl_random_bytes, :pseudo_bytes
+if defined?(OpenSSL::Random.pseudo_bytes)
+  describe "OpenSSL::Random.pseudo_bytes" do
+    it_behaves_like :openssl_random_bytes, :pseudo_bytes
+  end
 end

--- a/library/openssl/random/random_bytes_spec.rb
+++ b/library/openssl/random/random_bytes_spec.rb
@@ -1,6 +1,6 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
 require File.expand_path('../shared/random_bytes.rb', __FILE__)
 
-describe "OpenSSL::Random#random_bytes" do
+describe "OpenSSL::Random.random_bytes" do
   it_behaves_like :openssl_random_bytes, :random_bytes
 end

--- a/library/openssl/random/shared/random_bytes.rb
+++ b/library/openssl/random/shared/random_bytes.rb
@@ -4,7 +4,7 @@ require 'openssl'
 describe :openssl_random_bytes, shared: true do |cmd|
   it "generates a random binary string of specified length" do
     (1..64).each do |idx|
-      bytes = OpenSSL::Random.pseudo_bytes(idx)
+      bytes = OpenSSL::Random.send(@method, idx)
       bytes.should be_kind_of(String)
       bytes.length.should == idx
     end
@@ -14,7 +14,7 @@ describe :openssl_random_bytes, shared: true do |cmd|
     # quick and dirty check, but good enough
     values = []
     256.times do
-      val = OpenSSL::Random.pseudo_bytes(16)
+      val = OpenSSL::Random.send(@method, 16)
       # make sure the random bytes are not repeating
       values.include?(val).should == false
       values << val
@@ -23,7 +23,7 @@ describe :openssl_random_bytes, shared: true do |cmd|
 
   it "raises ArgumentError on negative arguments" do
     lambda {
-      OpenSSL::Random.pseudo_bytes(-1)
+      OpenSSL::Random.send(@method, -1)
     }.should raise_error(ArgumentError)
   end
 end


### PR DESCRIPTION
RAND_pseudo_bytes() is deprecated in OpenSSL 1.1.0, and ext/openssl disables OpenSSL::Random.pseudo_bytes when built with the version of OpenSSL.

- https://git.openssl.org/gitweb/?p=openssl.git;a=commit;h=302d38e3f73d5fd2ba2fd30bb7798778cb9f18dd
- https://svn.ruby-lang.org/cgi-bin/viewvc.cgi?view=revision&revision=55282