### PR TITLE
getsockopt(2) returns SO_LINGER instead of 1

### DIFF
--- a/library/socket/basicsocket/setsockopt_spec.rb
+++ b/library/socket/basicsocket/setsockopt_spec.rb
@@ -183,7 +183,7 @@ describe "BasicSocket#setsockopt" do
       @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE).bool.should == true
     end
 
-    platform_is_not :freebsd, :solaris do
+    platform_is_not :freebsd, :solaris, :darwin do
       it 'linger' do
         option = Socket::Option.linger(true, 10)
         @sock.setsockopt(option).should == 0
@@ -191,7 +191,7 @@ describe "BasicSocket#setsockopt" do
       end
     end
 
-    platform_is :freebsd, :solaris do
+    platform_is :freebsd, :solaris, :darwin do
       it 'linger' do
         option = Socket::Option.linger(true, 10)
         @sock.setsockopt(option).should == 0


### PR DESCRIPTION
On Darwin SO_LINGER getsockopt(SOL_SOCKET, SO_LINGER)
returns SO_LINGER instead of 1

This was already fixed for FreeBSD and Solaris by @nurse in f0548a9