### PR TITLE
Skip specs for getsockopt that are known to fail due to a bug in AIX

### DIFF
--- a/library/socket/basicsocket/getsockopt_spec.rb
+++ b/library/socket/basicsocket/getsockopt_spec.rb
@@ -11,14 +11,19 @@ describe "BasicSocket#getsockopt" do
     @sock.close
   end
 
-  it "gets a socket option Socket::SO_TYPE" do
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_TYPE).to_s
-    n.should == [Socket::SOCK_STREAM].pack("i")
-  end
+  platform_is_not :aix do
+    # A known bug in AIX.  getsockopt(2) does not properly set
+    # the fifth argument for SO_TYPE, SO_OOBINLINE, SO_BROADCAST, etc.
 
-  it "gets a socket option Socket::SO_OOBINLINE" do
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-    n.should == [0].pack("i")
+    it "gets a socket option Socket::SO_TYPE" do
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_TYPE).to_s
+      n.should == [Socket::SOCK_STREAM].pack("i")
+    end
+
+    it "gets a socket option Socket::SO_OOBINLINE" do
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+      n.should == [0].pack("i")
+    end
   end
 
   it "gets a socket option Socket::SO_LINGER" do


### PR DESCRIPTION
getsockopt(2) of AIX does not properly set the fifth argument for SO_TYPE, SO_OOBINLINE, SO_BROADCAST, etc.  This is a know bug in AIX and no fix has been provided yet by IBM. Is it OK to skip the related specs for the time being?  I am not sure how rubyspec should handle this kind of bugs in the underlying system.