### PR TITLE
Numeric timezone may not be bad

### DIFF
--- a/core/time/zone_spec.rb
+++ b/core/time/zone_spec.rb
@@ -70,9 +70,6 @@ describe "Time#zone" do
       with_timezone("1,2") do
         Time.now.utc_offset.should == 0
       end
-      with_timezone("7") do
-        Time.now.utc_offset.should == 0
-      end
       with_timezone("Sun,Fri,2") do
         Time.now.utc_offset.should == 0
       end


### PR DESCRIPTION
On FreeBSD, it seems to be treated as UTC offset in hours.
http://rubyci.org/logs/rubyci.s3.amazonaws.com/freebsd11zfs/ruby-trunk/log/20170428T003002Z.fail.html.gz