### PR TITLE
The result of `==` should be truthy or falsy

### DIFF
--- a/shared/rational/equal_value.rb
+++ b/shared/rational/equal_value.rb
@@ -34,6 +34,6 @@ describe :rational_equal_value, shared: true do
     obj = mock("Object")
     obj.should_receive(:==).and_return(:result)
 
-    (Rational(3, 4) == obj).should == :result
+    (Rational(3, 4) == obj).should_not be_false
   end
 end


### PR DESCRIPTION
`Rational#==` returns the returned value by peer's `==` method
right now, but the result is not meaningful.