### PR TITLE
Adds Numeric#finite? / Numeric#infinite? and Complex impl

### DIFF
--- a/core/complex/finite_spec.rb
+++ b/core/complex/finite_spec.rb
@@ -1,0 +1,24 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+ruby_version_is "2.4" do
+  describe "Complex#finite?" do
+    it "returns true if magnitude is finite" do
+      (1+1i).finite?.should == true
+    end
+
+    it "returns false for positive infinity" do
+      value = Complex(1, Float::INFINITY)
+      value.finite?.should == false
+    end
+
+    it "returns false for negative infinity" do
+      value = -Complex(1, Float::INFINITY)
+      value.finite?.should == false
+    end
+
+    it "returns true for NaN" do
+      value = Complex(Float::NAN, Float::NAN)
+      value.finite?.should == true
+    end
+  end
+end

--- a/core/complex/finite_spec.rb
+++ b/core/complex/finite_spec.rb
@@ -7,11 +7,21 @@ ruby_version_is "2.4" do
     end
 
     it "returns false for positive infinity" do
+      value = Complex(Float::INFINITY, 42)
+      value.finite?.should == false
+    end
+
+    it "returns false for positive complex with infinite imaginary" do
       value = Complex(1, Float::INFINITY)
       value.finite?.should == false
     end
 
     it "returns false for negative infinity" do
+      value = -Complex(Float::INFINITY, 42)
+      value.finite?.should == false
+    end
+
+    it "returns false for negative complex with infinite imaginary" do
       value = -Complex(1, Float::INFINITY)
       value.finite?.should == false
     end

--- a/core/complex/infinite_spec.rb
+++ b/core/complex/infinite_spec.rb
@@ -1,0 +1,24 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+ruby_version_is "2.4" do
+  describe "Complex#infinite?" do
+    it "returns nil if magnitude is finite" do
+      (1+1i).infinite?.should == nil
+    end
+
+    it "returns 1 for positive infinity" do
+      value = Complex(1, Float::INFINITY).infinite?
+      value.should == 1
+    end
+
+    it "returns -1 for negative infinity" do
+      value = -Complex(1, Float::INFINITY).infinite?
+      value.should == -1
+    end
+
+    it "returns nil for NaN" do
+      value = Complex(0, Float::NAN).infinite?
+      value.should == nil
+    end
+  end
+end

--- a/core/complex/infinite_spec.rb
+++ b/core/complex/infinite_spec.rb
@@ -7,11 +7,21 @@ ruby_version_is "2.4" do
     end
 
     it "returns 1 for positive infinity" do
+      value = Complex(Float::INFINITY, 42).infinite?
+      value.should == 1
+    end
+
+    it "returns 1 for positive complex with infinite imaginary" do
       value = Complex(1, Float::INFINITY).infinite?
       value.should == 1
     end
 
     it "returns -1 for negative infinity" do
+      value = -Complex(Float::INFINITY, 42).infinite?
+      value.should == -1
+    end
+
+    it "returns -1 for negative complex with infinite imaginary" do
       value = -Complex(1, Float::INFINITY).infinite?
       value.should == -1
     end

--- a/core/numeric/finite_spec.rb
+++ b/core/numeric/finite_spec.rb
@@ -1,0 +1,10 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+ruby_version_is "2.4" do
+  describe "Numeric#finite?" do
+    it "returns true by default" do
+      o = mock_numeric("finite")
+      o.finite?.should be_true
+    end
+  end
+end

--- a/core/numeric/infinite_spec.rb
+++ b/core/numeric/infinite_spec.rb
@@ -1,0 +1,10 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+ruby_version_is "2.4" do
+  describe "Numeric#infinite?" do
+    it "returns nil by default" do
+      o = mock_numeric("infinite")
+      o.infinite?.should == nil
+    end
+  end
+end


### PR DESCRIPTION
Part of #473 

Feature [#12039](https://bugs.ruby-lang.org/issues/12039), Numeric#finite? and Numeric#infinite?

This covers both the base class `Numeric` and subclass `Complex` with `finite?` and `infinite?` as the methods were implemented in both classes as part of [#12039](https://bugs.ruby-lang.org/issues/12039).

There are some oddities with mspec's == matcher when comparing against Complex negative infinity, which is why Complex#infinite? and Complex#finite?  have different test structures.  I kept the structure consistent within the tests of each file, however.