### PR TITLE
Split single % cases

### DIFF
--- a/core/string/modulo_spec.rb
+++ b/core/string/modulo_spec.rb
@@ -14,14 +14,20 @@ describe "String#%" do
     ("%d%% %s" % [10, "of chickens!"]).should == "10% of chickens!"
   end
 
-  it "formats single % characters before a newline or NULL as literal %s" do
+  it "formats single % characters at the end as literal %s" do
     ("%" % []).should == "%"
     ("foo%" % []).should == "foo%"
+  end
+
+  it "formats single % characters before a newline as literal %s" do
     ("%\n" % []).should == "%\n"
     ("foo%\n" % []).should == "foo%\n"
+    ("%\n.3f" % 1.2).should == "%\n.3f"
+  end
+
+  it "formats single % characters before a NUL as literal %s" do
     ("%\0" % []).should == "%\0"
     ("foo%\0" % []).should == "foo%\0"
-    ("%\n.3f" % 1.2).should == "%\n.3f"
     ("%\0.3f" % 1.2).should == "%\0.3f"
   end
 

--- a/core/string/modulo_spec.rb
+++ b/core/string/modulo_spec.rb
@@ -14,18 +14,18 @@ describe "String#%" do
     ("%d%% %s" % [10, "of chickens!"]).should == "10% of chickens!"
   end
 
-  it "formats single % characters at the end as literal %s" do
+  it "formats single % character at the end as literal %" do
     ("%" % []).should == "%"
     ("foo%" % []).should == "foo%"
   end
 
-  it "formats single % characters before a newline as literal %s" do
+  it "formats single % character before a newline as literal %" do
     ("%\n" % []).should == "%\n"
     ("foo%\n" % []).should == "foo%\n"
     ("%\n.3f" % 1.2).should == "%\n.3f"
   end
 
-  it "formats single % characters before a NUL as literal %s" do
+  it "formats single % character before a NUL as literal %" do
     ("%\0" % []).should == "%\0"
     ("foo%\0" % []).should == "foo%\0"
     ("%\0.3f" % 1.2).should == "%\0.3f"


### PR DESCRIPTION
Split cases `%` before a newline and before a NUL.
And `%` at the end differs from the both.