### PR TITLE
Add specs for rb_str_times

### DIFF
--- a/core/string/multiply_spec.rb
+++ b/core/string/multiply_spec.rb
@@ -1,53 +1,7 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes.rb', __FILE__)
+require File.expand_path('../../../shared/string/times', __FILE__)
 
 describe "String#*" do
-  it "returns a new string containing count copies of self" do
-    ("cool" * 0).should == ""
-    ("cool" * 1).should == "cool"
-    ("cool" * 3).should == "coolcoolcool"
-  end
-
-  it "tries to convert the given argument to an integer using to_int" do
-    ("cool" * 3.1).should == "coolcoolcool"
-    ("a" * 3.999).should == "aaa"
-
-    a = mock('4')
-    a.should_receive(:to_int).and_return(4)
-
-    ("a" * a).should == "aaaa"
-  end
-
-  it "raises an ArgumentError when given integer is negative" do
-    lambda { "cool" * -3    }.should raise_error(ArgumentError)
-    lambda { "cool" * -3.14 }.should raise_error(ArgumentError)
-  end
-
-  it "raises a RangeError when given integer is a Bignum" do
-    lambda { "cool" * 999999999999999999999 }.should raise_error(RangeError)
-  end
-
-  it "returns subclass instances" do
-    (StringSpecs::MyString.new("cool") * 0).should be_an_instance_of(StringSpecs::MyString)
-    (StringSpecs::MyString.new("cool") * 1).should be_an_instance_of(StringSpecs::MyString)
-    (StringSpecs::MyString.new("cool") * 2).should be_an_instance_of(StringSpecs::MyString)
-  end
-
-  it "always taints the result when self is tainted" do
-    ["", "OK", StringSpecs::MyString.new(""), StringSpecs::MyString.new("OK")].each do |str|
-      str.taint
-
-      [0, 1, 2].each do |arg|
-        (str * arg).tainted?.should == true
-      end
-    end
-  end
-
-  with_feature :encoding do
-    it "returns a String in the same encoding as self" do
-      str = "\xE3\x81\x82".force_encoding Encoding::UTF_8
-      result = str * 2
-      result.encoding.should equal(Encoding::UTF_8)
-    end
-  end
+  it_behaves_like :string_times, :*, ->(str, times) { str * times }
 end

--- a/optional/capi/ext/rubyspec.h
+++ b/optional/capi/ext/rubyspec.h
@@ -543,6 +543,7 @@
 #define HAVE_RB_STR_NEW4                   1
 #define HAVE_RB_STR_NEW5                   1
 #define HAVE_RB_STR_PLUS                   1
+#define HAVE_RB_STR_TIMES                  1
 #define HAVE_RB_STR_RESIZE                 1
 #define HAVE_RB_STR_SET_LEN                1
 #define HAVE_RB_STR_SPLIT                  1

--- a/optional/capi/ext/string_spec.c
+++ b/optional/capi/ext/string_spec.c
@@ -263,6 +263,12 @@ VALUE string_spec_rb_str_plus(VALUE self, VALUE str1, VALUE str2) {
 }
 #endif
 
+#ifdef HAVE_RB_STR_TIMES
+VALUE string_spec_rb_str_times(VALUE self, VALUE str, VALUE times) {
+  return rb_str_times(str, times);
+}
+#endif
+
 #ifdef HAVE_RB_STR_RESIZE
 VALUE string_spec_rb_str_resize(VALUE self, VALUE str, VALUE size) {
   return rb_str_resize(str, FIX2INT(size));
@@ -556,6 +562,10 @@ void Init_string_spec(void) {
 
 #ifdef HAVE_RB_STR_PLUS
   rb_define_method(cls, "rb_str_plus", string_spec_rb_str_plus, 2);
+#endif
+
+#ifdef HAVE_RB_STR_TIMES
+  rb_define_method(cls, "rb_str_times", string_spec_rb_str_times, 2);
 #endif
 
 #ifdef HAVE_RB_STR_RESIZE

--- a/optional/capi/string_spec.rb
+++ b/optional/capi/string_spec.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require File.expand_path('../spec_helper', __FILE__)
+require File.expand_path('../../../shared/string/times', __FILE__)
 
 load_extension('string')
 
@@ -249,29 +250,7 @@ describe "C-API String function" do
   end
 
   describe "rb_str_times" do
-    it "returns an empty string if the times argument is 0" do
-      @s.rb_str_times("abc", 0).should == ""
-    end
-
-    it "returns a new string containing the specified number of copies of the string" do
-      @s.rb_str_times("abc", 3).should == "abcabcabc"
-    end
-
-    it "raises an ArgumentError if the times argument is less than 0" do
-      lambda { @s.rb_str_times("abc", -1) }.should raise_error(ArgumentError)
-    end
-
-    platform_is wordsize: 32 do
-      it "raises an ArgumentError if the length of the resulting string doesn't fit into a long" do
-        lambda { @s.rb_str_times("abc", 1 << 31 - 1) }.should raise_error(ArgumentError)
-      end
-    end
-
-    platform_is wordsize: 64 do
-      it "raises an ArgumentError if the length of the resulting string doesn't fit into a long" do
-        lambda { @s.rb_str_times("abc", 1 << 63 - 1) }.should raise_error(ArgumentError)
-      end
-    end
+    it_behaves_like :string_times, :rb_str_times, ->(str, times) { @s.rb_str_times(str, times) }
   end
 
   describe "rb_str_buf_cat" do

--- a/optional/capi/string_spec.rb
+++ b/optional/capi/string_spec.rb
@@ -248,6 +248,32 @@ describe "C-API String function" do
     end
   end
 
+  describe "rb_str_times" do
+    it "returns an empty string if the times argument is 0" do
+      @s.rb_str_times("abc", 0).should == ""
+    end
+
+    it "returns a new string containing the specified number of copies of the string" do
+      @s.rb_str_times("abc", 3).should == "abcabcabc"
+    end
+
+    it "raises an ArgumentError if the times argument is less than 0" do
+      lambda { @s.rb_str_times("abc", -1) }.should raise_error(ArgumentError)
+    end
+
+    platform_is wordsize: 32 do
+      it "raises an ArgumentError if the length of the resulting string doesn't fit into a long" do
+        lambda { @s.rb_str_times("abc", 1 << 31 - 1) }.should raise_error(ArgumentError)
+      end
+    end
+
+    platform_is wordsize: 64 do
+      it "raises an ArgumentError if the length of the resulting string doesn't fit into a long" do
+        lambda { @s.rb_str_times("abc", 1 << 63 - 1) }.should raise_error(ArgumentError)
+      end
+    end
+  end
+
   describe "rb_str_buf_cat" do
     it "concatenates a C string to a ruby string" do
       @s.rb_str_buf_cat("Your house is on fire").should == "Your house is on fire?"

--- a/shared/string/times.rb
+++ b/shared/string/times.rb
@@ -50,15 +50,7 @@ describe :string_times, shared: true do
     end
   end
 
-  platform_is wordsize: 32 do
-    it "raises an ArgumentError if the length of the resulting string doesn't fit into a long" do
-      lambda { @object.call("abc", 1 << 31 - 1) }.should raise_error(ArgumentError)
-    end
-  end
-
-  platform_is wordsize: 64 do
-    it "raises an ArgumentError if the length of the resulting string doesn't fit into a long" do
-      lambda { @object.call("abc", 1 << 63 - 1) }.should raise_error(ArgumentError)
-    end
+  it "raises an ArgumentError if the length of the resulting string doesn't fit into a fixnum" do
+    lambda { @object.call("abc", fixnum_max) }.should raise_error(ArgumentError)
   end
 end

--- a/shared/string/times.rb
+++ b/shared/string/times.rb
@@ -1,0 +1,64 @@
+describe :string_times, shared: true do
+  class MyString < String; end
+
+  it "returns a new string containing count copies of self" do
+    @object.call("cool", 0).should == ""
+    @object.call("cool", 1).should == "cool"
+    @object.call("cool", 3).should == "coolcoolcool"
+  end
+
+  it "tries to convert the given argument to an integer using to_int" do
+    @object.call("cool", 3.1).should == "coolcoolcool"
+    @object.call("a", 3.999).should == "aaa"
+
+    a = mock('4')
+    a.should_receive(:to_int).and_return(4)
+
+    @object.call("a", a).should == "aaaa"
+  end
+
+  it "raises an ArgumentError when given integer is negative" do
+    lambda { @object.call("cool", -3)    }.should raise_error(ArgumentError)
+    lambda { @object.call("cool", -3.14) }.should raise_error(ArgumentError)
+  end
+
+  it "raises a RangeError when given integer is a Bignum" do
+    lambda { @object.call("cool", 999999999999999999999) }.should raise_error(RangeError)
+  end
+
+  it "returns subclass instances" do
+    @object.call(MyString.new("cool"), 0).should be_an_instance_of(MyString)
+    @object.call(MyString.new("cool"), 1).should be_an_instance_of(MyString)
+    @object.call(MyString.new("cool"), 2).should be_an_instance_of(MyString)
+  end
+
+  it "always taints the result when self is tainted" do
+    ["", "OK", MyString.new(""), MyString.new("OK")].each do |str|
+      str.taint
+
+      [0, 1, 2].each do |arg|
+        @object.call(str, arg).tainted?.should == true
+      end
+    end
+  end
+
+  with_feature :encoding do
+    it "returns a String in the same encoding as self" do
+      str = "\xE3\x81\x82".force_encoding Encoding::UTF_8
+      result = @object.call(str, 2)
+      result.encoding.should equal(Encoding::UTF_8)
+    end
+  end
+
+  platform_is wordsize: 32 do
+    it "raises an ArgumentError if the length of the resulting string doesn't fit into a long" do
+      lambda { @object.call("abc", 1 << 31 - 1) }.should raise_error(ArgumentError)
+    end
+  end
+
+  platform_is wordsize: 64 do
+    it "raises an ArgumentError if the length of the resulting string doesn't fit into a long" do
+      lambda { @object.call("abc", 1 << 63 - 1) }.should raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
`rb_str_times` is defined in https://github.com/ruby/ruby/blob/b6639a84095b2d5a829d2a277716d9e7c64db81b/string.c#L1830-L1885.