### PR TITLE
The result of `==` should be truthy or falsy

### DIFF
--- a/shared/complex/equal_value.rb
+++ b/shared/complex/equal_value.rb
@@ -60,7 +60,7 @@ describe :complex_equal_value, shared: true do
       obj = mock("Object")
       obj.should_receive(:==).with(value).and_return(:expected)
 
-      (value == obj).should == :expected
+      (value == obj).should_not be_false
     end
   end
 


### PR DESCRIPTION
`Complex#==` returns the value returned by the peer's `==` method right now, but the result is not meaningful, as well as #353.