### PR TITLE
Refactor httpgenericrequest/exec_spec to use an actual Net::BufferedIO

### DIFF
--- a/library/net/http/httpgenericrequest/exec_spec.rb
+++ b/library/net/http/httpgenericrequest/exec_spec.rb
@@ -5,18 +5,13 @@ require "stringio"
 describe "Net::HTTPGenericRequest#exec when passed socket, version, path" do
   before :each do
     @socket = StringIO.new("")
-    def @socket.io # 2.0's @socket is BufferedIO
-      self
-    end
-    def @socket.continue_timeout
-      1
-    end
+    @buffered_socket = Net::BufferedIO.new(@socket)
   end
 
   it "executes the request over the socket to the path using the HTTP version" do
     request = Net::HTTPGenericRequest.new("POST", true, true, "/some/path")
 
-    request.exec(@socket, "1.1", "/some/path")
+    request.exec(@buffered_socket, "1.1", "/some/path")
     str = @socket.string
 
     str.should =~ %r[POST /some/path HTTP/1.1\r\n]
@@ -26,7 +21,7 @@ describe "Net::HTTPGenericRequest#exec when passed socket, version, path" do
     request = Net::HTTPGenericRequest.new("GET", true, true, "/some/path",
                                           "Content-Type" => "text/html")
 
-    request.exec(@socket, "1.0", "/some/other/path")
+    request.exec(@buffered_socket, "1.0", "/some/other/path")
     str = @socket.string
 
     str.should =~ %r[GET /some/other/path HTTP/1.0\r\n]
@@ -40,7 +35,7 @@ describe "Net::HTTPGenericRequest#exec when passed socket, version, path" do
       request = Net::HTTPGenericRequest.new("POST", true, true, "/some/path")
       request.body = "Some Content"
 
-      request.exec(@socket, "1.1", "/some/other/path")
+      request.exec(@buffered_socket, "1.1", "/some/other/path")
       str = @socket.string
 
       str.should =~ %r[POST /some/other/path HTTP/1.1\r\n]
@@ -55,7 +50,7 @@ describe "Net::HTTPGenericRequest#exec when passed socket, version, path" do
                                             "Content-Type" => "text/html")
       request.body = "Some Content"
 
-      request.exec(@socket, "1.1", "/some/other/path")
+      request.exec(@buffered_socket, "1.1", "/some/other/path")
       str = @socket.string
 
       str.should =~ %r[POST /some/other/path HTTP/1.1\r\n]
@@ -72,7 +67,7 @@ describe "Net::HTTPGenericRequest#exec when passed socket, version, path" do
                                             "Content-Length" => "10")
       request.body_stream = StringIO.new("a" * 20)
 
-      request.exec(@socket, "1.1", "/some/other/path")
+      request.exec(@buffered_socket, "1.1", "/some/other/path")
       str = @socket.string
 
       str.should =~ %r[POST /some/other/path HTTP/1.1\r\n]
@@ -88,7 +83,7 @@ describe "Net::HTTPGenericRequest#exec when passed socket, version, path" do
                                             "Content-Length" => "10")
       request.body_stream = StringIO.new("a" * 20)
 
-      request.exec(@socket, "1.1", "/some/other/path")
+      request.exec(@buffered_socket, "1.1", "/some/other/path")
       str = @socket.string
 
       str.should =~ %r[POST /some/other/path HTTP/1.1\r\n]
@@ -105,7 +100,7 @@ describe "Net::HTTPGenericRequest#exec when passed socket, version, path" do
       datasize = 1024 * 10
       request.body_stream = StringIO.new("a" * datasize)
 
-      request.exec(@socket, "1.1", "/some/other/path")
+      request.exec(@buffered_socket, "1.1", "/some/other/path")
       str = @socket.string
 
       str.should =~ %r[POST /some/other/path HTTP/1.1\r\n]
@@ -130,7 +125,7 @@ describe "Net::HTTPGenericRequest#exec when passed socket, version, path" do
                                             "Content-Type" => "text/html")
       request.body_stream = StringIO.new("Some Content")
 
-      lambda { request.exec(@socket, "1.1", "/some/other/path") }.should raise_error(ArgumentError)
+      lambda { request.exec(@buffered_socket, "1.1", "/some/other/path") }.should raise_error(ArgumentError)
     end
   end
 end


### PR DESCRIPTION
This mock broke on this MRI PR: https://github.com/ruby/ruby/pull/1575

I'm not very familiar with Ruby Spec, but I see no reason to use a mock here.

