### PR TITLE
Update ruby_bug guards

### DIFF
--- a/core/module/autoload_spec.rb
+++ b/core/module/autoload_spec.rb
@@ -400,7 +400,7 @@ describe "Module#autoload" do
   end
 
   describe "(concurrently)" do
-    ruby_bug "#10892", "2.3" do
+    ruby_bug "#10892", ""..."2.3" do
       it "blocks others threads while doing an autoload" do
         file_path     = fixture(__FILE__, "repeated_concurrent_autoload.rb")
         autoload_path = file_path.sub(/\.rb\Z/, '')

--- a/core/range/inspect_spec.rb
+++ b/core/range/inspect_spec.rb
@@ -15,16 +15,12 @@ describe "Range#inspect" do
   it "returns a tainted string if either end is tainted" do
     (("a".taint)..."c").inspect.tainted?.should be_true
     ("a"...("c".taint)).inspect.tainted?.should be_true
-    ruby_bug("#11767", "2.2") do
-      ("a"..."c").taint.inspect.tainted?.should be_true
-    end
+    ("a"..."c").taint.inspect.tainted?.should be_true
   end
 
   it "returns a untrusted string if either end is untrusted" do
     (("a".untrust)..."c").inspect.untrusted?.should be_true
     ("a"...("c".untrust)).inspect.untrusted?.should be_true
-    ruby_bug("#11767", "2.2") do
-      ("a"..."c").untrust.inspect.untrusted?.should be_true
-    end
+    ("a"..."c").untrust.inspect.untrusted?.should be_true
   end
 end

--- a/core/range/to_s_spec.rb
+++ b/core/range/to_s_spec.rb
@@ -14,16 +14,12 @@ describe "Range#to_s" do
   it "returns a tainted string if either end is tainted" do
     (("a".taint)..."c").to_s.tainted?.should be_true
     ("a"...("c".taint)).to_s.tainted?.should be_true
-    ruby_bug("#11767", "2.2") do
-      ("a"..."c").taint.to_s.tainted?.should be_true
-    end
+    ("a"..."c").taint.to_s.tainted?.should be_true
   end
 
   it "returns a untrusted string if either end is untrusted" do
     (("a".untrust)..."c").to_s.untrusted?.should be_true
     ("a"...("c".untrust)).to_s.untrusted?.should be_true
-    ruby_bug("#11767", "2.2") do
-      ("a"..."c").untrust.to_s.untrusted?.should be_true
-    end
+    ("a"..."c").untrust.to_s.untrusted?.should be_true
   end
 end

--- a/language/yield_spec.rb
+++ b/language/yield_spec.rb
@@ -69,15 +69,7 @@ describe "The yield call" do
         }.should raise_error(ArgumentError)
       end
 
-      ruby_bug "#12705", "2.5" do
-        it "should not destructure an Array into multiple arguments" do
-          lambda {
-            @y.s([1, 2], &lambda { |a,b| [a,b] })
-          }.should raise_error(ArgumentError)
-        end
-      end
-
-      ruby_version_is ""..."2.2" do # above is a regression since 2.2
+      ruby_bug "#12705", "2.2"..."2.5" do
         it "should not destructure an Array into multiple arguments" do
           lambda {
             @y.s([1, 2], &lambda { |a,b| [a,b] })


### PR DESCRIPTION
* Remove guards which have been fixed in latest releases.
* Use a more explicit version Range.

For CI, https://bugs.ruby-lang.org/issues/12705 was just fixed 10 days ago in trunk.