### PR TITLE
Ignored deprecated methods of psych-3.0.0.beta1 with Ruby 2.5.0

### DIFF
--- a/library/yaml/load_documents_spec.rb
+++ b/library/yaml/load_documents_spec.rb
@@ -3,6 +3,8 @@ require File.expand_path('../fixtures/common', __FILE__)
 require File.expand_path('../fixtures/strings', __FILE__)
 require File.expand_path('../shared/each_document', __FILE__)
 
-describe "YAML.load_documents" do
-  it_behaves_like :yaml_each_document, :load_documents
+ruby_version_is ''...'2.5' do
+  describe "YAML.load_documents" do
+    it_behaves_like :yaml_each_document, :load_documents
+  end
 end

--- a/library/yaml/tagurize_spec.rb
+++ b/library/yaml/tagurize_spec.rb
@@ -1,9 +1,11 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/common', __FILE__)
 
-describe "YAML.tagurize" do
-  it "converts a type_id to a taguri" do
-    YAML.tagurize('wtf').should == "tag:yaml.org,2002:wtf"
-    YAML.tagurize(1).should == 1
+ruby_version_is ''...'2.5' do
+  describe "YAML.tagurize" do
+    it "converts a type_id to a taguri" do
+      YAML.tagurize('wtf').should == "tag:yaml.org,2002:wtf"
+      YAML.tagurize(1).should == 1
+    end
   end
 end


### PR DESCRIPTION
Fixed broken examples caused https://github.com/ruby/ruby/commit/6d77e28763ed17f75edf3b4072701b4dbd7644bb