### PR TITLE
Avoid utf-8 conflicts in Digest files

### DIFF
--- a/library/digest/md5/shared/constants.rb
+++ b/library/digest/md5/shared/constants.rb
@@ -1,4 +1,4 @@
-# -*- encoding: us-ascii -*-
+# -*- encoding: binary -*-
 require 'digest/md5'
 
 module MD5Constants

--- a/library/digest/md5/shared/sample.rb
+++ b/library/digest/md5/shared/sample.rb
@@ -1,3 +1,5 @@
+# -*- encoding: binary -*-
+
 require 'digest/md5'
 
 module MD5Constants

--- a/library/digest/sha1/shared/constants.rb
+++ b/library/digest/sha1/shared/constants.rb
@@ -1,4 +1,5 @@
-# -*- encoding: us-ascii -*-
+# -*- encoding: binary -*-
+
 require 'digest/sha1'
 
 module SHA1Constants

--- a/library/digest/sha256/shared/constants.rb
+++ b/library/digest/sha256/shared/constants.rb
@@ -1,4 +1,5 @@
-# -*- encoding: us-ascii -*-
+# -*- encoding: binary -*-
+
 require 'digest/sha2'
 
 module SHA256Constants

--- a/library/digest/sha384/shared/constants.rb
+++ b/library/digest/sha384/shared/constants.rb
@@ -1,4 +1,5 @@
-# -*- encoding: us-ascii -*-
+# -*- encoding: binary -*-
+
 require 'digest/sha2'
 
 module SHA384Constants

--- a/library/digest/sha512/shared/constants.rb
+++ b/library/digest/sha512/shared/constants.rb
@@ -1,4 +1,5 @@
-# -*- encoding: us-ascii -*-
+# -*- encoding: binary -*-
+
 require 'digest/sha2'
 
 module SHA512Constants


### PR DESCRIPTION
Use +# -*- encoding: binary -*- encoding comment to silence
utf-8 conflicts in several Digest files