### PR TITLE
Add specs for `half` option in `Rational#round`

### DIFF
--- a/shared/rational/round.rb
+++ b/shared/rational/round.rb
@@ -71,7 +71,7 @@ describe :rational_round, shared: true do
 
   ruby_version_is "2.4" do
     describe "with half option" do
-      it "returns an Integer" do
+      it "returns an Integer when precision is not passed" do
         Rational(10, 4).round(half: :up).should == 3
         Rational(10, 4).round(half: :down).should == 2
         Rational(10, 4).round(half: :even).should == 2
@@ -80,7 +80,7 @@ describe :rational_round, shared: true do
         Rational(-10, 4).round(half: :even).should == -2
       end
 
-      it "returns a Rational" do
+      it "returns a Rational when the precision is greater than 0" do
         Rational(25, 100).round(1, half: :up).should == Rational(3, 10)
         Rational(25, 100).round(1, half: :down).should == Rational(1, 5)
         Rational(25, 100).round(1, half: :even).should == Rational(1, 5)

--- a/shared/rational/round.rb
+++ b/shared/rational/round.rb
@@ -68,4 +68,29 @@ describe :rational_round, shared: true do
       Rational(3, 2).round(2_097_171).should == Rational(3, 2)
     end
   end
+
+  ruby_version_is "2.4" do
+    describe "with half option" do
+      it "returns an Integer" do
+        Rational(10, 4).round(half: :up).should == 3
+        Rational(10, 4).round(half: :down).should == 2
+        Rational(10, 4).round(half: :even).should == 2
+        Rational(-10, 4).round(half: :up).should == -3
+        Rational(-10, 4).round(half: :down).should == -2
+        Rational(-10, 4).round(half: :even).should == -2
+      end
+
+      it "returns a Rational" do
+        Rational(25, 100).round(1, half: :up).should == Rational(3, 10)
+        Rational(25, 100).round(1, half: :down).should == Rational(1, 5)
+        Rational(25, 100).round(1, half: :even).should == Rational(1, 5)
+        Rational(35, 100).round(1, half: :up).should == Rational(2, 5)
+        Rational(35, 100).round(1, half: :down).should == Rational(3, 10)
+        Rational(35, 100).round(1, half: :even).should == Rational(2, 5)
+        Rational(-25, 100).round(1, half: :up).should == Rational(-3, 10)
+        Rational(-25, 100).round(1, half: :down).should == Rational(-1, 5)
+        Rational(-25, 100).round(1, half: :even).should == Rational(-1, 5)
+      end
+    end
+  end
 end


### PR DESCRIPTION
In Ruby 2.4 the `round` method in `Rational` accepts a keyword argument
(`half`). 
The specs values were based on [rational.c](https://github.com/ruby/ruby/blob/6b05153a3a75b74b64553d6a46f501d9ee0f0376/rational.c#L1577-L1585) and [float/round_spec.rb](https://github.com/ruby/spec/blob/80119090e7cd9071cb52905f13d52ca56b5a340d/core/float/round_spec.rb#L88-L98)

See more on issue: https://github.com/ruby/spec/issues/473