### PR TITLE
Fix inaccurate description of a spec in string_times

### DIFF
--- a/shared/string/times.rb
+++ b/shared/string/times.rb
@@ -50,7 +50,15 @@ describe :string_times, shared: true do
     end
   end
 
-  it "raises an ArgumentError if the length of the resulting string doesn't fit into a fixnum" do
-    lambda { @object.call("abc", fixnum_max) }.should raise_error(ArgumentError)
+  platform_is wordsize: 32 do
+    it "raises an ArgumentError if the length of the resulting string doesn't fit into a long" do
+      lambda { @object.call("abc", (2 ** 31) - 1) }.should raise_error(ArgumentError)
+    end
+  end
+
+  platform_is wordsize: 64 do
+    it "raises an ArgumentError if the length of the resulting string doesn't fit into a long" do
+      lambda { @object.call("abc", (2 ** 63) - 1) }.should raise_error(ArgumentError)
+    end
   end
 end


### PR DESCRIPTION
String#* and rb_string_times raise an ArgumentError if the length of the
resulting string doesn't fit into a long rather than a fixnum.

See https://github.com/ruby/spec/pull/397#discussion_r108804128