### PR TITLE
AIX requires EXTDLDFLAGS to specify an entry point

### DIFF
--- a/optional/capi/spec_helper.rb
+++ b/optional/capi/spec_helper.rb
@@ -86,8 +86,9 @@ def compile_extension(name)
   ldshared += " #{RbConfig::CONFIG["ARCH_FLAG"]}" if RbConfig::CONFIG["ARCH_FLAG"]
   libpath   = "-L#{path}"
   libs      = RbConfig::CONFIG["LIBS"]
-  dldflags  = "#{RbConfig::CONFIG["LDFLAGS"]} #{RbConfig::CONFIG["DLDFLAGS"]}"
+  dldflags  = "#{RbConfig::CONFIG["LDFLAGS"]} #{RbConfig::CONFIG["DLDFLAGS"]} #{RbConfig::CONFIG["EXTDLDFLAGS"]}"
   dldflags.sub!(/-Wl,-soname,\S+/, '')
+  dldflags.sub!("$(TARGET_ENTRY)", "Init_#{ext}")
 
   link_cmd = "#{ldshared} #{obj} #{libpath} #{dldflags} #{libs} -o #{lib}"
   output = `#{link_cmd}`


### PR DESCRIPTION
EXTDLDFLAGS is defined as "-e$(TARGET_ENTRY)" on AIX, so replace "$(TARGET_ENTRY)" with an actual entry point name.  As of now, AIX is the only platform that defines EXTDLDFLAGS, so this change won't affect any other platforms.