### PR TITLE
Remove check for unicode_normalize to be required from v2.5

### DIFF
--- a/core/kernel/shared/require.rb
+++ b/core/kernel/shared/require.rb
@@ -481,6 +481,21 @@ describe :kernel_require, shared: true do
     end
   end
 
+    ruby_version_is "2.5" do
+      it "complex, enumerator, rational and thread are already required" do
+        provided = %w[complex enumerator rational thread]
+        features = ruby_exe("puts $LOADED_FEATURES", options: '--disable-gems')
+        provided.each { |feature|
+          features.should =~ /\b#{feature}\.(rb|so|jar)$/
+        }
+
+        code = provided.map { |f| "puts require #{f.inspect}\n" }.join
+        required = ruby_exe(code, options: '--disable-gems')
+        required.should == "false\n" * provided.size
+      end
+    end
+  end
+
   describe "(shell expansion)" do
     before :each do
       @path = File.expand_path("load_fixture.rb", CODE_LOADING_DIR)


### PR DESCRIPTION
The check is no longer needed for Ruby v2.5 and later, because the relevant functionality has been moved to C code in string.c. This check blocks the removal of enc/prelude from the list of files used in the prelude.
(see https://svn.ruby-lang.org/cgi-bin/viewvc.cgi?view=revision&revision=58559 and https://travis-ci.org/ruby/ruby/builds/228602567)
This is a revised version of https://github.com/ruby/spec/pull/433, see there for additional discussion.