### PR TITLE
Add specs for symbol#casecmp?

### DIFF
--- a/core/symbol/casecmp_spec.rb
+++ b/core/symbol/casecmp_spec.rb
@@ -106,7 +106,7 @@ ruby_version_is "2.4" do
       upper_a_umlaut.casecmp?(upper_a_tilde).should_not == true
     end
 
-    it "doesn't do case mapping for non-ascii characters" do
+    it "doesn't do case mapping for non-ascii and non-unicode characters" do
       # -- Latin-1 --
       upper_a_tilde  = "\xC3".b.to_sym
       upper_a_umlaut = "\xC4".b.to_sym
@@ -117,17 +117,30 @@ ruby_version_is "2.4" do
       upper_a_umlaut.casecmp?(lower_a_umlaut).should == false
       lower_a_tilde.casecmp?(upper_a_tilde).should == false
       lower_a_umlaut.casecmp?(upper_a_umlaut).should == false
+    end
 
+    it 'does case mapping for unicode characters' do
       # -- UTF-8 --
       upper_a_tilde  = :"Ã"
       lower_a_tilde  = :"ã"
       upper_a_umlaut = :"Ä"
       lower_a_umlaut = :"ä"
 
-      upper_a_tilde.casecmp?(lower_a_tilde).should == false
-      upper_a_umlaut.casecmp?(lower_a_umlaut).should == false
-      lower_a_tilde.casecmp?(upper_a_tilde).should == false
-      lower_a_umlaut.casecmp?(upper_a_umlaut).should == false
+      upper_a_tilde.casecmp?(lower_a_tilde).should == true
+      upper_a_umlaut.casecmp?(lower_a_umlaut).should == true
+      lower_a_tilde.casecmp?(upper_a_tilde).should == true
+      lower_a_umlaut.casecmp?(upper_a_umlaut).should == true
+    end
+
+    it 'returns nil when comparing characters with different encodings' do
+      # -- Latin-1 --
+      upper_a_tilde = "\xC3".b.to_sym
+
+      # -- UTF-8 --
+      lower_a_tilde = :"ã"
+
+      upper_a_tilde.casecmp?(lower_a_tilde).should == nil
+      lower_a_tilde.casecmp?(upper_a_tilde).should == nil
     end
   end
 end

--- a/core/symbol/casecmp_spec.rb
+++ b/core/symbol/casecmp_spec.rb
@@ -72,3 +72,62 @@ describe "Symbol#casecmp" do
     :abc.casecmp(obj).should be_nil
   end
 end
+
+ruby_version_is "2.4" do
+  describe 'Symbol#casecmp?' do
+    it "compares symbols without regard to case" do
+      :abcdef.casecmp?(:abcde).should == false
+      :aBcDeF.casecmp?(:abcdef).should == true
+      :abcdef.casecmp?(:abcdefg).should == false
+      :abcdef.casecmp?(:ABCDEF).should == true
+    end
+
+    it "doesn't consider non-ascii characters equal that aren't" do
+      # -- Latin-1 --
+      upper_a_tilde  = :"\xC3"
+      upper_a_umlaut = :"\xC4"
+      lower_a_tilde  = :"\xE3"
+      lower_a_umlaut = :"\xE4"
+
+      lower_a_tilde.casecmp(lower_a_umlaut).should_not == true
+      lower_a_umlaut.casecmp(lower_a_tilde).should_not == true
+      upper_a_tilde.casecmp(upper_a_umlaut).should_not == true
+      upper_a_umlaut.casecmp(upper_a_tilde).should_not == true
+
+      # -- UTF-8 --
+      upper_a_tilde  = :"\xC3\x83"
+      upper_a_umlaut = :"\xC3\x84"
+      lower_a_tilde  = :"\xC3\xA3"
+      lower_a_umlaut = :"\xC3\xA4"
+
+      lower_a_tilde.casecmp(lower_a_umlaut).should_not == true
+      lower_a_umlaut.casecmp(lower_a_tilde).should_not == true
+      upper_a_tilde.casecmp(upper_a_umlaut).should_not == true
+      upper_a_umlaut.casecmp(upper_a_tilde).should_not == true
+    end
+
+    it "doesn't do case mapping for non-ascii characters" do
+      # -- Latin-1 --
+      upper_a_tilde  = :"\xC3"
+      upper_a_umlaut = :"\xC4"
+      lower_a_tilde  = :"\xE3"
+      lower_a_umlaut = :"\xE4"
+
+      upper_a_tilde.casecmp(lower_a_tilde).should == false
+      upper_a_umlaut.casecmp(lower_a_umlaut).should == false
+      lower_a_tilde.casecmp(upper_a_tilde).should == false
+      lower_a_umlaut.casecmp(upper_a_umlaut).should == false
+
+      # -- UTF-8 --
+      upper_a_tilde  = :"\xC3\x83"
+      upper_a_umlaut = :"\xC3\x84"
+      lower_a_tilde  = :"\xC3\xA3"
+      lower_a_umlaut = :"\xC3\xA4"
+
+      upper_a_tilde.casecmp(lower_a_tilde).should == false
+      upper_a_umlaut.casecmp(lower_a_umlaut).should == false
+      lower_a_tilde.casecmp(upper_a_tilde).should == false
+      lower_a_umlaut.casecmp(upper_a_umlaut).should == false
+    end
+  end
+end

--- a/core/symbol/casecmp_spec.rb
+++ b/core/symbol/casecmp_spec.rb
@@ -84,50 +84,50 @@ ruby_version_is "2.4" do
 
     it "doesn't consider non-ascii characters equal that aren't" do
       # -- Latin-1 --
-      upper_a_tilde  = :"\xC3"
-      upper_a_umlaut = :"\xC4"
-      lower_a_tilde  = :"\xE3"
-      lower_a_umlaut = :"\xE4"
+      upper_a_tilde  = "\xC3".b.to_sym
+      upper_a_umlaut = "\xC4".b.to_sym
+      lower_a_tilde  = "\xE3".b.to_sym
+      lower_a_umlaut = "\xE4".b.to_sym
 
-      lower_a_tilde.casecmp(lower_a_umlaut).should_not == true
-      lower_a_umlaut.casecmp(lower_a_tilde).should_not == true
-      upper_a_tilde.casecmp(upper_a_umlaut).should_not == true
-      upper_a_umlaut.casecmp(upper_a_tilde).should_not == true
+      lower_a_tilde.casecmp?(lower_a_umlaut).should_not == true
+      lower_a_umlaut.casecmp?(lower_a_tilde).should_not == true
+      upper_a_tilde.casecmp?(upper_a_umlaut).should_not == true
+      upper_a_umlaut.casecmp?(upper_a_tilde).should_not == true
 
       # -- UTF-8 --
-      upper_a_tilde  = :"\xC3\x83"
-      upper_a_umlaut = :"\xC3\x84"
-      lower_a_tilde  = :"\xC3\xA3"
-      lower_a_umlaut = :"\xC3\xA4"
+      upper_a_tilde  = :"Ã"
+      lower_a_tilde  = :"ã"
+      upper_a_umlaut = :"Ä"
+      lower_a_umlaut = :"ä"
 
-      lower_a_tilde.casecmp(lower_a_umlaut).should_not == true
-      lower_a_umlaut.casecmp(lower_a_tilde).should_not == true
-      upper_a_tilde.casecmp(upper_a_umlaut).should_not == true
-      upper_a_umlaut.casecmp(upper_a_tilde).should_not == true
+      lower_a_tilde.casecmp?(lower_a_umlaut).should_not == true
+      lower_a_umlaut.casecmp?(lower_a_tilde).should_not == true
+      upper_a_tilde.casecmp?(upper_a_umlaut).should_not == true
+      upper_a_umlaut.casecmp?(upper_a_tilde).should_not == true
     end
 
     it "doesn't do case mapping for non-ascii characters" do
       # -- Latin-1 --
-      upper_a_tilde  = :"\xC3"
-      upper_a_umlaut = :"\xC4"
-      lower_a_tilde  = :"\xE3"
-      lower_a_umlaut = :"\xE4"
+      upper_a_tilde  = "\xC3".b.to_sym
+      upper_a_umlaut = "\xC4".b.to_sym
+      lower_a_tilde  = "\xE3".b.to_sym
+      lower_a_umlaut = "\xE4".b.to_sym
 
-      upper_a_tilde.casecmp(lower_a_tilde).should == false
-      upper_a_umlaut.casecmp(lower_a_umlaut).should == false
-      lower_a_tilde.casecmp(upper_a_tilde).should == false
-      lower_a_umlaut.casecmp(upper_a_umlaut).should == false
+      upper_a_tilde.casecmp?(lower_a_tilde).should == false
+      upper_a_umlaut.casecmp?(lower_a_umlaut).should == false
+      lower_a_tilde.casecmp?(upper_a_tilde).should == false
+      lower_a_umlaut.casecmp?(upper_a_umlaut).should == false
 
       # -- UTF-8 --
-      upper_a_tilde  = :"\xC3\x83"
-      upper_a_umlaut = :"\xC3\x84"
-      lower_a_tilde  = :"\xC3\xA3"
-      lower_a_umlaut = :"\xC3\xA4"
+      upper_a_tilde  = :"Ã"
+      lower_a_tilde  = :"ã"
+      upper_a_umlaut = :"Ä"
+      lower_a_umlaut = :"ä"
 
-      upper_a_tilde.casecmp(lower_a_tilde).should == false
-      upper_a_umlaut.casecmp(lower_a_umlaut).should == false
-      lower_a_tilde.casecmp(upper_a_tilde).should == false
-      lower_a_umlaut.casecmp(upper_a_umlaut).should == false
+      upper_a_tilde.casecmp?(lower_a_tilde).should == false
+      upper_a_umlaut.casecmp?(lower_a_umlaut).should == false
+      lower_a_tilde.casecmp?(upper_a_tilde).should == false
+      lower_a_umlaut.casecmp?(upper_a_umlaut).should == false
     end
   end
 end


### PR DESCRIPTION
Adds specs for the new method `casecmp?` on the `Symbol` class in ruby version 2.4 as part of #473.