### PR TITLE
Kerenel#warn no longer splats an array in 2.5

### DIFF
--- a/core/kernel/warn_spec.rb
+++ b/core/kernel/warn_spec.rb
@@ -55,11 +55,22 @@ describe "Kernel#warn" do
     }.should output(nil, "line 1\nline 2\n")
   end
 
-  it "writes each array element on a line when passes an array" do
-    lambda {
-      $VERBOSE = true
-      warn(["line 1", "line 2"])
-    }.should output(nil, "line 1\nline 2\n")
+  ruby_version_is ""..."2.5" do
+    it "writes each array element on a line when passes an array" do
+      lambda {
+        $VERBOSE = true
+        warn(["line 1", "line 2"])
+      }.should output(nil, "line 1\nline 2\n")
+    end
+  end
+
+  ruby_version_is "2.5" do
+    it "writes an array in a line" do
+      lambda {
+        $VERBOSE = true
+        warn(["line 1", "line 2"])
+      }.should output(nil, /line 1.*line 2/)
+    end
   end
 
   it "does not write strings when passed no arguments" do


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/12944