### PR TITLE
Import Socket::Option specs from rubysl-socket

### DIFF
--- a/library/socket/socket/option/bool_spec.rb
+++ b/library/socket/socket/option/bool_spec.rb
@@ -1,0 +1,56 @@
+# Copyright (c) 2013, Brian Shirai
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# 3. Neither the name of the library nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without
+#    specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require File.expand_path('../../../../../spec_helper', __FILE__)
+require File.expand_path('../../../fixtures/classes', __FILE__)
+
+require 'socket'
+
+describe 'Socket::Option.bool' do
+  it 'returns a Socket::Option' do
+    opt = Socket::Option.bool(:INET, :SOCKET, :KEEPALIVE, true)
+
+    opt.should be_an_instance_of(Socket::Option)
+
+    opt.family.should  == Socket::AF_INET
+    opt.level.should   == Socket::SOL_SOCKET
+    opt.optname.should == Socket::SO_KEEPALIVE
+    opt.data.should    == [1].pack('i')
+  end
+end
+
+describe 'Socket::Option#bool' do
+  it 'returns a boolean' do
+    Socket::Option.bool(:INET, :SOCKET, :KEEPALIVE, true).bool.should  == true
+    Socket::Option.bool(:INET, :SOCKET, :KEEPALIVE, false).bool.should == false
+  end
+
+  it 'raises TypeError when called on a non boolean option' do
+    opt = Socket::Option.linger(1, 4)
+
+    proc { opt.bool }.should raise_error(TypeError)
+  end
+end

--- a/library/socket/socket/option/initialize_spec.rb
+++ b/library/socket/socket/option/initialize_spec.rb
@@ -1,0 +1,106 @@
+# Copyright (c) 2013, Brian Shirai
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# 3. Neither the name of the library nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without
+#    specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require File.expand_path('../../../../../spec_helper', __FILE__)
+require File.expand_path('../../../fixtures/classes', __FILE__)
+
+require 'socket'
+
+describe 'Socket::Option#initialize' do
+  before do
+    @bool = [0].pack('i')
+  end
+
+  describe 'using Fixnums' do
+    it 'returns a Socket::Option' do
+      opt = Socket::Option
+        .new(Socket::AF_INET, Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, @bool)
+
+      opt.should be_an_instance_of(Socket::Option)
+
+      opt.family.should  == Socket::AF_INET
+      opt.level.should   == Socket::SOL_SOCKET
+      opt.optname.should == Socket::SO_KEEPALIVE
+      opt.data.should    == @bool
+    end
+  end
+
+  describe 'using Symbols' do
+    it 'returns a Socket::Option' do
+      opt = Socket::Option.new(:INET, :SOCKET, :KEEPALIVE, @bool)
+
+      opt.should be_an_instance_of(Socket::Option)
+
+      opt.family.should  == Socket::AF_INET
+      opt.level.should   == Socket::SOL_SOCKET
+      opt.optname.should == Socket::SO_KEEPALIVE
+      opt.data.should    == @bool
+    end
+
+    it 'raises when using an invalid address family' do
+      proc { Socket::Option.new(:INET2, :SOCKET, :KEEPALIVE, @bool) }
+        .should raise_error(SocketError)
+    end
+
+    it 'raises when using an invalid level' do
+      proc { Socket::Option.new(:INET, :CATS, :KEEPALIVE, @bool) }
+        .should raise_error(SocketError)
+    end
+
+    it 'raises when using an invalid option name' do
+      proc { Socket::Option.new(:INET, :SOCKET, :CATS, @bool) }
+        .should raise_error(SocketError)
+    end
+  end
+
+  describe 'using Strings' do
+    it 'returns a Socket::Option' do
+      opt = Socket::Option.new('INET', 'SOCKET', 'KEEPALIVE', @bool)
+
+      opt.should be_an_instance_of(Socket::Option)
+
+      opt.family.should  == Socket::AF_INET
+      opt.level.should   == Socket::SOL_SOCKET
+      opt.optname.should == Socket::SO_KEEPALIVE
+      opt.data.should    == @bool
+    end
+
+    it 'raises when using an invalid address family' do
+      proc { Socket::Option.new('INET2', 'SOCKET', 'KEEPALIVE', @bool) }
+        .should raise_error(SocketError)
+    end
+
+    it 'raises when using an invalid level' do
+      proc { Socket::Option.new('INET', 'CATS', 'KEEPALIVE', @bool) }
+        .should raise_error(SocketError)
+    end
+
+    it 'raises when using an invalid option name' do
+      proc { Socket::Option.new('INET', 'SOCKET', 'CATS', @bool) }
+        .should raise_error(SocketError)
+    end
+  end
+end

--- a/library/socket/socket/option/int_spec.rb
+++ b/library/socket/socket/option/int_spec.rb
@@ -1,0 +1,55 @@
+# Copyright (c) 2013, Brian Shirai
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# 3. Neither the name of the library nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without
+#    specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require File.expand_path('../../../../../spec_helper', __FILE__)
+require File.expand_path('../../../fixtures/classes', __FILE__)
+
+require 'socket'
+
+describe 'Socket::Option.int' do
+  it 'returns a Socket::Option' do
+    opt = Socket::Option.int(:INET, :IP, :TTL, 4)
+
+    opt.should be_an_instance_of(Socket::Option)
+
+    opt.family.should  == Socket::AF_INET
+    opt.level.should   == Socket::IPPROTO_IP
+    opt.optname.should == Socket::IP_TTL
+    opt.data.should    == [4].pack('i')
+  end
+end
+
+describe 'Socket::Option#int' do
+  it 'returns a Fixnum' do
+    Socket::Option.int(:INET, :IP, :TTL, 4).int.should == 4
+  end
+
+  it 'raises TypeError when called on a non integer option' do
+    opt = Socket::Option.linger(1, 4)
+
+    proc { opt.int }.should raise_error(TypeError)
+  end
+end

--- a/library/socket/socket/option/linger_spec.rb
+++ b/library/socket/socket/option/linger_spec.rb
@@ -1,0 +1,80 @@
+# Copyright (c) 2013, Brian Shirai
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# 3. Neither the name of the library nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without
+#    specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require File.expand_path('../../../../../spec_helper', __FILE__)
+require File.expand_path('../../../fixtures/classes', __FILE__)
+
+require 'socket'
+
+describe 'Socket::Option.linger' do
+  describe 'using a Fixnum as the first argument' do
+    it 'returns a Socket::Option' do
+      opt = Socket::Option.linger(1, 4)
+
+      opt.should be_an_instance_of(Socket::Option)
+
+      opt.family.should  == Socket::AF_UNSPEC
+      opt.level.should   == Socket::SOL_SOCKET
+      opt.optname.should == Socket::SO_LINGER
+
+      opt.data.should be_an_instance_of(String)
+    end
+  end
+
+  describe 'using a boolean as the first argument' do
+    it 'returns a Socket::Option' do
+      opt = Socket::Option.linger(true, 4)
+
+      opt.should be_an_instance_of(Socket::Option)
+
+      opt.family.should  == Socket::AF_UNSPEC
+      opt.level.should   == Socket::SOL_SOCKET
+      opt.optname.should == Socket::SO_LINGER
+
+      opt.data.should be_an_instance_of(String)
+    end
+  end
+end
+
+describe 'Socket::Option#linger' do
+  it 'returns an Array containing the on/off option and linger time' do
+    opt = Socket::Option.linger(1, 4)
+
+    opt.linger.should == [true, 4]
+  end
+
+  it 'raises TypeError when called on a non SOL_SOCKET/SO_LINGER option' do
+    opt = Socket::Option.int(:INET, :IP, :TTL, 4)
+
+    proc { opt.linger }.should raise_error(TypeError)
+  end
+
+  it 'raises TypeError when called on a non linger option' do
+    opt = Socket::Option.new(:INET, :SOCKET, :LINGER, '')
+
+    proc { opt.linger }.should raise_error(TypeError)
+  end
+end


### PR DESCRIPTION
This specs are originally authored by @YorickPeterse and licensed by BSD
license.