### PR TITLE
No TypeError on dup

### DIFF
--- a/core/kernel/shared/dup_clone.rb
+++ b/core/kernel/shared/dup_clone.rb
@@ -79,23 +79,25 @@ describe :kernel_dup_clone, shared: true do
     o3.untrusted?.should == true
   end
 
-  it "raises a TypeError for NilClass" do
-    lambda { nil.send(@method) }.should raise_error(TypeError)
-  end
+  ruby_version_is ''...'2.4' do
+    it "raises a TypeError for NilClass" do
+      lambda { nil.send(@method) }.should raise_error(TypeError)
+    end
 
-  it "raises a TypeError for TrueClass" do
-    lambda { true.send(@method) }.should raise_error(TypeError)
-  end
+    it "raises a TypeError for TrueClass" do
+      lambda { true.send(@method) }.should raise_error(TypeError)
+    end
 
-  it "raises a TypeError for FalseClass" do
-    lambda { false.send(@method) }.should raise_error(TypeError)
-  end
+    it "raises a TypeError for FalseClass" do
+      lambda { false.send(@method) }.should raise_error(TypeError)
+    end
 
-  it "raises a TypeError for Fixnum" do
-    lambda { 1.send(@method) }.should raise_error(TypeError)
-  end
+    it "raises a TypeError for Fixnum" do
+      lambda { 1.send(@method) }.should raise_error(TypeError)
+    end
 
-  it "raises a TypeError for Symbol" do
-    lambda { :my_symbol.send(@method) }.should raise_error(TypeError)
+    it "raises a TypeError for Symbol" do
+      lambda { :my_symbol.send(@method) }.should raise_error(TypeError)
+    end
   end
 end

--- a/core/nil/dup_spec.rb
+++ b/core/nil/dup_spec.rb
@@ -1,5 +1,0 @@
-describe "NilClass#dup" do
-  it "raises a TypeError" do
-    lambda { nil.dup }.should raise_error(TypeError)
-  end
-end


### PR DESCRIPTION
Special constants no longer raises a TypeError on dup since 2.4.
https://bugs.ruby-lang.org/issues/12979