### PR TITLE
Require date

### DIFF
--- a/library/yaml/load_spec.rb
+++ b/library/yaml/load_spec.rb
@@ -71,6 +71,7 @@ describe "YAML.load" do
   end
 
   it "works on complex keys" do
+    require 'date'
     expected = {
       [ 'Detroit Tigers', 'Chicago Cubs' ] => [ Date.new( 2001, 7, 23 ) ],
       [ 'New York Yankees', 'Atlanta Braves' ] => [ Date.new( 2001, 7, 2 ),

--- a/library/yaml/to_yaml_spec.rb
+++ b/library/yaml/to_yaml_spec.rb
@@ -18,6 +18,7 @@ describe "Object#to_yaml" do
   end
 
   it "returns the YAML representation of a Date object" do
+    require 'date'
     Date.parse('1997/12/30').to_yaml.should match_yaml("--- 1997-12-30\n")
   end
 


### PR DESCRIPTION
When running only this file, `date` was not loaded anywhere.