### PR TITLE
Remove check for unicode_normalize to be required

### DIFF
--- a/core/kernel/shared/require.rb
+++ b/core/kernel/shared/require.rb
@@ -453,8 +453,8 @@ describe :kernel_require, shared: true do
     end
 
     ruby_version_is "2.2"..."2.3" do
-      it "complex, enumerator, rational and unicode_normalize are already required" do
-        provided = %w[complex enumerator rational unicode_normalize]
+      it "complex, enumerator, and rational are already required" do
+        provided = %w[complex enumerator rational]
         features = ruby_exe("puts $LOADED_FEATURES", options: '--disable-gems')
         provided.each { |feature|
           features.should =~ /\b#{feature}\.(rb|so)$/
@@ -467,8 +467,8 @@ describe :kernel_require, shared: true do
     end
 
     ruby_version_is "2.3" do
-      it "complex, enumerator, rational, thread and unicode_normalize are already required" do
-        provided = %w[complex enumerator rational thread unicode_normalize]
+      it "complex, enumerator, rational, and thread are already required" do
+        provided = %w[complex enumerator rational thread]
         features = ruby_exe("puts $LOADED_FEATURES", options: '--disable-gems')
         provided.each { |feature|
           features.should =~ /\b#{feature}\.(rb|so|jar)$/


### PR DESCRIPTION
This check is no longer needed, because the relevant functionality has been moved to C code in string.c. This check blocks the removal of enc/prelude from the list of files used in the prelude.
(see https://svn.ruby-lang.org/cgi-bin/viewvc.cgi?view=revision&revision=58559 and https://travis-ci.org/ruby/ruby/builds/228602567)