### PR TITLE
Fix for libedit

### DIFF
--- a/library/readline/readline_spec.rb
+++ b/library/readline/readline_spec.rb
@@ -18,12 +18,12 @@ process_is_foreground do
       platform_is_not :windows do
         it "returns the input string" do
           out = ruby_exe('puts Readline.readline', options: "-rreadline", args: "< #{@file}")
-          out.should == "test\ntest\n"
+          out.should =~ /^test\Z/
         end
 
         it "taints the returned strings" do
           out = ruby_exe('puts Readline.readline.tainted?', options: "-rreadline", args: "< #{@file}")
-          out.should == "test\ntrue\n"
+          out.should =~ /^true\Z/
         end
       end
     end


### PR DESCRIPTION
Readline of libedit seems not to echo back when input comes from a file.
http://rubyci.org/logs/rubyci.s3.amazonaws.com/osx1011/ruby-trunk/log/20161130T034500Z.fail.html.gz

```
Expected "test\n"
 to equal "test\n" + "test\n"
```
```
Expected "true\n"
 to equal "test\n" + "true\n"
```