### PR TITLE
Test status of externally killed threads

### DIFF
--- a/core/thread/status_spec.rb
+++ b/core/thread/status_spec.rb
@@ -41,4 +41,20 @@ describe "Thread#status" do
   it "reports aborting on a killed thread after sleep" do
     ThreadSpecs.status_of_dying_thread_after_sleep.status.should == 'aborting'
   end
+
+  it "reports aborting on an externally killed thread that sleeps" do
+    q = Queue.new
+    t = Thread.new do
+      begin
+        q.push nil
+        sleep
+      ensure
+        q.push Thread.current.status
+      end 
+    end
+    q.pop
+    t.kill
+    t.join
+    q.pop.should == 'aborting'
+  end
 end


### PR DESCRIPTION
The additional spec tests that the status of a sleeping killed thread has the status of aborting.
The spec passes on mri 2.4.1, but fails on jruby. Also see #456.