### PR TITLE
Add missing ".should" and fix subsequent failure

### DIFF
--- a/core/enumerator/lazy/force_spec.rb
+++ b/core/enumerator/lazy/force_spec.rb
@@ -24,7 +24,7 @@ describe "Enumerator::Lazy#force" do
       (0..Float::INFINITY).lazy.map(&:succ).take(2).force.should == [1, 2]
 
       @eventsmixed.take(1).map(&:succ).force.should == [1]
-      ScratchPad.recorded == [:after_yields]
+      ScratchPad.recorded.should == [:before_yield]
     end
   end
 end


### PR DESCRIPTION
No "should" meant nothing was being tested
[:after_yields] was typo for [:after_yield], but should have been [:before_yield] anyway