### PR TITLE
Spec for Integer("0") parsing as 0

### DIFF
--- a/core/kernel/Integer_spec.rb
+++ b/core/kernel/Integer_spec.rb
@@ -171,6 +171,10 @@ describe "Integer() given a String", shared: true do
     lambda { Integer("") }.should raise_error(ArgumentError)
   end
 
+  it "parses the value as 0 if the string consists of a single zero character" do
+    Integer("0").should == 0
+  end
+
   %w(x X).each do |x|
     it "parses the value as a hex number if there's a leading 0#{x}" do
       Integer("0#{x}1").should == 0x1


### PR DESCRIPTION
This is an accompanying pull request for https://github.com/opal/opal/pull/1571.

I.e. checks that other implementations do not accidentally attempt to parse "0" as an octal number.