### PR TITLE
Update an `Enumerable#uniq` spec and add `Enumerator::Lazy#uniq` specs

### DIFF
--- a/core/enumerable/uniq_spec.rb
+++ b/core/enumerable/uniq_spec.rb
@@ -25,7 +25,7 @@ ruby_version_is '2.4' do
         end
       end
 
-      ruby_bug '#13669', ''...'2.5' do
+      ruby_bug '#13669', '2.5' do
         it 'returns an array that contains only first argument of the yield' do
           @enum.uniq { |_, label| label.downcase }.should == [0, 2]
         end

--- a/core/enumerable/uniq_spec.rb
+++ b/core/enumerable/uniq_spec.rb
@@ -19,8 +19,16 @@ ruby_version_is '2.4' do
         end
       end
 
-      it 'returns an array that contains only first argument of the yield' do
-        @enum.uniq { |_, label| label.downcase }.should == [0, 2]
+      ruby_version_is '2.5' do
+        it 'returns all yield arguments as an array' do
+          @enum.uniq { |_, label| label.downcase }.should == [[0, 'foo'], [2, 'bar']]
+        end
+      end
+
+      ruby_bug '#13669', ''...'2.5' do
+        it 'returns an array that contains only first argument of the yield' do
+          @enum.uniq { |_, label| label.downcase }.should == [0, 2]
+        end
       end
     end
   end

--- a/core/enumerator/lazy/uniq_spec.rb
+++ b/core/enumerator/lazy/uniq_spec.rb
@@ -1,0 +1,39 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require File.expand_path('../fixtures/classes', __FILE__)
+
+ruby_version_is '2.4' do
+  describe 'Enumerator::Lazy#uniq'do
+    context 'when yielded with an argument' do
+      before :each do
+        @lazy = [0, 1, 2, 3].to_enum.lazy.uniq(&:even?)
+      end
+
+      it 'returns a lazy enumerator'  do
+        @lazy.should be_an_instance_of(Enumerator::Lazy)
+        @lazy.force.should == [0, 1]
+      end
+
+      it 'sets the size to nil'  do
+        @lazy.size.should == nil
+      end
+    end
+
+    context 'when yielded with multiple arguments' do
+      before :each do
+        enum = Object.new.to_enum
+        class << enum
+          def each
+            yield 0, 'foo'
+            yield 1, 'FOO'
+            yield 2, 'bar'
+          end
+        end
+        @lazy = enum.lazy
+      end
+
+      it 'returns all yield arguments as an array' do
+        @lazy.uniq { |_, label| label.downcase }.force.should == [[0, 'foo'], [2, 'bar']]
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Update https://github.com/ruby/spec/pull/447 to follow https://bugs.ruby-lang.org/issues/13669 
* Add missing `Enumerator::Lazy#uniq` specs as `Enumerable#uniq`