### PR TITLE
Adds String#unpack1

### DIFF
--- a/core/string/unpack/1_spec.rb
+++ b/core/string/unpack/1_spec.rb
@@ -1,0 +1,12 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+
+ruby_version_is "2.4" do
+  describe "String#unpack1" do
+    it "returns the first value of #unpack" do
+      "ABCD".unpack1('x3C').should == "ABCD".unpack('x3C')[0]
+      "\u{3042 3044 3046}".unpack1("U*").should == 0x3042
+      "aG9nZWZ1Z2E=".unpack1("m").should == "hogefuga"
+      "A".unpack1("B*").should == "01000001"
+    end
+  end
+end

--- a/core/string/unpack1_spec.rb
+++ b/core/string/unpack1_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../../../spec_helper', __FILE__)
+require File.expand_path('../../../spec_helper', __FILE__)
 
 ruby_version_is "2.4" do
   describe "String#unpack1" do


### PR DESCRIPTION
Part of #473 

Adds spec for Feature [#12752](https://bugs.ruby-lang.org/issues/12752).

String#unpack1 is pretty straightforward.  Return the first matching value of String#unpack.