### PR TITLE
Fix PRN keyword argument tests

### DIFF
--- a/core/array/sample_spec.rb
+++ b/core/array/sample_spec.rb
@@ -76,10 +76,10 @@ describe "Array#sample" do
       [1, 2].sample(random: obj).should be_an_instance_of(Fixnum)
     end
 
-    it "ignores an Object passed for the RNG if it does not define #rand" do
-      obj = mock("array_sample_random")
+    it "raises a NoMethodError if an object passed for the RNG does not define #rand" do
+      obj = BasicObject.new
 
-      [1, 2].sample(random: obj).should be_an_instance_of(Fixnum)
+      lambda { [1, 2].sample(random: obj) }.should raise_error(NoMethodError)
     end
 
     describe "when the object returned by #rand is a Fixnum" do

--- a/core/array/shuffle_spec.rb
+++ b/core/array/shuffle_spec.rb
@@ -40,12 +40,10 @@ describe "Array#shuffle" do
     result.should include(1, 2)
   end
 
-  it "ignores an Object passed for the RNG if it does not define #rand" do
-    obj = mock("array_shuffle_random")
+  it "raises a NoMethodError if an object passed for the RNG does not define #rand" do
+    obj = BasicObject.new
 
-    result = [1, 2].shuffle(random: obj)
-    result.size.should == 2
-    result.should include(1, 2)
+    lambda { [1, 2].shuffle(random: obj) }.should raise_error(NoMethodError)
   end
 
   it "accepts a Float for the value returned by #rand" do


### PR DESCRIPTION
The description is incorrect since `MockObject` defines `#rand`
method, which is inherited from `Kernel`.
It is not ignored but just the private method is called.