### PR TITLE
Add spec for an invalid break from another thread

### DIFF
--- a/language/break_spec.rb
+++ b/language/break_spec.rb
@@ -40,12 +40,12 @@ describe "The break statement in a captured block" do
 
     it "raises a LocalJumpError when invoking the block from a method" do
       lambda { @program.break_in_nested_method }.should raise_error(LocalJumpError)
-      ScratchPad.recorded.should == [:a, :xa, :c, :aa, :b]
+      ScratchPad.recorded.should == [:a, :xa, :cc, :aa, :b]
     end
 
     it "raises a LocalJumpError when yielding to the block" do
       lambda { @program.break_in_yielding_method }.should raise_error(LocalJumpError)
-      ScratchPad.recorded.should == [:a, :xa, :c, :aa, :b]
+      ScratchPad.recorded.should == [:a, :xa, :cc, :aa, :b]
     end
   end
 

--- a/language/break_spec.rb
+++ b/language/break_spec.rb
@@ -63,8 +63,15 @@ describe "The break statement in a captured block" do
 
   describe "from another thread" do
     it "raises a LocalJumpError when getting the value from another thread" do
-      lambda { @program.break_in_another_thread }.should raise_error(LocalJumpError)
-      ScratchPad.recorded.should == [:a, :b, :d]
+      ScratchPad << :a
+      thread_with_break = Thread.new do
+        ScratchPad << :b
+        break :break
+        ScratchPad << :c
+      end
+
+      lambda { thread_with_break.value }.should raise_error(LocalJumpError)
+      ScratchPad.recorded.should == [:a, :b]
     end
   end
 end

--- a/language/break_spec.rb
+++ b/language/break_spec.rb
@@ -64,7 +64,7 @@ describe "The break statement in a captured block" do
   describe "from another thread" do
     it "raises a LocalJumpError when getting the value from another thread" do
       lambda { @program.break_in_another_thread }.should raise_error(LocalJumpError)
-      ScratchPad.recorded.should == [:a, :b]
+      ScratchPad.recorded.should == [:a, :b, :d]
     end
   end
 end

--- a/language/break_spec.rb
+++ b/language/break_spec.rb
@@ -60,6 +60,13 @@ describe "The break statement in a captured block" do
       ScratchPad.recorded.should == [:a, :za, :xa, :zd, :aa, :zb]
     end
   end
+
+  describe "from another thread" do
+    it "raises a LocalJumpError when getting the value from another thread" do
+      lambda { @program.break_in_another_thread }.should raise_error(LocalJumpError)
+      ScratchPad.recorded.should == [:a, :b]
+    end
+  end
 end
 
 describe "The break statement in a lambda" do

--- a/language/fixtures/break.rb
+++ b/language/fixtures/break.rb
@@ -89,7 +89,7 @@ module BreakSpecs
         break :break
         note :c
       }
-      note :c
+      note :cc
       note call_method(b)
       note :d
     end
@@ -101,7 +101,7 @@ module BreakSpecs
         break :break
         note :c
       }
-      note :c
+      note :cc
       note yielding(&b)
       note :d
     end

--- a/language/fixtures/break.rb
+++ b/language/fixtures/break.rb
@@ -128,6 +128,16 @@ module BreakSpecs
         note :c
       end
     end
+
+    def break_in_another_thread
+      note :a
+      Thread.new do
+        note :b
+        break :break
+        note :c
+      end.value
+      note :d
+    end
   end
 
   class Lambda < Driver

--- a/language/fixtures/break.rb
+++ b/language/fixtures/break.rb
@@ -131,12 +131,15 @@ module BreakSpecs
 
     def break_in_another_thread
       note :a
-      Thread.new do
+      thread = Thread.new do
         note :b
         break :break
         note :c
-      end.value
+      end
+      thread.join rescue nil
       note :d
+      thread.value
+      note :e
     end
   end
 

--- a/language/fixtures/break.rb
+++ b/language/fixtures/break.rb
@@ -128,19 +128,6 @@ module BreakSpecs
         note :c
       end
     end
-
-    def break_in_another_thread
-      note :a
-      thread = Thread.new do
-        note :b
-        break :break
-        note :c
-      end
-      thread.join rescue nil
-      note :d
-      thread.value
-      note :e
-    end
   end
 
   class Lambda < Driver


### PR DESCRIPTION
This checks that the LocalJumpError is correctly propagated across threads, see jruby/jruby#4697 .