### PR TITLE
Array pack with format J and j specs

### DIFF
--- a/core/array/pack/j_spec.rb
+++ b/core/array/pack/j_spec.rb
@@ -1,0 +1,127 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require File.expand_path('../../fixtures/classes', __FILE__)
+require File.expand_path('../shared/basic', __FILE__)
+require File.expand_path('../shared/numeric_basic', __FILE__)
+require File.expand_path('../shared/integer', __FILE__)
+require 'fiddle'
+
+def pointer_size_is size
+  yield if Fiddle::SIZEOF_INTPTR_T == size
+end
+
+ruby_version_is '2.3' do
+
+  pointer_size_is 8 do
+
+    describe "Array#pack with format 'J'" do
+      it_behaves_like :array_pack_basic, 'J'
+      it_behaves_like :array_pack_basic_non_float, 'J'
+      it_behaves_like :array_pack_arguments, 'J'
+      it_behaves_like :array_pack_numeric_basic, 'J'
+      it_behaves_like :array_pack_integer, 'J'
+    end
+
+    describe "Array#pack with format 'j'" do
+      it_behaves_like :array_pack_basic, 'j'
+      it_behaves_like :array_pack_basic_non_float, 'j'
+      it_behaves_like :array_pack_arguments, 'j'
+      it_behaves_like :array_pack_numeric_basic, 'j'
+      it_behaves_like :array_pack_integer, 'j'
+    end
+
+    describe "Array#pack with modifier '_'" do
+      it_behaves_like :array_pack_64bit_le, 'J_'
+      it_behaves_like :array_pack_64bit_le, 'j_'
+    end
+
+    describe "Array#pack with modifier '!'" do
+      it_behaves_like :array_pack_64bit_le, 'J!'
+      it_behaves_like :array_pack_64bit_le, 'j!'
+    end
+
+    describe "Array#pack with modifier '<' and '_'" do
+      it_behaves_like :array_pack_64bit_le, 'J<_'
+      it_behaves_like :array_pack_64bit_le, 'J_<'
+      it_behaves_like :array_pack_64bit_le, 'j<_'
+      it_behaves_like :array_pack_64bit_le, 'j_<'
+    end
+
+    describe "Array#pack with modifier '<' and '!'" do
+      it_behaves_like :array_pack_64bit_le, 'J<!'
+      it_behaves_like :array_pack_64bit_le, 'J!<'
+      it_behaves_like :array_pack_64bit_le, 'j<!'
+      it_behaves_like :array_pack_64bit_le, 'j!<'
+    end
+
+    describe "Array#pack with modifier '>' and '_'" do
+      it_behaves_like :array_pack_64bit_be, 'J>_'
+      it_behaves_like :array_pack_64bit_be, 'J_>'
+      it_behaves_like :array_pack_64bit_be, 'j>_'
+      it_behaves_like :array_pack_64bit_be, 'j_>'
+    end
+
+    describe "Array#pack with modifier '>' and '!'" do
+      it_behaves_like :array_pack_64bit_be, 'J>!'
+      it_behaves_like :array_pack_64bit_be, 'J!>'
+      it_behaves_like :array_pack_64bit_be, 'j>!'
+      it_behaves_like :array_pack_64bit_be, 'j!>'
+    end
+
+    pointer_size_is 4 do
+
+      describe "Array#pack with format 'J'" do
+        it_behaves_like :array_pack_basic, 'J'
+        it_behaves_like :array_pack_basic_non_float, 'J'
+        it_behaves_like :array_pack_arguments, 'J'
+        it_behaves_like :array_pack_numeric_basic, 'J'
+        it_behaves_like :array_pack_integer, 'J'
+      end
+
+      describe "Array#pack with format 'j'" do
+        it_behaves_like :array_pack_basic, 'j'
+        it_behaves_like :array_pack_basic_non_float, 'j'
+        it_behaves_like :array_pack_arguments, 'j'
+        it_behaves_like :array_pack_numeric_basic, 'j'
+        it_behaves_like :array_pack_integer, 'j'
+      end
+
+      describe "Array#pack with modifier '_'" do
+        it_behaves_like :array_pack_32bit_le, 'J_'
+        it_behaves_like :array_pack_32bit_le, 'j_'
+      end
+
+      describe "Array#pack with modifier '!'" do
+        it_behaves_like :array_pack_32bit_le, 'J!'
+        it_behaves_like :array_pack_32bit_le, 'j!'
+      end
+
+      describe "Array#pack with modifier '<' and '_'" do
+        it_behaves_like :array_pack_32bit_le, 'J<_'
+        it_behaves_like :array_pack_32bit_le, 'J_<'
+        it_behaves_like :array_pack_32bit_le, 'j<_'
+        it_behaves_like :array_pack_32bit_le, 'j_<'
+      end
+
+      describe "Array#pack with modifier '<' and '!'" do
+        it_behaves_like :array_pack_32bit_le, 'J<!'
+        it_behaves_like :array_pack_32bit_le, 'J!<'
+        it_behaves_like :array_pack_32bit_le, 'j<!'
+        it_behaves_like :array_pack_32bit_le, 'j!<'
+      end
+
+      describe "Array#pack with modifier '>' and '_'" do
+        it_behaves_like :array_pack_32bit_be, 'J>_'
+        it_behaves_like :array_pack_32bit_be, 'J_>'
+        it_behaves_like :array_pack_32bit_be, 'j>_'
+        it_behaves_like :array_pack_32bit_be, 'j_>'
+      end
+
+      describe "Array#pack with modifier '>' and '!'" do
+        it_behaves_like :array_pack_32bit_be, 'J>!'
+        it_behaves_like :array_pack_32bit_be, 'J!>'
+        it_behaves_like :array_pack_32bit_be, 'j>!'
+        it_behaves_like :array_pack_32bit_be, 'j!>'
+      end
+    end
+  end
+end

--- a/core/array/pack/j_spec.rb
+++ b/core/array/pack/j_spec.rb
@@ -3,15 +3,10 @@ require File.expand_path('../../fixtures/classes', __FILE__)
 require File.expand_path('../shared/basic', __FILE__)
 require File.expand_path('../shared/numeric_basic', __FILE__)
 require File.expand_path('../shared/integer', __FILE__)
-require 'fiddle'
-
-def pointer_size_is size
-  yield if Fiddle::SIZEOF_INTPTR_T == size
-end
 
 ruby_version_is '2.3' do
 
-  pointer_size_is 8 do
+  platform_is wordsize: 64 do
 
     describe "Array#pack with format 'J'" do
       it_behaves_like :array_pack_basic, 'J'
@@ -67,7 +62,7 @@ ruby_version_is '2.3' do
       it_behaves_like :array_pack_64bit_be, 'j!>'
     end
 
-    pointer_size_is 4 do
+  platform_is wordsize: 32 do
 
       describe "Array#pack with format 'J'" do
         it_behaves_like :array_pack_basic, 'J'

--- a/core/array/pack/j_spec.rb
+++ b/core/array/pack/j_spec.rb
@@ -24,60 +24,60 @@ ruby_version_is '2.3' do
 
     platform_is_not :mingw32 do
       describe "Array#pack with format 'J'" do
-        describe "Array#pack with modifier '_'" do
+        describe "with modifier '_'" do
           it_behaves_like :array_pack_64bit_le, 'J_'
         end
 
-        describe "Array#pack with modifier '!'" do
+        describe "with modifier '!'" do
           it_behaves_like :array_pack_64bit_le, 'J!'
         end
 
-        describe "Array#pack with modifier '<' and '_'" do
+        describe "with modifier '<' and '_'" do
           it_behaves_like :array_pack_64bit_le, 'J<_'
           it_behaves_like :array_pack_64bit_le, 'J_<'
         end
 
-        describe "Array#pack with modifier '<' and '!'" do
+        describe "with modifier '<' and '!'" do
           it_behaves_like :array_pack_64bit_le, 'J<!'
           it_behaves_like :array_pack_64bit_le, 'J!<'
         end
 
-        describe "Array#pack with modifier '>' and '_'" do
+        describe "with modifier '>' and '_'" do
           it_behaves_like :array_pack_64bit_be, 'J>_'
           it_behaves_like :array_pack_64bit_be, 'J_>'
         end
 
-        describe "Array#pack with modifier '>' and '!'" do
+        describe "with modifier '>' and '!'" do
           it_behaves_like :array_pack_64bit_be, 'J>!'
           it_behaves_like :array_pack_64bit_be, 'J!>'
         end
       end
 
       describe "Array#pack with format 'j'" do
-        describe "Array#pack with modifier '_'" do
+        describe "with modifier '_'" do
           it_behaves_like :array_pack_64bit_le, 'j_'
         end
 
-        describe "Array#pack with modifier '!'" do
+        describe "with modifier '!'" do
           it_behaves_like :array_pack_64bit_le, 'j!'
         end
 
-        describe "Array#pack with modifier '<' and '_'" do
+        describe "with modifier '<' and '_'" do
           it_behaves_like :array_pack_64bit_le, 'j<_'
           it_behaves_like :array_pack_64bit_le, 'j_<'
         end
 
-        describe "Array#pack with modifier '<' and '!'" do
+        describe "with modifier '<' and '!'" do
           it_behaves_like :array_pack_64bit_le, 'j<!'
           it_behaves_like :array_pack_64bit_le, 'j!<'
         end
 
-        describe "Array#pack with modifier '>' and '_'" do
+        describe "with modifier '>' and '_'" do
           it_behaves_like :array_pack_64bit_be, 'j>_'
           it_behaves_like :array_pack_64bit_be, 'j_>'
         end
 
-        describe "Array#pack with modifier '>' and '!'" do
+        describe "with modifier '>' and '!'" do
           it_behaves_like :array_pack_64bit_be, 'j>!'
           it_behaves_like :array_pack_64bit_be, 'j!>'
         end
@@ -86,60 +86,60 @@ ruby_version_is '2.3' do
 
     platform_is :mingw32 do
       describe "Array#pack with format 'J'" do
-        describe "Array#pack with modifier '_'" do
+        describe "with modifier '_'" do
           it_behaves_like :array_pack_32bit_le, 'J_'
         end
 
-        describe "Array#pack with modifier '!'" do
+        describe "with modifier '!'" do
           it_behaves_like :array_pack_32bit_le, 'J!'
         end
 
-        describe "Array#pack with modifier '<' and '_'" do
+        describe "with modifier '<' and '_'" do
           it_behaves_like :array_pack_32bit_le, 'J<_'
           it_behaves_like :array_pack_32bit_le, 'J_<'
         end
 
-        describe "Array#pack with modifier '<' and '!'" do
+        describe "with modifier '<' and '!'" do
           it_behaves_like :array_pack_32bit_le, 'J<!'
           it_behaves_like :array_pack_32bit_le, 'J!<'
         end
 
-        describe "Array#pack with modifier '>' and '_'" do
+        describe "with modifier '>' and '_'" do
           it_behaves_like :array_pack_32bit_be, 'J>_'
           it_behaves_like :array_pack_32bit_be, 'J_>'
         end
 
-        describe "Array#pack with modifier '>' and '!'" do
+        describe "with modifier '>' and '!'" do
           it_behaves_like :array_pack_32bit_be, 'J>!'
           it_behaves_like :array_pack_32bit_be, 'J!>'
         end
       end
 
       describe "Array#pack with format 'j'" do
-        describe "Array#pack with modifier '_'" do
+        describe "with modifier '_'" do
           it_behaves_like :array_pack_32bit_le, 'j_'
         end
 
-        describe "Array#pack with modifier '!'" do
+        describe "with modifier '!'" do
           it_behaves_like :array_pack_32bit_le, 'j!'
         end
 
-        describe "Array#pack with modifier '<' and '_'" do
+        describe "with modifier '<' and '_'" do
           it_behaves_like :array_pack_32bit_le, 'j<_'
           it_behaves_like :array_pack_32bit_le, 'j_<'
         end
 
-        describe "Array#pack with modifier '<' and '!'" do
+        describe "with modifier '<' and '!'" do
           it_behaves_like :array_pack_32bit_le, 'j<!'
           it_behaves_like :array_pack_32bit_le, 'j!<'
         end
 
-        describe "Array#pack with modifier '>' and '_'" do
+        describe "with modifier '>' and '_'" do
           it_behaves_like :array_pack_32bit_be, 'j>_'
           it_behaves_like :array_pack_32bit_be, 'j_>'
         end
 
-        describe "Array#pack with modifier '>' and '!'" do
+        describe "with modifier '>' and '!'" do
           it_behaves_like :array_pack_32bit_be, 'j>!'
           it_behaves_like :array_pack_32bit_be, 'j!>'
         end
@@ -165,60 +165,60 @@ ruby_version_is '2.3' do
     end
 
     describe "Array#pack with format 'J'" do
-      describe "Array#pack with modifier '_'" do
+      describe "with modifier '_'" do
         it_behaves_like :array_pack_32bit_le, 'J_'
       end
 
-      describe "Array#pack with modifier '!'" do
+      describe "with modifier '!'" do
         it_behaves_like :array_pack_32bit_le, 'J!'
       end
 
-      describe "Array#pack with modifier '<' and '_'" do
+      describe "with modifier '<' and '_'" do
         it_behaves_like :array_pack_32bit_le, 'J<_'
         it_behaves_like :array_pack_32bit_le, 'J_<'
       end
 
-      describe "Array#pack with modifier '<' and '!'" do
+      describe "with modifier '<' and '!'" do
         it_behaves_like :array_pack_32bit_le, 'J<!'
         it_behaves_like :array_pack_32bit_le, 'J!<'
       end
 
-      describe "Array#pack with modifier '>' and '_'" do
+      describe "with modifier '>' and '_'" do
         it_behaves_like :array_pack_32bit_be, 'J>_'
         it_behaves_like :array_pack_32bit_be, 'J_>'
       end
 
-      describe "Array#pack with modifier '>' and '!'" do
+      describe "with modifier '>' and '!'" do
         it_behaves_like :array_pack_32bit_be, 'J>!'
         it_behaves_like :array_pack_32bit_be, 'J!>'
       end
     end
 
     describe "Array#pack with format 'j'" do
-      describe "Array#pack with modifier '_'" do
+      describe "with modifier '_'" do
         it_behaves_like :array_pack_32bit_le, 'j_'
       end
 
-      describe "Array#pack with modifier '!'" do
+      describe "with modifier '!'" do
         it_behaves_like :array_pack_32bit_le, 'j!'
       end
 
-      describe "Array#pack with modifier '<' and '_'" do
+      describe "with modifier '<' and '_'" do
         it_behaves_like :array_pack_32bit_le, 'j<_'
         it_behaves_like :array_pack_32bit_le, 'j_<'
       end
 
-      describe "Array#pack with modifier '<' and '!'" do
+      describe "with modifier '<' and '!'" do
         it_behaves_like :array_pack_32bit_le, 'j<!'
         it_behaves_like :array_pack_32bit_le, 'j!<'
       end
 
-      describe "Array#pack with modifier '>' and '_'" do
+      describe "with modifier '>' and '_'" do
         it_behaves_like :array_pack_32bit_be, 'j>_'
         it_behaves_like :array_pack_32bit_be, 'j_>'
       end
 
-      describe "Array#pack with modifier '>' and '!'" do
+      describe "with modifier '>' and '!'" do
         it_behaves_like :array_pack_32bit_be, 'j>!'
         it_behaves_like :array_pack_32bit_be, 'j!>'
       end

--- a/core/array/pack/j_spec.rb
+++ b/core/array/pack/j_spec.rb
@@ -5,9 +5,7 @@ require File.expand_path('../shared/numeric_basic', __FILE__)
 require File.expand_path('../shared/integer', __FILE__)
 
 ruby_version_is '2.3' do
-
   platform_is wordsize: 64 do
-
     describe "Array#pack with format 'J'" do
       it_behaves_like :array_pack_basic, 'J'
       it_behaves_like :array_pack_basic_non_float, 'J'
@@ -25,90 +23,131 @@ ruby_version_is '2.3' do
     end
 
     platform_is_not :mingw32 do
+      describe "Array#pack with format 'J'" do
+        describe "Array#pack with modifier '_'" do
+          it_behaves_like :array_pack_64bit_le, 'J_'
+        end
 
-      describe "Array#pack with modifier '_'" do
-        it_behaves_like :array_pack_64bit_le, 'J_'
-        it_behaves_like :array_pack_64bit_le, 'j_'
+        describe "Array#pack with modifier '!'" do
+          it_behaves_like :array_pack_64bit_le, 'J!'
+        end
+
+        describe "Array#pack with modifier '<' and '_'" do
+          it_behaves_like :array_pack_64bit_le, 'J<_'
+          it_behaves_like :array_pack_64bit_le, 'J_<'
+        end
+
+        describe "Array#pack with modifier '<' and '!'" do
+          it_behaves_like :array_pack_64bit_le, 'J<!'
+          it_behaves_like :array_pack_64bit_le, 'J!<'
+        end
+
+        describe "Array#pack with modifier '>' and '_'" do
+          it_behaves_like :array_pack_64bit_be, 'J>_'
+          it_behaves_like :array_pack_64bit_be, 'J_>'
+        end
+
+        describe "Array#pack with modifier '>' and '!'" do
+          it_behaves_like :array_pack_64bit_be, 'J>!'
+          it_behaves_like :array_pack_64bit_be, 'J!>'
+        end
       end
 
-      describe "Array#pack with modifier '!'" do
-        it_behaves_like :array_pack_64bit_le, 'J!'
-        it_behaves_like :array_pack_64bit_le, 'j!'
-      end
+      describe "Array#pack with format 'j'" do
+        describe "Array#pack with modifier '_'" do
+          it_behaves_like :array_pack_64bit_le, 'j_'
+        end
 
-      describe "Array#pack with modifier '<' and '_'" do
-        it_behaves_like :array_pack_64bit_le, 'J<_'
-        it_behaves_like :array_pack_64bit_le, 'J_<'
-        it_behaves_like :array_pack_64bit_le, 'j<_'
-        it_behaves_like :array_pack_64bit_le, 'j_<'
-      end
+        describe "Array#pack with modifier '!'" do
+          it_behaves_like :array_pack_64bit_le, 'j!'
+        end
 
-      describe "Array#pack with modifier '<' and '!'" do
-        it_behaves_like :array_pack_64bit_le, 'J<!'
-        it_behaves_like :array_pack_64bit_le, 'J!<'
-        it_behaves_like :array_pack_64bit_le, 'j<!'
-        it_behaves_like :array_pack_64bit_le, 'j!<'
-      end
+        describe "Array#pack with modifier '<' and '_'" do
+          it_behaves_like :array_pack_64bit_le, 'j<_'
+          it_behaves_like :array_pack_64bit_le, 'j_<'
+        end
 
-      describe "Array#pack with modifier '>' and '_'" do
-        it_behaves_like :array_pack_64bit_be, 'J>_'
-        it_behaves_like :array_pack_64bit_be, 'J_>'
-        it_behaves_like :array_pack_64bit_be, 'j>_'
-        it_behaves_like :array_pack_64bit_be, 'j_>'
-      end
+        describe "Array#pack with modifier '<' and '!'" do
+          it_behaves_like :array_pack_64bit_le, 'j<!'
+          it_behaves_like :array_pack_64bit_le, 'j!<'
+        end
 
-      describe "Array#pack with modifier '>' and '!'" do
-        it_behaves_like :array_pack_64bit_be, 'J>!'
-        it_behaves_like :array_pack_64bit_be, 'J!>'
-        it_behaves_like :array_pack_64bit_be, 'j>!'
-        it_behaves_like :array_pack_64bit_be, 'j!>'
+        describe "Array#pack with modifier '>' and '_'" do
+          it_behaves_like :array_pack_64bit_be, 'j>_'
+          it_behaves_like :array_pack_64bit_be, 'j_>'
+        end
+
+        describe "Array#pack with modifier '>' and '!'" do
+          it_behaves_like :array_pack_64bit_be, 'j>!'
+          it_behaves_like :array_pack_64bit_be, 'j!>'
+        end
       end
     end
 
     platform_is :mingw32 do
+      describe "Array#pack with format 'J'" do
+        describe "Array#pack with modifier '_'" do
+          it_behaves_like :array_pack_32bit_le, 'J_'
+        end
 
-      describe "Array#pack with modifier '_'" do
-        it_behaves_like :array_pack_32bit_le, 'J_'
-        it_behaves_like :array_pack_32bit_le, 'j_'
+        describe "Array#pack with modifier '!'" do
+          it_behaves_like :array_pack_32bit_le, 'J!'
+        end
+
+        describe "Array#pack with modifier '<' and '_'" do
+          it_behaves_like :array_pack_32bit_le, 'J<_'
+          it_behaves_like :array_pack_32bit_le, 'J_<'
+        end
+
+        describe "Array#pack with modifier '<' and '!'" do
+          it_behaves_like :array_pack_32bit_le, 'J<!'
+          it_behaves_like :array_pack_32bit_le, 'J!<'
+        end
+
+        describe "Array#pack with modifier '>' and '_'" do
+          it_behaves_like :array_pack_32bit_be, 'J>_'
+          it_behaves_like :array_pack_32bit_be, 'J_>'
+        end
+
+        describe "Array#pack with modifier '>' and '!'" do
+          it_behaves_like :array_pack_32bit_be, 'J>!'
+          it_behaves_like :array_pack_32bit_be, 'J!>'
+        end
       end
 
-      describe "Array#pack with modifier '!'" do
-        it_behaves_like :array_pack_32bit_le, 'J!'
-        it_behaves_like :array_pack_32bit_le, 'j!'
-      end
+      describe "Array#pack with format 'j'" do
+        describe "Array#pack with modifier '_'" do
+          it_behaves_like :array_pack_32bit_le, 'j_'
+        end
 
-      describe "Array#pack with modifier '<' and '_'" do
-        it_behaves_like :array_pack_32bit_le, 'J<_'
-        it_behaves_like :array_pack_32bit_le, 'J_<'
-        it_behaves_like :array_pack_32bit_le, 'j<_'
-        it_behaves_like :array_pack_32bit_le, 'j_<'
-      end
+        describe "Array#pack with modifier '!'" do
+          it_behaves_like :array_pack_32bit_le, 'j!'
+        end
 
-      describe "Array#pack with modifier '<' and '!'" do
-        it_behaves_like :array_pack_32bit_le, 'J<!'
-        it_behaves_like :array_pack_32bit_le, 'J!<'
-        it_behaves_like :array_pack_32bit_le, 'j<!'
-        it_behaves_like :array_pack_32bit_le, 'j!<'
-      end
+        describe "Array#pack with modifier '<' and '_'" do
+          it_behaves_like :array_pack_32bit_le, 'j<_'
+          it_behaves_like :array_pack_32bit_le, 'j_<'
+        end
 
-      describe "Array#pack with modifier '>' and '_'" do
-        it_behaves_like :array_pack_32bit_be, 'J>_'
-        it_behaves_like :array_pack_32bit_be, 'J_>'
-        it_behaves_like :array_pack_32bit_be, 'j>_'
-        it_behaves_like :array_pack_32bit_be, 'j_>'
-      end
+        describe "Array#pack with modifier '<' and '!'" do
+          it_behaves_like :array_pack_32bit_le, 'j<!'
+          it_behaves_like :array_pack_32bit_le, 'j!<'
+        end
 
-      describe "Array#pack with modifier '>' and '!'" do
-        it_behaves_like :array_pack_32bit_be, 'J>!'
-        it_behaves_like :array_pack_32bit_be, 'J!>'
-        it_behaves_like :array_pack_32bit_be, 'j>!'
-        it_behaves_like :array_pack_32bit_be, 'j!>'
+        describe "Array#pack with modifier '>' and '_'" do
+          it_behaves_like :array_pack_32bit_be, 'j>_'
+          it_behaves_like :array_pack_32bit_be, 'j_>'
+        end
+
+        describe "Array#pack with modifier '>' and '!'" do
+          it_behaves_like :array_pack_32bit_be, 'j>!'
+          it_behaves_like :array_pack_32bit_be, 'j!>'
+        end
       end
     end
   end
 
   platform_is wordsize: 32 do
-
     describe "Array#pack with format 'J'" do
       it_behaves_like :array_pack_basic, 'J'
       it_behaves_like :array_pack_basic_non_float, 'J'
@@ -125,42 +164,64 @@ ruby_version_is '2.3' do
       it_behaves_like :array_pack_integer, 'j'
     end
 
-    describe "Array#pack with modifier '_'" do
-      it_behaves_like :array_pack_32bit_le, 'J_'
-      it_behaves_like :array_pack_32bit_le, 'j_'
+    describe "Array#pack with format 'J'" do
+      describe "Array#pack with modifier '_'" do
+        it_behaves_like :array_pack_32bit_le, 'J_'
+      end
+
+      describe "Array#pack with modifier '!'" do
+        it_behaves_like :array_pack_32bit_le, 'J!'
+      end
+
+      describe "Array#pack with modifier '<' and '_'" do
+        it_behaves_like :array_pack_32bit_le, 'J<_'
+        it_behaves_like :array_pack_32bit_le, 'J_<'
+      end
+
+      describe "Array#pack with modifier '<' and '!'" do
+        it_behaves_like :array_pack_32bit_le, 'J<!'
+        it_behaves_like :array_pack_32bit_le, 'J!<'
+      end
+
+      describe "Array#pack with modifier '>' and '_'" do
+        it_behaves_like :array_pack_32bit_be, 'J>_'
+        it_behaves_like :array_pack_32bit_be, 'J_>'
+      end
+
+      describe "Array#pack with modifier '>' and '!'" do
+        it_behaves_like :array_pack_32bit_be, 'J>!'
+        it_behaves_like :array_pack_32bit_be, 'J!>'
+      end
     end
 
-    describe "Array#pack with modifier '!'" do
-      it_behaves_like :array_pack_32bit_le, 'J!'
-      it_behaves_like :array_pack_32bit_le, 'j!'
-    end
+    describe "Array#pack with format 'j'" do
+      describe "Array#pack with modifier '_'" do
+        it_behaves_like :array_pack_32bit_le, 'j_'
+      end
 
-    describe "Array#pack with modifier '<' and '_'" do
-      it_behaves_like :array_pack_32bit_le, 'J<_'
-      it_behaves_like :array_pack_32bit_le, 'J_<'
-      it_behaves_like :array_pack_32bit_le, 'j<_'
-      it_behaves_like :array_pack_32bit_le, 'j_<'
-    end
+      describe "Array#pack with modifier '!'" do
+        it_behaves_like :array_pack_32bit_le, 'j!'
+      end
 
-    describe "Array#pack with modifier '<' and '!'" do
-      it_behaves_like :array_pack_32bit_le, 'J<!'
-      it_behaves_like :array_pack_32bit_le, 'J!<'
-      it_behaves_like :array_pack_32bit_le, 'j<!'
-      it_behaves_like :array_pack_32bit_le, 'j!<'
-    end
+      describe "Array#pack with modifier '<' and '_'" do
+        it_behaves_like :array_pack_32bit_le, 'j<_'
+        it_behaves_like :array_pack_32bit_le, 'j_<'
+      end
 
-    describe "Array#pack with modifier '>' and '_'" do
-      it_behaves_like :array_pack_32bit_be, 'J>_'
-      it_behaves_like :array_pack_32bit_be, 'J_>'
-      it_behaves_like :array_pack_32bit_be, 'j>_'
-      it_behaves_like :array_pack_32bit_be, 'j_>'
-    end
+      describe "Array#pack with modifier '<' and '!'" do
+        it_behaves_like :array_pack_32bit_le, 'j<!'
+        it_behaves_like :array_pack_32bit_le, 'j!<'
+      end
 
-    describe "Array#pack with modifier '>' and '!'" do
-      it_behaves_like :array_pack_32bit_be, 'J>!'
-      it_behaves_like :array_pack_32bit_be, 'J!>'
-      it_behaves_like :array_pack_32bit_be, 'j>!'
-      it_behaves_like :array_pack_32bit_be, 'j!>'
+      describe "Array#pack with modifier '>' and '_'" do
+        it_behaves_like :array_pack_32bit_be, 'j>_'
+        it_behaves_like :array_pack_32bit_be, 'j_>'
+      end
+
+      describe "Array#pack with modifier '>' and '!'" do
+        it_behaves_like :array_pack_32bit_be, 'j>!'
+        it_behaves_like :array_pack_32bit_be, 'j!>'
+      end
     end
   end
 end

--- a/core/array/pack/j_spec.rb
+++ b/core/array/pack/j_spec.rb
@@ -24,61 +24,48 @@ ruby_version_is '2.3' do
       it_behaves_like :array_pack_integer, 'j'
     end
 
-    describe "Array#pack with modifier '_'" do
-      it_behaves_like :array_pack_64bit_le, 'J_'
-      it_behaves_like :array_pack_64bit_le, 'j_'
-    end
+    platform_is_not :mingw32 do
 
-    describe "Array#pack with modifier '!'" do
-      it_behaves_like :array_pack_64bit_le, 'J!'
-      it_behaves_like :array_pack_64bit_le, 'j!'
-    end
-
-    describe "Array#pack with modifier '<' and '_'" do
-      it_behaves_like :array_pack_64bit_le, 'J<_'
-      it_behaves_like :array_pack_64bit_le, 'J_<'
-      it_behaves_like :array_pack_64bit_le, 'j<_'
-      it_behaves_like :array_pack_64bit_le, 'j_<'
-    end
-
-    describe "Array#pack with modifier '<' and '!'" do
-      it_behaves_like :array_pack_64bit_le, 'J<!'
-      it_behaves_like :array_pack_64bit_le, 'J!<'
-      it_behaves_like :array_pack_64bit_le, 'j<!'
-      it_behaves_like :array_pack_64bit_le, 'j!<'
-    end
-
-    describe "Array#pack with modifier '>' and '_'" do
-      it_behaves_like :array_pack_64bit_be, 'J>_'
-      it_behaves_like :array_pack_64bit_be, 'J_>'
-      it_behaves_like :array_pack_64bit_be, 'j>_'
-      it_behaves_like :array_pack_64bit_be, 'j_>'
-    end
-
-    describe "Array#pack with modifier '>' and '!'" do
-      it_behaves_like :array_pack_64bit_be, 'J>!'
-      it_behaves_like :array_pack_64bit_be, 'J!>'
-      it_behaves_like :array_pack_64bit_be, 'j>!'
-      it_behaves_like :array_pack_64bit_be, 'j!>'
-    end
-
-  platform_is wordsize: 32 do
-
-      describe "Array#pack with format 'J'" do
-        it_behaves_like :array_pack_basic, 'J'
-        it_behaves_like :array_pack_basic_non_float, 'J'
-        it_behaves_like :array_pack_arguments, 'J'
-        it_behaves_like :array_pack_numeric_basic, 'J'
-        it_behaves_like :array_pack_integer, 'J'
+      describe "Array#pack with modifier '_'" do
+        it_behaves_like :array_pack_64bit_le, 'J_'
+        it_behaves_like :array_pack_64bit_le, 'j_'
       end
 
-      describe "Array#pack with format 'j'" do
-        it_behaves_like :array_pack_basic, 'j'
-        it_behaves_like :array_pack_basic_non_float, 'j'
-        it_behaves_like :array_pack_arguments, 'j'
-        it_behaves_like :array_pack_numeric_basic, 'j'
-        it_behaves_like :array_pack_integer, 'j'
+      describe "Array#pack with modifier '!'" do
+        it_behaves_like :array_pack_64bit_le, 'J!'
+        it_behaves_like :array_pack_64bit_le, 'j!'
       end
+
+      describe "Array#pack with modifier '<' and '_'" do
+        it_behaves_like :array_pack_64bit_le, 'J<_'
+        it_behaves_like :array_pack_64bit_le, 'J_<'
+        it_behaves_like :array_pack_64bit_le, 'j<_'
+        it_behaves_like :array_pack_64bit_le, 'j_<'
+      end
+
+      describe "Array#pack with modifier '<' and '!'" do
+        it_behaves_like :array_pack_64bit_le, 'J<!'
+        it_behaves_like :array_pack_64bit_le, 'J!<'
+        it_behaves_like :array_pack_64bit_le, 'j<!'
+        it_behaves_like :array_pack_64bit_le, 'j!<'
+      end
+
+      describe "Array#pack with modifier '>' and '_'" do
+        it_behaves_like :array_pack_64bit_be, 'J>_'
+        it_behaves_like :array_pack_64bit_be, 'J_>'
+        it_behaves_like :array_pack_64bit_be, 'j>_'
+        it_behaves_like :array_pack_64bit_be, 'j_>'
+      end
+
+      describe "Array#pack with modifier '>' and '!'" do
+        it_behaves_like :array_pack_64bit_be, 'J>!'
+        it_behaves_like :array_pack_64bit_be, 'J!>'
+        it_behaves_like :array_pack_64bit_be, 'j>!'
+        it_behaves_like :array_pack_64bit_be, 'j!>'
+      end
+    end
+
+    platform_is :mingw32 do
 
       describe "Array#pack with modifier '_'" do
         it_behaves_like :array_pack_32bit_le, 'J_'
@@ -117,6 +104,63 @@ ruby_version_is '2.3' do
         it_behaves_like :array_pack_32bit_be, 'j>!'
         it_behaves_like :array_pack_32bit_be, 'j!>'
       end
+    end
+  end
+
+  platform_is wordsize: 32 do
+
+    describe "Array#pack with format 'J'" do
+      it_behaves_like :array_pack_basic, 'J'
+      it_behaves_like :array_pack_basic_non_float, 'J'
+      it_behaves_like :array_pack_arguments, 'J'
+      it_behaves_like :array_pack_numeric_basic, 'J'
+      it_behaves_like :array_pack_integer, 'J'
+    end
+
+    describe "Array#pack with format 'j'" do
+      it_behaves_like :array_pack_basic, 'j'
+      it_behaves_like :array_pack_basic_non_float, 'j'
+      it_behaves_like :array_pack_arguments, 'j'
+      it_behaves_like :array_pack_numeric_basic, 'j'
+      it_behaves_like :array_pack_integer, 'j'
+    end
+
+    describe "Array#pack with modifier '_'" do
+      it_behaves_like :array_pack_32bit_le, 'J_'
+      it_behaves_like :array_pack_32bit_le, 'j_'
+    end
+
+    describe "Array#pack with modifier '!'" do
+      it_behaves_like :array_pack_32bit_le, 'J!'
+      it_behaves_like :array_pack_32bit_le, 'j!'
+    end
+
+    describe "Array#pack with modifier '<' and '_'" do
+      it_behaves_like :array_pack_32bit_le, 'J<_'
+      it_behaves_like :array_pack_32bit_le, 'J_<'
+      it_behaves_like :array_pack_32bit_le, 'j<_'
+      it_behaves_like :array_pack_32bit_le, 'j_<'
+    end
+
+    describe "Array#pack with modifier '<' and '!'" do
+      it_behaves_like :array_pack_32bit_le, 'J<!'
+      it_behaves_like :array_pack_32bit_le, 'J!<'
+      it_behaves_like :array_pack_32bit_le, 'j<!'
+      it_behaves_like :array_pack_32bit_le, 'j!<'
+    end
+
+    describe "Array#pack with modifier '>' and '_'" do
+      it_behaves_like :array_pack_32bit_be, 'J>_'
+      it_behaves_like :array_pack_32bit_be, 'J_>'
+      it_behaves_like :array_pack_32bit_be, 'j>_'
+      it_behaves_like :array_pack_32bit_be, 'j_>'
+    end
+
+    describe "Array#pack with modifier '>' and '!'" do
+      it_behaves_like :array_pack_32bit_be, 'J>!'
+      it_behaves_like :array_pack_32bit_be, 'J!>'
+      it_behaves_like :array_pack_32bit_be, 'j>!'
+      it_behaves_like :array_pack_32bit_be, 'j!>'
     end
   end
 end


### PR DESCRIPTION
Add specs for Array pack j and J directives for pointer width integer type. 

Issue Ruby 2.3 specs  #175 - Feature [#11215](https://bugs.ruby-lang.org/issues/11215)
