### PR TITLE
Remove duplicated `KernelBlockGiven` module

### DIFF
--- a/core/kernel/fixtures/classes.rb
+++ b/core/kernel/fixtures/classes.rb
@@ -213,22 +213,6 @@ module KernelSpecs
     end
   end
 
-  module KernelBlockGiven
-    def self.accept_block
-      Kernel.block_given?
-    end
-
-    def self.accept_block_as_argument(&block)
-      Kernel.block_given?
-    end
-
-    class << self
-      define_method(:defined_block) do
-        Kernel.block_given?
-      end
-    end
-  end
-
   module SelfBlockGiven
     def self.accept_block
       self.send(:block_given?)


### PR DESCRIPTION
`KernelBlockGiven` module is defined twice in core/kernel/fixtures/classes.rb at [L216](https://github.com/ruby/spec/blob/master/core/kernel/fixtures/classes.rb#L216) and [L248](https://github.com/ruby/spec/blob/master/core/kernel/fixtures/classes.rb#L248).
The definition bodies are same. So, I guess I can remove one of the classes.