### PR TITLE
String#{concat|prepend} and Array#concat take multiple arguments since 2.4.0

### DIFF
--- a/core/array/concat_spec.rb
+++ b/core/array/concat_spec.rb
@@ -109,4 +109,24 @@ describe "Array#concat" do
     3.times { ary.shift }
     ary.concat([5, 6]).should == [4, 5, 6]
   end
+
+  ruby_version_is "2.4" do
+    it "takes multiple arguments" do
+      ary = [1, 2]
+      ary.concat [3, 4]
+      ary.should == [1, 2, 3, 4]
+    end
+
+    it "concatenates the initial value when given arguments contain 2 self" do
+      ary = [1, 2]
+      ary.concat ary, ary
+      ary.should == [1, 2, 1, 2, 1, 2]
+    end
+
+    it "returns self when given no arguments" do
+      ary = [1, 2]
+      ary.concat.should equal(ary)
+      ary.should == [1, 2]
+    end
+  end
 end

--- a/core/string/concat_spec.rb
+++ b/core/string/concat_spec.rb
@@ -5,4 +5,24 @@ require File.expand_path('../shared/concat', __FILE__)
 describe "String#concat" do
   it_behaves_like :string_concat, :concat
   it_behaves_like :string_concat_encoding, :concat
+
+  ruby_version_is "2.4" do
+    it "takes multiple arguments" do
+      str = "hello "
+      str.concat "wo", "", "rld"
+      str.should == "hello world"
+    end
+
+    it "concatenates the initial value when given arguments contain 2 self" do
+      str = "hello"
+      str.concat str, str
+      str.should == "hellohellohello"
+    end
+
+    it "returns self when given no arguments" do
+      str = "hello"
+      str.concat.should equal(str)
+      str.should == "hello"
+    end
+  end
 end

--- a/core/string/prepend_spec.rb
+++ b/core/string/prepend_spec.rb
@@ -41,4 +41,24 @@ describe "String#prepend" do
     x = "x"
     x.prepend("y".taint).tainted?.should be_true
   end
+
+  ruby_version_is "2.4" do
+    it "takes multiple arguments" do
+      str = " world"
+      str.prepend "he", "", "llo"
+      str.should == "hello world"
+    end
+
+    it "prepends the initial value when given arguments contain 2 self" do
+      str = "hello"
+      str.prepend str, str
+      str.should == "hellohellohello"
+    end
+
+    it "returns self when given no arguments" do
+      str = "hello"
+      str.prepend.should equal(str)
+      str.should == "hello"
+    end
+  end
 end


### PR DESCRIPTION
Add specs around https://bugs.ruby-lang.org/issues/12333