### PR TITLE
Aix socket constants

### DIFF
--- a/library/socket/constants/constants_spec.rb
+++ b/library/socket/constants/constants_spec.rb
@@ -70,7 +70,7 @@ describe "Socket::Constants" do
     end
   end
 
-  platform_is_not :solaris, :windows do
+  platform_is_not :solaris, :windows, :aix do
     it "defines multicast options" do
       consts = ["IP_MAX_MEMBERSHIPS"]
       consts.each do |c|

--- a/library/socket/constants/constants_spec.rb
+++ b/library/socket/constants/constants_spec.rb
@@ -56,7 +56,6 @@ describe "Socket::Constants" do
     consts.each do |c|
       Socket::Constants.should have_constant(c)
     end
-
   end
 
   it "defines multicast options" do

--- a/library/socket/constants/constants_spec.rb
+++ b/library/socket/constants/constants_spec.rb
@@ -11,16 +11,28 @@ describe "Socket::Constants" do
   end
 
   it "defines protocol families" do
-    consts = ["PF_INET6", "PF_INET", "PF_IPX", "PF_UNIX", "PF_UNSPEC"]
+    consts = ["PF_INET6", "PF_INET", "PF_UNIX", "PF_UNSPEC"]
     consts.each do |c|
       Socket::Constants.should have_constant(c)
     end
   end
 
+  platform_is_not :aix do
+    it "defines PF_IPX protocol" do
+      Socket::Constants.should have_constant("PF_IPX")
+    end
+  end
+
   it "defines address families" do
-    consts = ["AF_INET6", "AF_INET", "AF_IPX", "AF_UNIX", "AF_UNSPEC"]
+    consts = ["AF_INET6", "AF_INET", "AF_UNIX", "AF_UNSPEC"]
     consts.each do |c|
       Socket::Constants.should have_constant(c)
+    end
+  end
+
+  platform_is_not :aix do
+    it "defines AF_IPX address" do
+      Socket::Constants.should have_constant("AF_IPX")
     end
   end
 


### PR DESCRIPTION
@eregon I've been looking at some AIX platform consistent fails on ruby CI:
```
3) Socket::Constants defines protocol families FAILED
Expected Socket::Constants to have constant 'PF_IPX' but it does not

4) Socket::Constants defines address families FAILED
Expected Socket::Constants to have constant 'AF_IPX' but it does not

5) Socket::Constants defines multicast options FAILED
Expected Socket::Constants to have constant 'IP_MAX_MEMBERSHIPS' but it does not
```
It seems AF_IPX and PF_IPX are not defined on aix. 
Looking at `ext/socket/constdefs.c` these constants are only declared if defined at compile time which they presumably are not for aix (AIX is a legacy protocol used mainly by Novell).
Also aix has multicast fixed to 20 and so doesn't have IP_MAX_MEMBERSHIPS requirement.
Can I fix these fails?
[IBM ref](http://www.ibm.com/support/knowledgecenter/SSQPD3_2.6.0/com.ibm.wllm.doc/Joiningmultiplemulticastgroups.html)
Edit: [JRuby ref I found](https://apt-browse.org/browse/debian/wheezy/main/all/jruby/1.5.6-5/file/usr/lib/jruby/lib/ruby/site_ruby/shared/ffi/platform/powerpc-aix/socket.rb)