### PR TITLE
Add spec for CGI::Cookie.parse about handling , separator

### DIFF
--- a/library/cgi/cookie/parse_spec.rb
+++ b/library/cgi/cookie/parse_spec.rb
@@ -10,6 +10,27 @@ describe "CGI::Cookie.parse" do
     CGI::Cookie.parse("first cookie=one&two;second cookie=three&four").should == expected
   end
 
+  ruby_version_is ""..."2.4" do
+    it "uses , for cookie separators" do
+      expected = {
+        "first cookie" => ["one", "two"],
+        "second cookie" => ["three", "four"],
+        "third_cookie" => ["five", "six"]
+      }
+      CGI::Cookie.parse("first cookie=one&two;second cookie=three&four,third_cookie=five&six").should == expected
+    end
+  end
+
+  ruby_version_is "2.4" do
+    it "does not use , for cookie separators" do
+      expected = {
+        "first cookie" => ["one", "two"],
+        "second cookie" => ["three", "four,third_cookie=five", "six"]
+      }
+      CGI::Cookie.parse("first cookie=one&two;second cookie=three&four,third_cookie=five&six").should == expected
+    end
+  end
+
   it "unescapes the Cookie values" do
     cookie = "test-cookie=+%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F0123456789%3A%3B%3C%3D%3E%3F%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D%7E"
     expected = { "test-cookie" => [ " !\"\#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~" ] }


### PR DESCRIPTION
Also added a spec for previous Ruby versions to be complete.

(#473)