### PR TITLE
ruby_cmd for spawn

### DIFF
--- a/shared/process/spawn.rb
+++ b/shared/process/spawn.rb
@@ -256,14 +256,14 @@ describe :process_spawn, shared: true do
     it "unsets other environment variables when given a true :unsetenv_others option" do
       ENV["FOO"] = "BAR"
       lambda do
-        Process.wait @object.spawn('ruby', fixture(__FILE__, "env.rb"), unsetenv_others: true)
+        Process.wait @object.spawn(ruby_cmd(fixture(__FILE__, "env.rb")), unsetenv_others: true)
       end.should output_to_fd("")
     end
 
     it "unsets other environment variables when given a non-false :unsetenv_others option" do
       ENV["FOO"] = "BAR"
       lambda do
-        Process.wait @object.spawn('ruby', fixture(__FILE__, "env.rb"), unsetenv_others: :true)
+        Process.wait @object.spawn(ruby_cmd(fixture(__FILE__, "env.rb")), unsetenv_others: :true)
       end.should output_to_fd("")
     end
   end
@@ -285,7 +285,7 @@ describe :process_spawn, shared: true do
   platform_is_not :windows do
     it "does not unset environment variables included in the environment hash" do
       lambda do
-        Process.wait @object.spawn({"FOO" => "BAR"}, 'ruby', fixture(__FILE__, "env.rb"), unsetenv_others: true)
+        Process.wait @object.spawn({"FOO" => "BAR"}, ruby_cmd(fixture(__FILE__, "env.rb")), unsetenv_others: true)
       end.should output_to_fd("BAR")
     end
   end


### PR DESCRIPTION
Use ruby_cmd instead of system ruby which may not exist.
Fix #288.