### PR TITLE
Add test case for non-zero Time#to_i.

### DIFF
--- a/core/time/shared/to_i.rb
+++ b/core/time/shared/to_i.rb
@@ -2,4 +2,8 @@ describe :time_to_i, shared: true do
   it "returns the value of time as an integer number of seconds since epoch" do
     Time.at(0).send(@method).should == 0
   end
+
+  it "doesn't return an actual number of seconds in time" do
+    Time.at(65.5).send(@method).should == 65
+  end
 end


### PR DESCRIPTION
In Opal we had `alias tv_sec sec` which was fine for the only test case of `Time#to_i`:

``` ruby
Time.at(0).to_i
# => 0
Time.at(0).sec
# => 0
Time.at(0).tv_sec
# => 0

Time.at(65.5).to_i
# => 65
Time.at(65.5).sec
# => 5
Time.at(65.5).tv_sec
# => 65
```