### PR TITLE
Add specs for Integer ceil, floor, truncate and round that takes optional digits

### DIFF
--- a/core/integer/ceil_spec.rb
+++ b/core/integer/ceil_spec.rb
@@ -10,6 +10,8 @@ describe "Integer#ceil" do
         1.ceil.should eql(1)
         1.ceil(0).should eql(1)
         1.ceil(2).should eql(1.0)
+        1832.ceil(3).should eql(1832.0)
+        -1832.ceil(3).should eql(-1832.0)
       end
     end
 

--- a/core/integer/ceil_spec.rb
+++ b/core/integer/ceil_spec.rb
@@ -3,4 +3,25 @@ require File.expand_path('../shared/to_i', __FILE__)
 
 describe "Integer#ceil" do
   it_behaves_like(:integer_to_i, :ceil)
+
+  ruby_version_is "2.4" do
+    context "precision argument specified as part of the ceil method is zero or positive" do
+      it "returns self as integer or float" do
+        1.ceil.should eql(1)
+        1.ceil(0).should eql(1)
+        1.ceil(2).should eql(1.0)
+      end
+    end
+
+    context "precision argument specified as part of the ceil method is negative" do
+      it "returns the smallest integer greater than self with at least precision.abs trailing zeros" do
+        18.ceil(-1).should eql(20)
+        18.ceil(-2).should eql(100)
+        18.ceil(-3).should eql(1000)
+        -1832.ceil(-1).should eql(-1830)
+        -1832.ceil(-2).should eql(-1800)
+        -1832.ceil(-3).should eql(-1000)
+      end
+    end
+  end
 end

--- a/core/integer/floor_spec.rb
+++ b/core/integer/floor_spec.rb
@@ -10,6 +10,8 @@ describe "Integer#floor" do
         1.floor.should eql(1)
         1.floor(0).should eql(1)
         1.floor(2).should eql(1.0)
+        1832.floor(3).should eql(1832.0)
+        -1832.floor(3).should eql(-1832.0)
       end
     end
 

--- a/core/integer/floor_spec.rb
+++ b/core/integer/floor_spec.rb
@@ -3,4 +3,25 @@ require File.expand_path('../shared/to_i', __FILE__)
 
 describe "Integer#floor" do
   it_behaves_like(:integer_to_i, :floor)
+
+  ruby_version_is "2.4" do
+    context "precision argument specified as part of the floor method is zero or positive" do
+      it "returns self as integer or float" do
+        1.floor.should eql(1)
+        1.floor(0).should eql(1)
+        1.floor(2).should eql(1.0)
+      end
+    end
+
+    context "precision argument specified as part of the floor method is negative" do
+      it "returns the largest integer less than self with at least precision.abs trailing zeros" do
+        1832.floor(-1).should eql(1830)
+        1832.floor(-2).should eql(1800)
+        1832.floor(-3).should eql(1000)
+        -1832.floor(-1).should eql(-1840)
+        -1832.floor(-2).should eql(-1900)
+        -1832.floor(-3).should eql(-2000)
+      end
+    end
+  end
 end

--- a/core/integer/truncate_spec.rb
+++ b/core/integer/truncate_spec.rb
@@ -3,4 +3,27 @@ require File.expand_path('../shared/to_i', __FILE__)
 
 describe "Integer#truncate" do
   it_behaves_like(:integer_to_i, :truncate)
+
+  ruby_version_is "2.4" do
+    context "precision argument specified as part of the truncate method is zero or positive" do
+      it "returns self as integer or float" do
+        1.truncate.should eql(1)
+        1.truncate(0).should eql(1)
+        1.truncate(2).should eql(1.0)
+        1832.truncate(3).should eql(1832.0)
+        -1832.truncate(3).should eql(-1832.0)
+      end
+    end
+
+    context "precision argument specified as part of the truncate method is negative" do
+      it "returns an integer with at least precision.abs trailing zeros" do
+        1832.truncate(-1).should eql(1830)
+        1832.truncate(-2).should eql(1800)
+        1832.truncate(-3).should eql(1000)
+        -1832.truncate(-1).should eql(-1830)
+        -1832.truncate(-2).should eql(-1800)
+        -1832.truncate(-3).should eql(-1000)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is currently Work in Progress(WIP). 

**Update**: This is now complete based on the requirement specified as part of [this issue](https://github.com/ruby/spec/issues/473).