### PR TITLE
Skip specs that use getsockopt(2), which has a bug on AIX

### DIFF
--- a/library/socket/basicsocket/setsockopt_spec.rb
+++ b/library/socket/basicsocket/setsockopt_spec.rb
@@ -36,70 +36,75 @@ describe "BasicSocket#setsockopt" do
     end
   end
 
-  it "sets the socket option Socket::SO_OOBINLINE" do
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, true).should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-    n.should_not == [0].pack("i")
+  platform_is_not :aix do
+    # A known bug in AIX.  getsockopt(2) does not properly set
+    # the fifth argument for SO_TYPE, SO_OOBINLINE, SO_BROADCAST, etc.
 
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, false).should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-    n.should == [0].pack("i")
+    it "sets the socket option Socket::SO_OOBINLINE" do
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, true).should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+      n.should_not == [0].pack("i")
 
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, 1).should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-    n.should_not == [0].pack("i")
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, false).should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+      n.should == [0].pack("i")
 
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, 0).should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-    n.should == [0].pack("i")
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, 1).should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+      n.should_not == [0].pack("i")
 
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, 2).should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-    n.should_not == [0].pack("i")
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, 0).should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+      n.should == [0].pack("i")
 
-    platform_is_not os: :windows do
-      lambda {
-        @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, "")
-      }.should raise_error(SystemCallError)
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, 2).should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+      n.should_not == [0].pack("i")
+
+      platform_is_not os: :windows do
+        lambda {
+          @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, "")
+        }.should raise_error(SystemCallError)
+      end
+
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, "blah").should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+      n.should_not == [0].pack("i")
+
+      platform_is_not os: :windows do
+        lambda {
+          @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, "0")
+        }.should raise_error(SystemCallError)
+      end
+
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, "\x00\x00\x00\x00").should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+      n.should == [0].pack("i")
+
+      platform_is_not os: :windows do
+        lambda {
+          @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, "1")
+        }.should raise_error(SystemCallError)
+      end
+
+      platform_is_not os: :windows do
+        lambda {
+          @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, "\x00\x00\x00")
+        }.should raise_error(SystemCallError)
+      end
+
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, [1].pack('i')).should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+      n.should_not == [0].pack("i")
+
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, [0].pack('i')).should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+      n.should == [0].pack("i")
+
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, [1000].pack('i')).should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+      n.should_not == [0].pack("i")
     end
-
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, "blah").should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-    n.should_not == [0].pack("i")
-
-    platform_is_not os: :windows do
-      lambda {
-        @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, "0")
-      }.should raise_error(SystemCallError)
-    end
-
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, "\x00\x00\x00\x00").should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-    n.should == [0].pack("i")
-
-    platform_is_not os: :windows do
-      lambda {
-        @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, "1")
-      }.should raise_error(SystemCallError)
-    end
-
-    platform_is_not os: :windows do
-      lambda {
-        @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, "\x00\x00\x00")
-      }.should raise_error(SystemCallError)
-    end
-
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, [1].pack('i')).should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-    n.should_not == [0].pack("i")
-
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, [0].pack('i')).should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-    n.should == [0].pack("i")
-
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, [1000].pack('i')).should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-    n.should_not == [0].pack("i")
   end
 
   it "sets the socket option Socket::SO_SNDBUF" do


### PR DESCRIPTION
getsockopt(2) of AIX does not properly set the fifth argument for SO_TYPE, SO_OOBINLINE, SO_BROADCAST, etc.