### PR TITLE
Test status of dying threads

### DIFF
--- a/core/thread/stop_spec.rb
+++ b/core/thread/stop_spec.rb
@@ -54,3 +54,13 @@ describe "Thread#stop?" do
   end
   end
 end
+
+describe "Thread#status" do
+  it "describes a dying running thread" do
+    ThreadSpecs.status_of_dying_running_thread.status.should == 'aborting'
+  end
+
+  it "describes a dying sleeping thread" do
+    ThreadSpecs.status_of_dying_running_thread.status.should == 'aborting'
+  end
+end


### PR DESCRIPTION
The status of a dying running or sleeping thread should be 'aborting'.
On jruby this is not the case. These spec additions show this issue.

There already is an open issue for jruby: https://github.com/jruby/jruby/issues/4705

```
$ ruby ./jruby/mspec/bin/mspec-run core/thread/stop_spec.rb
jruby 9.1.12.0 (2.3.3) 2017-06-15 33c6439 Java HotSpot(TM) 64-Bit Server VM 25.112-b16 on 1.8.0_112-b16 +jit [darwin-x86_64]
                                                                                             
1)
Thread#status describes a dying running thread FAILED
Expected "run"
 to equal "aborting"

./jruby/ruby-spec/core/thread/stop_spec.rb:60:in `block in (root)'
org/jruby/RubyBasicObject.java:1691:in `instance_eval'
org/jruby/RubyEnumerable.java:1596:in `all?'
org/jruby/RubyFixnum.java:299:in `times'
org/jruby/RubyArray.java:1734:in `each'
./jruby/ruby-spec/core/thread/stop_spec.rb:58:in `<main>'
org/jruby/RubyKernel.java:979:in `load'
org/jruby/RubyBasicObject.java:1691:in `instance_eval'
org/jruby/RubyArray.java:1734:in `each'
                                                                                             
2)
Thread#status describes a dying sleeping thread FAILED
Expected "run"
 to equal "aborting"

./jruby/ruby-spec/core/thread/stop_spec.rb:64:in `block in (root)'
org/jruby/RubyBasicObject.java:1691:in `instance_eval'
org/jruby/RubyEnumerable.java:1596:in `all?'
org/jruby/RubyFixnum.java:299:in `times'
org/jruby/RubyArray.java:1734:in `each'
./jruby/ruby-spec/core/thread/stop_spec.rb:58:in `<main>'
org/jruby/RubyKernel.java:979:in `load'
org/jruby/RubyBasicObject.java:1691:in `instance_eval'
org/jruby/RubyArray.java:1734:in `each'
[| | ==================100%================== | 00:00:00]      2F      0E 

Finished in 0.175762 seconds

1 file, 12 examples, 13 expectations, 2 failures, 0 errors, 0 tagged
```