### PR TITLE
Add specs for rb_ary_cat

### DIFF
--- a/optional/capi/array_spec.rb
+++ b/optional/capi/array_spec.rb
@@ -60,6 +60,18 @@ describe "C-API Array function" do
     end
   end
 
+  ruby_version_is "2.1" do
+    describe "rb_ary_cat" do
+      it "pushes the given objects onto the end of the array" do
+        @s.rb_ary_cat([1, 2], 3, 4).should == [1, 2, 3, 4]
+      end
+
+      it "raises a RuntimeError if the array is frozen" do
+        lambda { @s.rb_ary_cat([].freeze, 1) }.should raise_error(RuntimeError)
+      end
+    end
+  end
+
   describe "rb_ary_pop" do
     it "removes and returns the last element in the array" do
       a = [1,2,3]

--- a/optional/capi/ext/array_spec.c
+++ b/optional/capi/ext/array_spec.c
@@ -154,6 +154,14 @@ static VALUE array_spec_rb_ary_push(VALUE self, VALUE array, VALUE item) {
 }
 #endif
 
+#ifdef HAVE_RB_ARY_CAT
+static VALUE array_spec_rb_ary_cat(int argc, VALUE *argv, VALUE self) {
+  VALUE ary, args;
+  rb_scan_args(argc, argv, "1*", &ary, &args);
+  return rb_ary_cat(ary, RARRAY_PTR(args), RARRAY_LEN(args));
+}
+#endif
+
 #ifdef HAVE_RB_ARY_REVERSE
 static VALUE array_spec_rb_ary_reverse(VALUE self, VALUE array) {
   return rb_ary_reverse(array);
@@ -348,6 +356,10 @@ void Init_array_spec(void) {
 
 #ifdef HAVE_RB_ARY_PUSH
   rb_define_method(cls, "rb_ary_push", array_spec_rb_ary_push, 2);
+#endif
+
+#ifdef HAVE_RB_ARY_CAT
+  rb_define_method(cls, "rb_ary_cat", array_spec_rb_ary_cat, -1);
 #endif
 
 #ifdef HAVE_RB_ARY_REVERSE

--- a/optional/capi/ext/rubyspec.h
+++ b/optional/capi/ext/rubyspec.h
@@ -66,6 +66,9 @@
 #define HAVE_RB_ARY_NEW4                   1
 #define HAVE_RB_ARY_POP                    1
 #define HAVE_RB_ARY_PUSH                   1
+#ifdef RUBY_VERSION_IS_2_1
+#define HAVE_RB_ARY_CAT                    1
+#endif
 #define HAVE_RB_ARY_REVERSE                1
 #define HAVE_RB_ARY_SHIFT                  1
 #define HAVE_RB_ARY_STORE                  1


### PR DESCRIPTION
rb_ary_cat is available from Ruby 2.1.