### PR TITLE
Fix SHELL env var passing

### DIFF
--- a/core/kernel/system_spec.rb
+++ b/core/kernel/system_spec.rb
@@ -38,12 +38,21 @@ describe :kernel_system, shared: true do
   end
 
   platform_is_not :windows do
+    before :each do
+      @shell = ENV['SHELL']
+    end
+
+    before :each do
+      ENV['SHELL'] = @shell
+    end
+
     it "executes with `sh` if the command contains shell characters" do
       lambda { @object.system("echo $0") }.should output_to_fd("sh\n")
     end
 
     it "ignores SHELL env var and always uses `sh`" do
-      lambda { @object.system("SHELL=/bin/zsh echo $0") }.should output_to_fd("sh\n")
+      ENV['SHELL'] = "/bin/zsh"
+      lambda { @object.system("echo $0") }.should output_to_fd("sh\n")
     end
   end
 


### PR DESCRIPTION
Setting `SHELL` env in a command line affects only that command,
after a shell started.