### PR TITLE
Update string/modulo_spec for ruby core changes

### DIFF
--- a/core/string/modulo_spec.rb
+++ b/core/string/modulo_spec.rb
@@ -14,9 +14,9 @@ describe "String#%" do
     ("%d%% %s" % [10, "of chickens!"]).should == "10% of chickens!"
   end
 
-  it "formats single % character at the end as literal %" do
-    ("%" % []).should == "%"
-    ("foo%" % []).should == "foo%"
+  it "raises an error if single % appears at the end" do
+    lambda { ("%" % []) }.should raise_error(ArgumentError)
+    lambda { ("foo%" % [])}.should raise_error(ArgumentError)
   end
 
   it "formats single % character before a newline as literal %" do

--- a/core/string/modulo_spec.rb
+++ b/core/string/modulo_spec.rb
@@ -14,9 +14,18 @@ describe "String#%" do
     ("%d%% %s" % [10, "of chickens!"]).should == "10% of chickens!"
   end
 
-  it "raises an error if single % appears at the end" do
-    lambda { ("%" % []) }.should raise_error(ArgumentError)
-    lambda { ("foo%" % [])}.should raise_error(ArgumentError)
+  ruby_version_is ""..."2.5" do
+    it "formats single % character at the end as literal %" do
+      ("%" % []).should == "%"
+      ("foo%" % []).should == "foo%"
+    end
+  end
+
+  ruby_version_is "2.5" do
+    it "raises an error if single % appears at the end" do
+      lambda { ("%" % []) }.should raise_error(ArgumentError)
+      lambda { ("foo%" % [])}.should raise_error(ArgumentError)
+    end
   end
 
   it "formats single % character before a newline as literal %" do


### PR DESCRIPTION
I will change `sprintf` to raise an error if single "%" character appears at the end.
https://github.com/ruby/ruby/pull/1560#issuecomment-290028117
https://bugs.ruby-lang.org/issues/13315

This pull-request follows the change.
Please review.