### PR TITLE
Add spec for Net::FTP#status(pathname)

### DIFF
--- a/library/net/ftp/fixtures/server.rb
+++ b/library/net/ftp/fixtures/server.rb
@@ -229,8 +229,12 @@ module NetFTPSpecs
       end
     end
 
-    def stat
-      self.response("211 System status, or system help reply. (STAT)")
+    def stat(param = :default)
+      if param == :default
+        self.response("211 System status, or system help reply. (STAT)")
+      else
+        self.response("211 System status, or system help reply. (STAT #{param})")
+      end
     end
 
     def stor(file)

--- a/library/net/ftp/status_spec.rb
+++ b/library/net/ftp/status_spec.rb
@@ -22,6 +22,12 @@ describe "Net::FTP#status" do
     @ftp.last_response.should == "211 System status, or system help reply. (STAT)\n"
   end
 
+  ruby_version_is "2.4" do
+    it "sends the STAT command with an optional parameter to the server" do
+      @ftp.status("/pub").should == "211 System status, or system help reply. (STAT /pub)\n"
+    end
+  end
+
   it "returns the received information" do
     @ftp.status.should == "211 System status, or system help reply. (STAT)\n"
   end


### PR DESCRIPTION
Yes, Ruby does not try to parse the file list as it's just part of a 211 response.

e.g.
``` ruby
2.4.2 :012 > ftp.status '.'
 => "211-Status of .:\n211-drwxr-xr-x   2 ftp      ftp          4096 Oct  7 15:43 .\n211-drwxr-xr-x   2 ftp      ftp          4096 Oct  7 15:43 ..\n211--rw-r--r--   1 ftp      ftp           170 Apr  5  2016 welcome.msg\n211 End of status\n"
```