### PR TITLE
Improve spec for String#split with capture and limit

### DIFF
--- a/core/string/split_spec.rb
+++ b/core/string/split_spec.rb
@@ -300,8 +300,8 @@ describe "String#split with Regexp" do
     "AabB".split(/([a-z])+/).should == ["A", "b", "B"]
   end
 
-  it "applies the limit only to the number of matches, not to the number of captures" do
-    "aBa".split(/(B)()/, 2).should == ["a", "B", "", "a"]
+  it "applies the limit to the number of split substrings, without counting captures" do
+    "aBaBa".split(/(B)()()/, 2).should == ["a", "B", "", "", "aBa"]
   end
 
   it "does not include non-matching captures in the result array" do


### PR DESCRIPTION
* use an example where the result with limit is different from the
  result without limit, and that also demonstrates that the limit
  is not applied separately to both split fields and captures
* improve wording of spec description
  ("matches" IMO rather refers to the delimiters matched by the regexp, i.e. the captures, and not to the split substrings)