### PR TITLE
DateTime#to_time and Time#to_time

### DIFF
--- a/library/datetime/to_time_spec.rb
+++ b/library/datetime/to_time_spec.rb
@@ -6,18 +6,20 @@ describe "DateTime#to_time" do
     DateTime.now.to_time.should be_kind_of(Time)
   end
 
-  it "preserves the same time regardless of local time or zone" do
-    date = DateTime.new(2012, 12, 24, 12, 23, 00, '+03:00')
-    time = date.to_time
+  ruby_version_is "2.4" do
+    it "preserves the same time regardless of local time or zone" do
+      date = DateTime.new(2012, 12, 24, 12, 23, 00, '+03:00')
+      time = date.to_time
 
-    with_timezone("Pactific/Pago_Pago", -11) do
-      time.utc_offset.should == 3 * 3600
-      time.year.should == date.year
-      time.mon.should == date.mon
-      time.day.should == date.day
-      time.hour.should == date.hour
-      time.min.should == date.min
-      time.sec.should == date.sec
+      with_timezone("Pactific/Pago_Pago", -11) do
+        time.utc_offset.should == 3 * 3600
+        time.year.should == date.year
+        time.mon.should == date.mon
+        time.day.should == date.day
+        time.hour.should == date.hour
+        time.min.should == date.min
+        time.sec.should == date.sec
+      end
     end
   end
 end

--- a/library/datetime/to_time_spec.rb
+++ b/library/datetime/to_time_spec.rb
@@ -1,6 +1,24 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require 'date'
 
-describe "DateTime#to_time" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is "2.4" do
+  describe "DateTime#to_time" do
+    it "yields a new Time object" do
+      DateTime.now.to_time.should be_kind_of(Time)
+    end
+
+    it "preserves the same time regardless of local time or zone" do
+      with_timezone("Pactific/Pago_Pago", -11) do
+        date = DateTime.new(2012, 12, 24, 12, 23, 00, '+03:00')
+        time = date.to_time
+
+        time.year.should == date.year
+        time.mon.should == date.mon
+        time.day.should == date.day
+        time.hour.should == date.hour
+        time.min.should == date.min
+        time.sec.should == date.sec
+      end
+    end
+  end
 end

--- a/library/datetime/to_time_spec.rb
+++ b/library/datetime/to_time_spec.rb
@@ -9,9 +9,10 @@ describe "DateTime#to_time" do
   ruby_version_is "2.4" do
     it "preserves the same time regardless of local time or zone" do
       date = DateTime.new(2012, 12, 24, 12, 23, 00, '+03:00')
-      time = date.to_time
 
       with_timezone("Pactific/Pago_Pago", -11) do
+        time = date.to_time
+
         time.utc_offset.should == 3 * 3600
         time.year.should == date.year
         time.mon.should == date.mon

--- a/library/datetime/to_time_spec.rb
+++ b/library/datetime/to_time_spec.rb
@@ -1,25 +1,23 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require 'date'
 
-ruby_version_is "2.4" do
-  describe "DateTime#to_time" do
-    it "yields a new Time object" do
-      DateTime.now.to_time.should be_kind_of(Time)
-    end
+describe "DateTime#to_time" do
+  it "yields a new Time object" do
+    DateTime.now.to_time.should be_kind_of(Time)
+  end
 
-    it "preserves the same time regardless of local time or zone" do
-      with_timezone("Pactific/Pago_Pago", -11) do
-        date = DateTime.new(2012, 12, 24, 12, 23, 00, '+03:00')
-        time = date.to_time
+  it "preserves the same time regardless of local time or zone" do
+    date = DateTime.new(2012, 12, 24, 12, 23, 00, '+03:00')
+    time = date.to_time
 
-        time.strftime("%z").should == date.strftime("%z")
-        time.year.should == date.year
-        time.mon.should == date.mon
-        time.day.should == date.day
-        time.hour.should == date.hour
-        time.min.should == date.min
-        time.sec.should == date.sec
-      end
+    with_timezone("Pactific/Pago_Pago", -11) do
+      time.utc_offset.should == 3 * 3600
+      time.year.should == date.year
+      time.mon.should == date.mon
+      time.day.should == date.day
+      time.hour.should == date.hour
+      time.min.should == date.min
+      time.sec.should == date.sec
     end
   end
 end

--- a/library/datetime/to_time_spec.rb
+++ b/library/datetime/to_time_spec.rb
@@ -12,6 +12,7 @@ ruby_version_is "2.4" do
         date = DateTime.new(2012, 12, 24, 12, 23, 00, '+03:00')
         time = date.to_time
 
+        time.strftime("%z").should == date.strftime("%z")
         time.year.should == date.year
         time.mon.should == date.mon
         time.day.should == date.day

--- a/library/time/to_time_spec.rb
+++ b/library/time/to_time_spec.rb
@@ -4,8 +4,9 @@ require 'time'
 ruby_version_is "2.4" do
   describe "Time#to_time" do
     it "returns itself in the same timezone" do
+      time = Time.new(2012, 2, 21, 10, 11, 12)
+
       with_timezone("America/Regina") do
-        time = Time.new(2012, 2, 21, 10, 11, 12)
         time.to_time.should == time
       end
 

--- a/library/time/to_time_spec.rb
+++ b/library/time/to_time_spec.rb
@@ -1,0 +1,16 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+require 'time'
+
+ruby_version_is "2.4" do
+  describe "Time#to_time" do
+    it "returns itself in the same timezone" do
+      with_timezone("America/Regina") do
+        time = Time.new(2012, 2, 21, 10, 11, 12)
+        time.to_time.should == time
+      end
+
+      time2 = Time.utc(2012, 2, 21, 10, 11, 12)
+      time2.to_time.should == time2
+    end
+  end
+end


### PR DESCRIPTION
Part of #473 

Specs for Features [#12271](https://bugs.ruby-lang.org/issues/12271) and [#12189](https://bugs.ruby-lang.org/issues/12189).

DateTime#to_time creates a Time object with the same time at the same timezone as the DateTime.  Time#to_time just returns itself.