### PR TITLE
Opal strings are always frozen, avoid dup & clone

### DIFF
--- a/core/hash/compare_by_identity_spec.rb
+++ b/core/hash/compare_by_identity_spec.rb
@@ -8,10 +8,10 @@ describe "Hash#compare_by_identity" do
   end
 
   it "causes future comparisons on the receiver to be made by identity" do
-    @h["a"] = :a
-    @h["a"].should == :a
+    @h[[1]] = :a
+    @h[[1]].should == :a
     @h.compare_by_identity
-    @h["a".dup].should be_nil
+    @h[[1].dup].should be_nil
   end
 
   it "rehashes internally so that old keys can be looked up" do
@@ -44,10 +44,7 @@ describe "Hash#compare_by_identity" do
     :bar.should equal(:bar)
     @idh[:bar] = :e
     @idh[:bar] = :f
-    "bar".should_not equal('bar')
-    @idh["bar"] = :g
-    @idh["bar".dup] = :h
-    @idh.values.should == [:c, :d, :f, :g, :h]
+    @idh.values.should == [:c, :d, :f]
   end
 
   it "uses #equal? semantics, but doesn't actually call #equal? to determine identity" do
@@ -65,15 +62,15 @@ describe "Hash#compare_by_identity" do
   end
 
   it "regards #dup'd objects as having different identities" do
-    str = 'foo'
-    @idh[str.dup] = :str
-    @idh[str].should be_nil
+    key = ['foo']
+    @idh[key.dup] = :str
+    @idh[key].should be_nil
   end
 
   it "regards #clone'd objects as having different identities" do
-    str = 'foo'
-    @idh[str.clone] = :str
-    @idh[str].should be_nil
+    key = ['foo']
+    @idh[key.clone] = :str
+    @idh[key].should be_nil
   end
 
   it "regards references to the same object as having the same identity" do


### PR DESCRIPTION
I'm open to suggestions on alternative ways to avoid using mutable strings. 
I thought given the move of ruby toward frozen-by-default strings would be ok to update specs in this direction.