### PR TITLE
Revert "Kerenel#warn no longer splats an array in 2.5 (#382)"

### DIFF
--- a/core/kernel/warn_spec.rb
+++ b/core/kernel/warn_spec.rb
@@ -55,22 +55,11 @@ describe "Kernel#warn" do
     }.should output(nil, "line 1\nline 2\n")
   end
 
-  ruby_version_is ""..."2.5" do
-    it "writes each array element on a line when passes an array" do
-      lambda {
-        $VERBOSE = true
-        warn(["line 1", "line 2"])
-      }.should output(nil, "line 1\nline 2\n")
-    end
-  end
-
-  ruby_version_is "2.5" do
-    it "writes an array in a line" do
-      lambda {
-        $VERBOSE = true
-        warn(["line 1", "line 2"])
-      }.should output(nil, /line 1.*line 2/)
-    end
+  it "writes each array element on a line when passes an array" do
+    lambda {
+      $VERBOSE = true
+      warn(["line 1", "line 2"])
+    }.should output(nil, "line 1\nline 2\n")
   end
 
   it "does not write strings when passed no arguments" do


### PR DESCRIPTION
This reverts commit 859eeb08396d8520ca144727876d5490aeb50124.

https://bugs.ruby-lang.org/issues/12944#change-64454