### PR TITLE
Avoid problematic byte sequence in UTF-8 encoding

### DIFF
--- a/library/zlib/zstream/flush_next_out_spec.rb
+++ b/library/zlib/zstream/flush_next_out_spec.rb
@@ -5,12 +5,12 @@ describe "Zlib::ZStream#flush_next_out" do
 
   it "flushes the stream and flushes the output buffer" do
     zs = Zlib::Inflate.new
-    zs << "x\234K\313\317\a\000\002\202\001E"
+    zs << [120, 156, 75, 203, 207, 7, 0, 2, 130, 1, 69].pack('C*')
 
     zs.flush_next_out.should == 'foo'
     zs.finished?.should == true
     zs.flush_next_out.should == ''
   end
-
 end
+
 


### PR DESCRIPTION
Fix avoids "invalid byte sequence in UTF-8 (EncodingError)" in
non MRI parsers