### PR TITLE
Add spec for Integer#round(half:)

### DIFF
--- a/core/integer/round_spec.rb
+++ b/core/integer/round_spec.rb
@@ -74,4 +74,22 @@ describe "Integer#round" do
     obj.stub!(:to_int).and_return([])
     lambda { 42.round(obj) }.should raise_error(TypeError)
   end
+
+  ruby_version_is "2.4" do
+    it "returns different rounded values depending on the half option" do
+      35.round(1, half: :up).should      eql(35.0)
+      35.round(1, half: :down).should    eql(35.0)
+      35.round(1, half: :even).should    eql(35.0)
+
+      25.round(-1, half: :up).should      eql(30)
+      25.round(-1, half: :down).should    eql(20)
+      25.round(-1, half: :even).should    eql(20)
+      35.round(-1, half: :up).should      eql(40)
+      35.round(-1, half: :down).should    eql(30)
+      35.round(-1, half: :even).should    eql(40)
+      (-25).round(-1, half: :up).should   eql(-30)
+      (-25).round(-1, half: :down).should eql(-20)
+      (-25).round(-1, half: :even).should eql(-20)
+    end
+  end
 end


### PR DESCRIPTION
Again, the testing values are taken from [numeric.c](https://github.com/ruby/ruby/blob/6b05153a3a75b74b64553d6a46f501d9ee0f0376/numeric.c#L5017-L5025).  