### PR TITLE
Avoid using the "daemon" group because it might not exist

### DIFF
--- a/library/etc/getgrnam_spec.rb
+++ b/library/etc/getgrnam_spec.rb
@@ -14,7 +14,9 @@ end
 platform_is_not :windows do
   describe "Etc.getgrnam" do
     it "returns a Etc::Group struct instance for the given group" do
-      gr = Etc.getgrnam("daemon")
+      gr_name = Etc.getgrent.name
+      Etc.endgrent
+      gr = Etc.getgrnam(gr_name)
       gr.is_a?(Etc::Group).should == true
     end
 


### PR DESCRIPTION
The Etc.getgrnam spec uses a hard-coded group name "daemon", but it does not necessarily exist in the system. Instead, use the first group name in the system returned by Etc.getgrent.