### PR TITLE
Ignored mathn/{complex,rational} examples. 

### DIFF
--- a/library/mathn/complex/Complex_spec.rb
+++ b/library/mathn/complex/Complex_spec.rb
@@ -1,11 +1,14 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'mathn'
 
-describe "Kernel#Complex" do
-  it "returns an Integer if imaginary part is 0" do
-    Complex(42,0).should == 42
-    Complex(42,0).should be_kind_of(Fixnum)
-    Complex(bignum_value,0).should == bignum_value
-    Complex(bignum_value,0).should be_kind_of(Bignum)
+ruby_version_is ''...'2.5' do
+  require 'mathn'
+
+  describe "Kernel#Complex" do
+    it "returns an Integer if imaginary part is 0" do
+      Complex(42,0).should == 42
+      Complex(42,0).should be_kind_of(Fixnum)
+      Complex(bignum_value,0).should == bignum_value
+      Complex(bignum_value,0).should be_kind_of(Bignum)
+    end
   end
 end

--- a/library/mathn/rational/Rational_spec.rb
+++ b/library/mathn/rational/Rational_spec.rb
@@ -1,11 +1,14 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'mathn'
 
-describe "Kernel#Rational" do
-  it "returns an Integer if denominator divides numerator evenly" do
-    Rational(42,6).should == 7
-    Rational(42,6).should be_kind_of(Fixnum)
-    Rational(bignum_value,1).should == bignum_value
-    Rational(bignum_value,1).should be_kind_of(Bignum)
+ruby_version_is ''...'2.5' do
+  require 'mathn'
+
+  describe "Kernel#Rational" do
+    it "returns an Integer if denominator divides numerator evenly" do
+      Rational(42,6).should == 7
+      Rational(42,6).should be_kind_of(Fixnum)
+      Rational(bignum_value,1).should == bignum_value
+      Rational(bignum_value,1).should be_kind_of(Bignum)
+    end
   end
 end

--- a/library/mathn/rational/inspect_spec.rb
+++ b/library/mathn/rational/inspect_spec.rb
@@ -1,12 +1,15 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'mathn'
 
-describe "Rational#inspect" do
-  it "returns a string representation of self" do
-    Rational(3, 4).inspect.should == "(3/4)"
-    Rational(-5, 8).inspect.should == "(-5/8)"
-    Rational(-1, -2).inspect.should == "(1/2)"
-    Rational(0, 2).inspect.should == "0"
-    Rational(bignum_value, 1).inspect.should == "#{bignum_value}"
+ruby_version_is ''...'2.5' do
+  require 'mathn'
+
+  describe "Rational#inspect" do
+    it "returns a string representation of self" do
+      Rational(3, 4).inspect.should == "(3/4)"
+      Rational(-5, 8).inspect.should == "(-5/8)"
+      Rational(-1, -2).inspect.should == "(1/2)"
+      Rational(0, 2).inspect.should == "0"
+      Rational(bignum_value, 1).inspect.should == "#{bignum_value}"
+    end
   end
 end


### PR DESCRIPTION
Follow up https://github.com/ruby/ruby/commit/7b3ac07781be812468674911825e86cd82dfb5b8