### PR TITLE
Add microseconds specs for File.mtime, .atime and .ctime

### DIFF
--- a/core/file/atime_spec.rb
+++ b/core/file/atime_spec.rb
@@ -15,6 +15,17 @@ describe "File.atime" do
     File.atime(@file).should be_kind_of(Time)
   end
 
+  platform_is :linux do
+    it "returns the last access time for the named file with microseconds" do
+      3.times do
+        @atime = File.atime(@file)
+        break if @atime.usec > 0
+        sleep 0.001
+      end
+      @atime.usec.should > 0
+    end
+  end
+
   it "raises an Errno::ENOENT exception if the file is not found" do
     lambda { File.atime('a_fake_file') }.should raise_error(Errno::ENOENT)
   end

--- a/core/file/ctime_spec.rb
+++ b/core/file/ctime_spec.rb
@@ -14,6 +14,21 @@ describe "File.ctime" do
     File.ctime(@file).should be_kind_of(Time)
   end
 
+  platform_is :linux do
+    it "Returns the change time for the named file (the time at which directory information about the file was changed, not the file itself) with microseconds." do
+      file = tmp('ctime')
+      3.times do
+        touch file
+        @ctime = File.ctime(file)
+        break if @ctime.usec > 0
+        rm_r file
+        sleep 0.001
+      end
+      rm_r file
+      @ctime.usec.should > 0
+    end
+  end
+
   it "accepts an object that has a #to_path method" do
     File.ctime(mock_to_path(@file))
   end

--- a/core/file/mtime_spec.rb
+++ b/core/file/mtime_spec.rb
@@ -15,6 +15,18 @@ describe "File.mtime" do
     File.mtime(@filename).should be_close(@mtime, 2.0)
   end
 
+  platform_is :linux do
+    it "returns the modification Time of the file with microseconds" do
+      3.times do
+        touch(@filename)
+        @mtime = File.mtime(@filename)
+        break if @mtime.usec > 0
+        sleep 0.001
+      end
+      @mtime.usec.should > 0
+    end
+  end
+
   it "raises an Errno::ENOENT exception if the file is not found" do
     lambda { File.mtime('bogus') }.should raise_error(Errno::ENOENT)
   end


### PR DESCRIPTION
Reference: https://github.com/jruby/jruby/issues/4520#issuecomment-284501906

Three attemps to avoid zero in these values with small sleep (if failed).

And some code refactoring.