### PR TITLE
Adds specs for Dir.empty?

### DIFF
--- a/core/dir/empty_spec.rb
+++ b/core/dir/empty_spec.rb
@@ -1,7 +1,7 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/common', __FILE__)
 
-describe "Dir#empty?" do
+describe "Dir.empty?" do
   ruby_version_is "2.4" do
     before :all do
       DirSpecs.create_mock_dirs

--- a/core/dir/empty_spec.rb
+++ b/core/dir/empty_spec.rb
@@ -1,0 +1,37 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../fixtures/common', __FILE__)
+
+describe "Dir#empty?" do
+  ruby_version_is "2.4" do
+    before :all do
+      DirSpecs.create_mock_dirs
+      @empty_dir = DirSpecs.mock_dir "empty_dir"
+      mkdir_p @empty_dir
+    end
+
+    after :all do
+      DirSpecs.delete_mock_dirs
+      rm_r @empty_dir
+    end
+
+    it "returns true for empty directories" do
+      result = Dir.empty? @empty_dir
+      result.should be_true
+    end
+
+    it "returns false for non-empty directories" do
+      result = Dir.empty? DirSpecs.mock_dir
+      result.should be_false
+    end
+
+    it "returns false for a non-directory" do
+      first_file = DirSpecs.mock_dir_files.first
+      result = Dir.empty? "#{DirSpecs.mock_dir}/#{first_file}"
+      result.should be_false
+    end
+
+    it "raises ENOENT for nonexistent directories" do
+      lambda { Dir.empty?(DirSpecs.nonexistent) }.should raise_error(Errno::ENOENT)
+    end
+  end
+end

--- a/core/dir/empty_spec.rb
+++ b/core/dir/empty_spec.rb
@@ -1,16 +1,13 @@
 require File.expand_path('../../../spec_helper', __FILE__)
-require File.expand_path('../fixtures/common', __FILE__)
 
-describe "Dir.empty?" do
-  ruby_version_is "2.4" do
+ruby_version_is "2.4" do
+  describe "Dir.empty?" do
     before :all do
-      DirSpecs.create_mock_dirs
-      @empty_dir = DirSpecs.mock_dir "empty_dir"
+      @empty_dir = tmp("empty_dir")
       mkdir_p @empty_dir
     end
 
     after :all do
-      DirSpecs.delete_mock_dirs
       rm_r @empty_dir
     end
 
@@ -20,18 +17,17 @@ describe "Dir.empty?" do
     end
 
     it "returns false for non-empty directories" do
-      result = Dir.empty? DirSpecs.mock_dir
+      result = Dir.empty? __dir__
       result.should be_false
     end
 
     it "returns false for a non-directory" do
-      first_file = DirSpecs.mock_dir_files.first
-      result = Dir.empty? "#{DirSpecs.mock_dir}/#{first_file}"
+      result = Dir.empty? __FILE__
       result.should be_false
     end
 
     it "raises ENOENT for nonexistent directories" do
-      lambda { Dir.empty?(DirSpecs.nonexistent) }.should raise_error(Errno::ENOENT)
+      lambda { Dir.empty? tmp("nonexistent") }.should raise_error(Errno::ENOENT)
     end
   end
 end


### PR DESCRIPTION
Completes part of #473 

Specs for Feature [#10121](https://bugs.ruby-lang.org/issues/10121).

Dir.empty? returns true when param is directory with no entries, false
when param is directory with entries or a non-directory, and raises
Errno::ENOENT when param is a non-existent directory/file.