### PR TITLE
Add a spec for rb_struct_size

### DIFF
--- a/optional/capi/ext/rubyspec.h
+++ b/optional/capi/ext/rubyspec.h
@@ -23,6 +23,10 @@
    (RUBY_VERSION_MAJOR == (major) && RUBY_VERSION_MINOR < (minor)) || \
    (RUBY_VERSION_MAJOR == (major) && RUBY_VERSION_MINOR == (minor) && RUBY_VERSION_TEENY < (teeny)))
 
+#if RUBY_VERSION_MAJOR > 2 || (RUBY_VERSION_MAJOR == 2 && RUBY_VERSION_MINOR >= 4)
+#define RUBY_VERSION_IS_2_4
+#endif
+
 #if RUBY_VERSION_MAJOR > 2 || (RUBY_VERSION_MAJOR == 2 && RUBY_VERSION_MINOR >= 3)
 #define RUBY_VERSION_IS_2_3
 #endif
@@ -565,6 +569,9 @@
 #define HAVE_RB_STRUCT_DEFINE              1
 #define HAVE_RB_STRUCT_NEW                 1
 #define HAVE_RB_STRUCT_GETMEMBER           1
+#ifdef RUBY_VERSION_IS_2_4
+#define HAVE_RB_STRUCT_SIZE                1
+#endif
 
 /* Symbol */
 #define HAVE_RB_ID2NAME                    1

--- a/optional/capi/ext/struct_spec.c
+++ b/optional/capi/ext/struct_spec.c
@@ -50,6 +50,13 @@ static VALUE struct_spec_rb_struct_new(VALUE self, VALUE klass,
 }
 #endif
 
+#ifdef HAVE_RB_STRUCT_SIZE
+static VALUE struct_spec_rb_struct_size(VALUE self, VALUE st)
+{
+  return rb_struct_size(st);
+}
+#endif
+
 void Init_struct_spec(void) {
   VALUE cls;
   cls = rb_define_class("CApiStructSpecs", rb_cObject);
@@ -72,6 +79,10 @@ void Init_struct_spec(void) {
 
 #ifdef HAVE_RB_STRUCT_NEW
   rb_define_method(cls, "rb_struct_new", struct_spec_rb_struct_new, 4);
+#endif
+
+#ifdef HAVE_RB_STRUCT_SIZE
+  rb_define_method(cls, "rb_struct_size", struct_spec_rb_struct_size, 1);
 #endif
 }
 

--- a/optional/capi/struct_spec.rb
+++ b/optional/capi/struct_spec.rb
@@ -126,4 +126,12 @@ describe "C-API Struct function" do
       i.c.should == 3
     end
   end
+
+  ruby_version_is "2.4" do
+    describe "rb_struct_size" do
+      it "returns the number of struct members" do
+        @s.rb_struct_size(@struct).should == 3
+      end
+    end
+  end
 end


### PR DESCRIPTION
rb_struct_size is available from Ruby 2.4.
See https://bugs.ruby-lang.org/issues/9916.