### PR TITLE
Require round-to-nearest-even behavior for Ruby 2.4+

### DIFF
--- a/core/float/round_spec.rb
+++ b/core/float/round_spec.rb
@@ -65,17 +65,17 @@ describe "Float#round" do
     0.42.round(2.0**30).should == 0.42
   end
 
-  ruby_version_is "2.4" do
-    it "returns big values rounded to nearest even" do
-      +2.5e20.round(-20).should   eql( +2 * 10 ** 20  )
-      -2.5e20.round(-20).should   eql( -2 * 10 ** 20  )
-    end
-  end
-
   ruby_version_is ""..."2.4" do
     it "returns big values rounded to nearest" do
       +2.5e20.round(-20).should   eql( +3 * 10 ** 20  )
       -2.5e20.round(-20).should   eql( -3 * 10 ** 20  )
+    end
+  end
+
+  ruby_version_is "2.4" do
+    it "returns big values rounded to nearest even" do
+      +2.5e20.round(-20).should   eql( +2 * 10 ** 20  )
+      -2.5e20.round(-20).should   eql( -2 * 10 ** 20  )
     end
   end
 

--- a/core/float/round_spec.rb
+++ b/core/float/round_spec.rb
@@ -65,11 +65,23 @@ describe "Float#round" do
     0.42.round(2.0**30).should == 0.42
   end
 
+  ruby_version_is "2.4" do
+    it "returns big values rounded to nearest even" do
+      +2.5e20.round(-20).should   eql( +2 * 10 ** 20  )
+      -2.5e20.round(-20).should   eql( -2 * 10 ** 20  )
+    end
+  end
+
+  ruby_version_is ""..."2.4" do
+    it "returns big values rounded to nearest" do
+      +2.5e20.round(-20).should   eql( +3 * 10 ** 20  )
+      -2.5e20.round(-20).should   eql( -3 * 10 ** 20  )
+    end
+  end
+
   # redmine #5272
   it "returns rounded values for big values" do
-    +2.5e20.round(-20).should   eql( +3 * 10 ** 20  )
     +2.4e20.round(-20).should   eql( +2 * 10 ** 20  )
-    -2.5e20.round(-20).should   eql( -3 * 10 ** 20  )
     -2.4e20.round(-20).should   eql( -2 * 10 ** 20  )
     +2.5e200.round(-200).should eql( +3 * 10 ** 200 )
     +2.4e200.round(-200).should eql( +2 * 10 ** 200 )

--- a/core/integer/round_spec.rb
+++ b/core/integer/round_spec.rb
@@ -19,13 +19,27 @@ describe "Integer#round" do
   # redmine:5228
   it "returns itself rounded if passed a negative value" do
     +249.round(-2).should eql(+200)
-    +250.round(-2).should eql(+300)
     -249.round(-2).should eql(-200)
-    -250.round(-2).should eql(-300)
-    (+25 * 10**70).round(-71).should eql(+30 * 10**70)
-    (-25 * 10**70).round(-71).should eql(-30 * 10**70)
     (+25 * 10**70 - 1).round(-71).should eql(+20 * 10**70)
     (-25 * 10**70 + 1).round(-71).should eql(-20 * 10**70)
+  end
+
+  ruby_version_is ""..."2.4" do
+    it "returns itself rounded to nearest if passed a negative value" do
+      +250.round(-2).should eql(+300)
+      -250.round(-2).should eql(-300)
+      (+25 * 10**70).round(-71).should eql(+30 * 10**70)
+      (-25 * 10**70).round(-71).should eql(-30 * 10**70)
+    end
+  end
+
+  ruby_version_is "2.4" do
+    it "returns itself rounded to nearest even if passed a negative value" do
+      +250.round(-2).should eql(+200)
+      -250.round(-2).should eql(-200)
+      (+25 * 10**70).round(-71).should eql(+20 * 10**70)
+      (-25 * 10**70).round(-71).should eql(-20 * 10**70)
+    end
   end
 
   platform_is_not wordsize: 32 do

--- a/core/time/strftime_spec.rb
+++ b/core/time/strftime_spec.rb
@@ -45,8 +45,21 @@ describe "Time#strftime" do
   end
 
   # Date/DateTime round at creation time, but Time does it in strftime.
-  it "rounds an offset to the nearest second when formatting with %z" do
-    time = @new_time_with_offset[2012, 1, 1, 0, 0, 0, Rational(36645, 10)]
-    time.strftime("%::z").should == "+01:01:05"
+  ruby_version_is ""..."2.4" do
+    it "rounds an offset to the nearest second when formatting with %z" do
+      time = @new_time_with_offset[2012, 1, 1, 0, 0, 0, Rational(36645, 10)]
+      time.strftime("%::z").should == "+01:01:05"
+    end
+  end
+
+  ruby_version_is "2.4" do
+    it "rounds an offset to the nearest even second when formatting with %z" do
+      time = @new_time_with_offset[2012, 1, 1, 0, 0, 0, Rational(36645, 10)]
+      time.strftime("%::z").should == "+01:01:04"
+      time = @new_time_with_offset[2012, 1, 1, 0, 0, 0, Rational(36655, 10)]
+      time.strftime("%::z").should == "+01:01:06"
+      time = @new_time_with_offset[2012, 1, 1, 0, 0, 0, Rational(36665, 10)]
+      time.strftime("%::z").should == "+01:01:06"
+    end
   end
 end

--- a/shared/rational/round.rb
+++ b/shared/rational/round.rb
@@ -14,10 +14,30 @@ describe :rational_round, shared: true do
 
     it "returns the truncated value toward the nearest integer" do
       @rational.round.should == 314
-      Rational(1, 2).round.should == 1
-      Rational(-1, 2).round.should == -1
       Rational(0, 1).round(0).should == 0
       Rational(2, 1).round(0).should == 2
+    end
+
+    ruby_version_is ""..."2.4" do
+      it "returns the rounded value toward the nearest integer" do
+        Rational(1, 2).round.should == 1
+        Rational(-1, 2).round.should == -1
+        Rational(3, 2).round.should == 2
+        Rational(-3, 2).round.should == -2
+        Rational(5, 2).round.should == 3
+        Rational(-5, 2).round.should == -3
+      end
+    end
+
+    ruby_version_is "2.4" do
+      it "returns the rounded value toward the nearest even integer" do
+        Rational(1, 2).round.should == 0
+        Rational(-1, 2).round.should == 0
+        Rational(3, 2).round.should == 2
+        Rational(-3, 2).round.should == -2
+        Rational(5, 2).round.should == 2
+        Rational(-5, 2).round.should == -2
+      end
     end
   end
 


### PR DESCRIPTION
But require round-to-nearest before that.
