### PR TITLE
Basic syntax in fixtures

### DIFF
--- a/core/kernel/fixtures/classes.rb
+++ b/core/kernel/fixtures/classes.rb
@@ -384,12 +384,6 @@ module KernelSpecs
       [3, 4]
     end
   end
-
-  class NotMatch
-    def !~(obj)
-      :foo
-    end
-  end
 end
 
 class EvalSpecs

--- a/core/kernel/not_match_spec.rb
+++ b/core/kernel/not_match_spec.rb
@@ -2,6 +2,12 @@ require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
 
 describe "Kernel#!~" do
+  class KernelSpecs::NotMatch
+    def !~(obj)
+      :foo
+    end
+  end
+
   it 'calls =~ internally and negates the result' do
     obj = Object.new
     obj.should_receive(:=~).and_return(true)

--- a/core/method/fixtures/classes.rb
+++ b/core/method/fixtures/classes.rb
@@ -77,11 +77,6 @@ module MethodSpecs
     def two_req_one_opt_with_splat_and_block(a, b, c=nil, *d, &blk); end
     def one_req_two_opt_with_splat_and_block(a, b=nil, c=nil, *d, &blk); end
 
-    def one_key(a: 1); end
-    def one_keyrest(**a); end
-
-    def one_keyreq(a:); end
-
     define_method(:zero_defined_method, Proc.new {||})
     define_method(:zero_with_splat_defined_method, Proc.new {|*x|})
     define_method(:one_req_defined_method, Proc.new {|x|})
@@ -186,19 +181,4 @@ module MethodSpecs
     end
   end
 
-  class Methods
-    def one_splat_one_req(*a,b); end
-    def one_splat_two_req(*a,b,c); end
-    def one_splat_one_req_with_block(*a,b,&blk); end
-
-    def one_opt_with_stabby(a=->(b){true}); end
-
-    def one_unnamed_splat(*); end
-
-    def one_splat_one_block(*args, &block)
-      local_is_not_parameter = {}
-    end
-
-    define_method(:one_optional_defined_method) {|x = 1|}
-  end
 end

--- a/core/method/parameters_spec.rb
+++ b/core/method/parameters_spec.rb
@@ -2,6 +2,27 @@ require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
 
 describe "Method#parameters" do
+  class MethodSpecs::Methods
+    def one_key(a: 1); end
+    def one_keyrest(**a); end
+
+    def one_keyreq(a:); end
+
+    def one_splat_one_req(*a,b); end
+    def one_splat_two_req(*a,b,c); end
+    def one_splat_one_req_with_block(*a,b,&blk); end
+
+    def one_opt_with_stabby(a=->(b){true}); end
+
+    def one_unnamed_splat(*); end
+
+    def one_splat_one_block(*args, &block)
+      local_is_not_parameter = {}
+    end
+
+    define_method(:one_optional_defined_method) {|x = 1|}
+  end
+
   it "returns an empty Array when the method expects no arguments" do
     MethodSpecs::Methods.instance_method(:zero).parameters.should == []
   end


### PR DESCRIPTION
tldnr: any objection to this code moving?

These two commits move some method definitions from fixtures to the specs where they are used.

IMO, this helps legibility. More importantly it limits the more modern syntax definitions to the specs that need it. This should make it easier for alternative implementations or Ruby (or older version of Ruby) to run most of the specs.

I'm mentioning older versions of Ruby because that's exactly what is doing the [`backports` project](https://github.com/marcandre/backports)  — a collection of over 200 polyfills of Ruby features for older versions of Ruby. To make sure that the trivial `Kernel#itself` polyfill works in old Ruby versions, it loads the polyfill and then runs the spec for `itself`. As trivial as that should be, without the present PR this won't work in old Ruby because the spec loads a fixture that does not parse in old versions.

The newer features are rarely used in many specs and fixtures. Indeed the two cases I found for 1.9.x compatibility were only used once, so it was easy to move them there.

Any objection?
