### PR TITLE
Add specs for Array#reject!, delete_if 2.3 change

### DIFF
--- a/core/array/delete_if_spec.rb
+++ b/core/array/delete_if_spec.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
 require File.expand_path('../shared/enumeratorize', __FILE__)
+require File.expand_path('../shared/delete_if', __FILE__)
 require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "Array#delete_if" do
@@ -61,4 +62,5 @@ describe "Array#delete_if" do
   end
 
   it_behaves_like :enumeratorized_with_origin_size, :delete_if, [1,2,3]
+  it_behaves_like :delete_if, :delete_if
 end

--- a/core/array/reject_spec.rb
+++ b/core/array/reject_spec.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
 require File.expand_path('../shared/enumeratorize', __FILE__)
+require File.expand_path('../shared/delete_if', __FILE__)
 require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "Array#reject" do
@@ -112,4 +113,5 @@ describe "Array#reject!" do
 
   it_behaves_like :enumeratorize, :reject!
   it_behaves_like :enumeratorized_with_origin_size, :reject!, [1,2,3]
+  it_behaves_like :delete_if, :reject!
 end

--- a/core/array/shared/delete_if.rb
+++ b/core/array/shared/delete_if.rb
@@ -1,0 +1,27 @@
+describe :delete_if, shared: true do
+  before :each do
+    @object = [1,2,3]
+  end
+
+  ruby_version_is "2.3" do
+    it "updates the receiver after all blocks" do
+      @object.send(@method) do |e|
+        @object.length.should == 3
+        true
+      end
+      @object.length.should == 0
+    end
+  end
+
+  ruby_version_is ""..."2.3" do
+    it "updates the receiver after each true block" do
+      count = 0
+      @object.send(@method) do |e|
+        @object.length.should == (3 - count)
+        count += 1
+        true
+      end
+      @object.length.should == 0
+    end
+  end
+end

--- a/core/array/shared/keep_if.rb
+++ b/core/array/shared/keep_if.rb
@@ -11,6 +11,15 @@ describe :keep_if, shared: true do
     [1, 2, 3].send(@method).should be_an_instance_of(enumerator_class)
   end
 
+  it "updates the receiver after all blocks" do
+    a = [1, 2, 3]
+    a.send(@method) do |e|
+      a.length.should == 3
+      false
+    end
+    a.length.should == 0
+  end
+
   before :all do
     @object = [1,2,3]
   end


### PR DESCRIPTION
From #175:
Array#select!, Array#keep_if, Array#reject!, and Array#delete_if
no longer changes the receiver array instantly every time the
block is called. Feature #10714

Note, select! and keep_if's behavior seems to be unchanged with 2.3.
I tested with 2.3.1, 2.2.5, 2.1.8, and 2.0.0-p648 and they don't mutate the
receiver after each block, only after all blocks.