### PR TITLE
platform guard requires OS name list, not an array

### DIFF
--- a/library/syslog/log_spec.rb
+++ b/library/syslog/log_spec.rb
@@ -3,7 +3,7 @@ platform_is_not :windows do
   require 'syslog'
 
   describe "Syslog.log" do
-    platform_is_not [:windows, :darwin] do
+    platform_is_not :windows, :darwin do
 
       before :each do
         Syslog.opened?.should be_false

--- a/library/syslog/shared/log.rb
+++ b/library/syslog/shared/log.rb
@@ -1,5 +1,5 @@
 describe :syslog_log, shared: true do
-  platform_is_not [:windows, :darwin] do
+  platform_is_not :windows, :darwin do
     before :each do
       Syslog.opened?.should be_false
     end


### PR DESCRIPTION
Previously, it had wrongly matched against a regexp with a
character class.

`platform_is_not [:windows, :darwin]` was equal to
`RUBY_PLATFORM =~ /[:windows, :darwin]/`, which was same as
`/[:windosar]/`.