### PR TITLE
Avoid utf8 conflicts in Marshall specs

### DIFF
--- a/core/marshal/dump_spec.rb
+++ b/core/marshal/dump_spec.rb
@@ -1,4 +1,4 @@
-# -*- encoding: us-ascii -*-
+# -*- encoding: binary -*-
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/marshal_data', __FILE__)
 

--- a/core/marshal/dump_spec.rb
+++ b/core/marshal/dump_spec.rb
@@ -220,7 +220,7 @@ describe "Marshal.dump" do
     it "dumps a String with instance variables" do
       str = ""
       str.instance_variable_set("@foo", "bar")
-      Marshal.dump(str.force_encoding("binary")).should == "\x04\bI\"\x00\x06:\t@fooI\"\bbar\x06:\x06EF"
+      Marshal.dump(str.force_encoding("binary")).should == "\x04\bI\"\x00\x06:\t@foo\"\bbar"
     end
 
     with_feature :encoding do
@@ -474,13 +474,13 @@ describe "Marshal.dump" do
     end
 
     it "dumps the message for the exception" do
-      Marshal.dump(Exception.new("foo")).should == "\x04\bo:\x0EException\a:\tmesgI\"\bfoo\x06:\x06EF:\abt0"
+      Marshal.dump(Exception.new("foo")).should == "\x04\bo:\x0EException\a:\tmesg\"\bfoo:\abt0"
     end
 
     it "contains the filename in the backtrace" do
       obj = Exception.new("foo")
       obj.set_backtrace(["foo/bar.rb:10"])
-      Marshal.dump(obj).should == "\x04\bo:\x0EException\a:\tmesgI\"\bfoo\x06:\x06EF:\abt[\x06I\"\x12foo/bar.rb:10\x06;\aF"
+      Marshal.dump(obj).should == "\x04\bo:\x0EException\a:\tmesg\"\bfoo:\abt[\x06\"\x12foo/bar.rb:10"
     end
   end
 

--- a/core/marshal/fixtures/marshal_data.rb
+++ b/core/marshal/fixtures/marshal_data.rb
@@ -1,3 +1,4 @@
+# -*- encoding: binary -*-
 class UserDefined
   class Nested
     def ==(other)

--- a/core/marshal/shared/load.rb
+++ b/core/marshal/shared/load.rb
@@ -1,3 +1,4 @@
+# -*- encoding: binary -*-
 require File.expand_path('../../fixtures/marshal_data', __FILE__)
 require 'stringio'
 


### PR DESCRIPTION
Use magic binary encoding to silence utf-8 conflicts in Marshall
specs