### PR TITLE
Add a spec for rb_Hash

### DIFF
--- a/optional/capi/ext/hash_spec.c
+++ b/optional/capi/ext/hash_spec.c
@@ -11,6 +11,12 @@ VALUE hash_spec_rb_hash(VALUE self, VALUE hash) {
 }
 #endif
 
+#ifdef HAVE_RB_HASH2
+VALUE hash_spec_rb_Hash(VALUE self, VALUE val) {
+  return rb_Hash(val);
+}
+#endif
+
 #ifdef HAVE_RB_HASH_DUP
 VALUE hash_spec_rb_hash_dup(VALUE self, VALUE hash) {
   return rb_hash_dup(hash);
@@ -134,6 +140,10 @@ void Init_hash_spec(void) {
 
 #ifdef HAVE_RB_HASH
   rb_define_method(cls, "rb_hash", hash_spec_rb_hash, 1);
+#endif
+
+#ifdef HAVE_RB_HASH2
+  rb_define_method(cls, "rb_Hash", hash_spec_rb_Hash, 1);
 #endif
 
 #ifdef HAVE_RB_HASH_DUP

--- a/optional/capi/ext/rubyspec.h
+++ b/optional/capi/ext/rubyspec.h
@@ -306,6 +306,7 @@
 
 /* Hash */
 #define HAVE_RB_HASH                       1
+#define HAVE_RB_HASH2                      1
 #define HAVE_RB_HASH_DUP                   1
 #define HAVE_RB_HASH_FREEZE                1
 #define HAVE_RB_HASH_AREF                  1

--- a/optional/capi/hash_spec.rb
+++ b/optional/capi/hash_spec.rb
@@ -201,4 +201,30 @@ describe "C-API Hash function" do
       end
     end
   end
+
+  describe "rb_Hash" do
+    it "returns an empty hash when the argument is nil" do
+      @s.rb_Hash(nil).should == {}
+    end
+
+    it "returns an empty hash when the argument is []" do
+      @s.rb_Hash([]).should == {}
+    end
+
+    it "tries to convert the passed argument to a hash by calling #to_hash" do
+      h = BasicObject.new
+      def h.to_hash; {"bar" => "foo"}; end
+      @s.rb_Hash(h).should == {"bar" => "foo"}
+    end
+
+    it "raises a TypeError if the argument does not respond to #to_hash" do
+      lambda { @s.rb_Hash(42) }.should raise_error(TypeError)
+    end
+
+    it "raises a TypeError if #to_hash does not return a hash" do
+      h = BasicObject.new
+      def h.to_hash; 42; end
+      lambda { @s.rb_Hash(h) }.should raise_error(TypeError)
+    end
+  end
 end


### PR DESCRIPTION
I took `HAVE_RB_HASH2` as the macro name as `HAVE_RB_HASH` is already used by `rb_hash`, but I'm not sure it is the right name…