### PR TITLE
Improve `File.atime` and `.mtime` specs with microseconds

### DIFF
--- a/core/file/atime_spec.rb
+++ b/core/file/atime_spec.rb
@@ -16,13 +16,11 @@ describe "File.atime" do
   end
 
   platform_is :linux do
+    ## NOTE also that some Linux systems disable atime (e.g. via mount params) for better filesystem speed.
     it "returns the last access time for the named file with microseconds" do
-      3.times do
-        @atime = File.atime(@file)
-        break if @atime.usec > 0
-        sleep 0.001
-      end
-      @atime.usec.should > 0
+      expected_time = Time.at(Time.now.to_i + 0.123456)
+      File.utime expected_time, 0, @file
+      File.atime(@file).usec.should == expected_time.usec
     end
   end
 

--- a/core/file/ctime_spec.rb
+++ b/core/file/ctime_spec.rb
@@ -17,7 +17,7 @@ describe "File.ctime" do
   platform_is :linux do
     it "returns the change time for the named file (the time at which directory information about the file was changed, not the file itself) with microseconds." do
       file = tmp('ctime')
-      3.times do
+      10.times do
         touch file
         @ctime = File.ctime(file)
         break if @ctime.usec > 0

--- a/core/file/mtime_spec.rb
+++ b/core/file/mtime_spec.rb
@@ -17,13 +17,9 @@ describe "File.mtime" do
 
   platform_is :linux do
     it "returns the modification Time of the file with microseconds" do
-      3.times do
-        touch(@filename)
-        @mtime = File.mtime(@filename)
-        break if @mtime.usec > 0
-        sleep 0.001
-      end
-      @mtime.usec.should > 0
+      expected_time = Time.at(Time.now.to_i + 0.123456)
+      File.utime 0, expected_time, @filename
+      File.mtime(@filename).usec.should == expected_time.usec
     end
   end
 


### PR DESCRIPTION
Change to alternative way as @headius suggested.

Increase the number of attempts from 3 to 10 times for `File.ctime`
(in the worst case that will take 0.01 second)