### PR TITLE
Extend GzipReader specs to cover returned Enumerators.

### DIFF
--- a/library/zlib/gzipreader/each_byte_spec.rb
+++ b/library/zlib/gzipreader/each_byte_spec.rb
@@ -22,6 +22,22 @@ describe "GzipReader#each_byte" do
     ScratchPad.recorded.should == [49, 50, 51, 52, 53, 97, 98, 99, 100, 101]
   end
 
+  it "returns an enumerator, which yields each byte in the stream, when no block is passed" do
+    gz = Zlib::GzipReader.new @io
+    enum = gz.each_byte
+
+    ScratchPad.record []
+    while true
+      begin
+        ScratchPad << enum.next
+      rescue StopIteration
+        break
+      end
+    end
+
+    ScratchPad.recorded.should == [49, 50, 51, 52, 53, 97, 98, 99, 100, 101]
+  end
+
   it "increments position before calling the block" do
     gz = Zlib::GzipReader.new @io
 

--- a/library/zlib/gzipreader/each_line_spec.rb
+++ b/library/zlib/gzipreader/each_line_spec.rb
@@ -1,1 +1,5 @@
-require File.expand_path('../../../../spec_helper', __FILE__)
+require File.expand_path('../shared/each', __FILE__)
+
+describe "GzipReader#each_line" do
+  it_behaves_like :gzipreader_each, :each_line
+end

--- a/library/zlib/gzipreader/each_spec.rb
+++ b/library/zlib/gzipreader/each_spec.rb
@@ -1,1 +1,5 @@
-require File.expand_path('../../../../spec_helper', __FILE__)
+require File.expand_path('../shared/each', __FILE__)
+
+describe "GzipReader#each" do
+  it_behaves_like :gzipreader_each, :each
+end

--- a/library/zlib/gzipreader/shared/each.rb
+++ b/library/zlib/gzipreader/shared/each.rb
@@ -1,0 +1,51 @@
+require File.expand_path('../../../../../spec_helper', __FILE__)
+require 'stringio'
+require 'zlib'
+
+describe :gzipreader_each, shared: true do
+
+  before :each do
+    @data = "firstline\nsecondline\n\nforthline"
+    @zip = [31, 139, 8, 0, 244, 125, 128, 88, 2, 255, 75, 203, 44, 42, 46, 201,
+            201, 204, 75, 229, 42, 78, 77, 206, 207, 75, 1, 51, 185, 210,242,
+            139, 74, 50, 64, 76, 0, 180, 54, 61, 111, 31, 0, 0, 0].pack('C*')
+
+    @io = StringIO.new @zip
+    @gzreader = Zlib::GzipReader.new @io
+  end
+
+  after :each do
+    ScratchPad.clear
+  end
+
+  it "calls the given block for each line in the stream, passing the line as an argument" do
+    ScratchPad.record []
+    @gzreader.send(@method) { |b| ScratchPad << b }
+
+    ScratchPad.recorded.should == ["firstline\n", "secondline\n", "\n", "forthline"]
+  end
+
+  it "returns an enumerator, which yields each byte in the stream, when no block is passed" do
+    enum = @gzreader.send(@method)
+
+    ScratchPad.record []
+    while true
+      begin
+        ScratchPad << enum.next
+      rescue StopIteration
+        break
+      end
+    end
+
+    ScratchPad.recorded.should == ["firstline\n", "secondline\n", "\n", "forthline"]
+  end
+
+  it "increments position before calling the block" do
+    i = 0
+    @gzreader.send(@method) do |line|
+      i += line.length
+      @gzreader.pos.should == i
+    end
+  end
+
+end


### PR DESCRIPTION
These additional specs aim to cover the recent fixes from https://github.com/jruby/jruby/issues/4443. This PR might be good enough for the time being.
However, seems to me that the specs for GzipReader could benefit from reusing most of the tests from `core/io/shared/each.rb`, but unfortunately I couldn't figure out how to implement the reuse (I'm kind of new to the Rspec/Mspec language).