### PR TITLE
Adding Pathname#empty? specs

### DIFF
--- a/library/pathname/empty_spec.rb
+++ b/library/pathname/empty_spec.rb
@@ -1,0 +1,28 @@
+require File.expand_path('../../spec_helper', __dir__)
+require 'pathname'
+
+describe "Pathname#empty?" do
+  ruby_version_is "2.4" do
+    it 'returns true when file is not empty' do
+      (Pathname.new(__FILE__).empty?).should be_false
+    end
+
+    it 'returns false when the directory is not empty' do
+      (Pathname.new(__dir__).empty?).should be_false
+    end
+
+    it 'return true when file is empty' do
+      file = tmp('new_file_path_name.txt')
+      touch(file)
+      (Pathname.new(file).empty?).should be_true
+      File.delete(file)
+    end
+
+    it 'returns true when directory is empty' do
+      dir = File.join(tmp("new_directory_path_name"))
+      Dir.mkdir(dir)
+      (Pathname.new(dir).empty?).should be_true
+      Dir.rmdir(dir)
+    end
+  end
+end

--- a/library/pathname/empty_spec.rb
+++ b/library/pathname/empty_spec.rb
@@ -1,28 +1,34 @@
 require File.expand_path('../../spec_helper', __dir__)
 require 'pathname'
 
-describe "Pathname#empty?" do
-  ruby_version_is "2.4" do
+ruby_version_is '2.4' do
+  describe 'Pathname#empty?' do
+    before :all  do
+      @file = tmp 'new_file_path_name.txt'
+      touch @file
+      @dir = tmp 'new_directory_path_name'
+      Dir.mkdir @dir
+    end
+
+    after :all do
+      rm_r @file
+      rm_r @dir
+    end
+
     it 'returns true when file is not empty' do
-      (Pathname.new(__FILE__).empty?).should be_false
+      Pathname.new(__FILE__).empty?.should be_false
     end
 
     it 'returns false when the directory is not empty' do
-      (Pathname.new(__dir__).empty?).should be_false
+      Pathname.new(__dir__).empty?.should be_false
     end
 
     it 'return true when file is empty' do
-      file = tmp('new_file_path_name.txt')
-      touch(file)
-      (Pathname.new(file).empty?).should be_true
-      File.delete(file)
+      Pathname.new(@file).empty?.should be_true
     end
 
     it 'returns true when directory is empty' do
-      dir = File.join(tmp("new_directory_path_name"))
-      Dir.mkdir(dir)
-      (Pathname.new(dir).empty?).should be_true
-      Dir.rmdir(dir)
+      Pathname.new(@dir).empty?.should be_true
     end
   end
 end


### PR DESCRIPTION
added on MRI 2.4 as the [Feature #12596](https://bugs.ruby-lang.org/issues/12596) - Add Pathname#empty? to be consistent with Dir.empty? and File.empty?

Part of #473 

[feature_12345]: https://bugs.ruby-lang.org/issues/12596