### PR TITLE
Character manipulation coverage for symbol ruby 2.4

### DIFF
--- a/core/symbol/capitalize_spec.rb
+++ b/core/symbol/capitalize_spec.rb
@@ -23,8 +23,8 @@ describe "Symbol#capitalize" do
 
   ruby_version_is '2.4' do
     it "capitalizes the first character if it is Unicode" do
-      "äöü".capitalize.should == :"Äöü"
-      "aou".capitalize.should == :"Aou"
+      :"äöü".capitalize.should == :"Äöü"
+      :"aou".capitalize.should == :"Aou"
     end
   end
 

--- a/core/symbol/capitalize_spec.rb
+++ b/core/symbol/capitalize_spec.rb
@@ -21,6 +21,13 @@ describe "Symbol#capitalize" do
     end
   end
 
+  ruby_version_is '2.4' do
+    it "capitalizes the first character regardless of if it is Unicode"
+      "äöü".to_sym.capitalize.should == :"Äöü"
+      "aou".to_sym.capitalize.should == :"Aou"
+    end
+  end
+
   it "converts subsequent uppercase ASCII characters to their lowercase equivalents" do
     :lOWER.capitalize.should == :Lower
   end

--- a/core/symbol/capitalize_spec.rb
+++ b/core/symbol/capitalize_spec.rb
@@ -22,9 +22,9 @@ describe "Symbol#capitalize" do
   end
 
   ruby_version_is '2.4' do
-    it "capitalizes the first character regardless of if it is Unicode" do
-      "äöü".to_sym.capitalize.should == :"Äöü"
-      "aou".to_sym.capitalize.should == :"Aou"
+    it "capitalizes the first character if it is Unicode" do
+      "äöü".capitalize.should == :"Äöü"
+      "aou".capitalize.should == :"Aou"
     end
   end
 

--- a/core/symbol/capitalize_spec.rb
+++ b/core/symbol/capitalize_spec.rb
@@ -22,7 +22,7 @@ describe "Symbol#capitalize" do
   end
 
   ruby_version_is '2.4' do
-    it "capitalizes the first character regardless of if it is Unicode"
+    it "capitalizes the first character regardless of if it is Unicode" do
       "äöü".to_sym.capitalize.should == :"Äöü"
       "aou".to_sym.capitalize.should == :"Aou"
     end

--- a/core/symbol/downcase_spec.rb
+++ b/core/symbol/downcase_spec.rb
@@ -21,7 +21,7 @@ describe "Symbol#downcase" do
   end
 
   ruby_version_is '2.4' do
-    it "uncapitalizes all characters regardless of if it is Unicode"
+    it "uncapitalizes all characters regardless of if it is Unicode" do
       "ÄÖÜ".to_sym.downcase.should == :"äöü"
       "AOU".to_sym.downcase.should == :"aou"
     end

--- a/core/symbol/downcase_spec.rb
+++ b/core/symbol/downcase_spec.rb
@@ -21,7 +21,7 @@ describe "Symbol#downcase" do
   end
 
   ruby_version_is '2.4' do
-    it "uncapitalizes all characters regardless of if it is Unicode" do
+    it "uncapitalizes all Unicode characters" do
       "ÄÖÜ".to_sym.downcase.should == :"äöü"
       "AOU".to_sym.downcase.should == :"aou"
     end

--- a/core/symbol/downcase_spec.rb
+++ b/core/symbol/downcase_spec.rb
@@ -20,6 +20,13 @@ describe "Symbol#downcase" do
     end
   end
 
+  ruby_version_is '2.4' do
+    it "uncapitalizes all characters regardless of if it is Unicode"
+      "ÄÖÜ".to_sym.downcase.should == :"äöü"
+      "AOU".to_sym.downcase.should == :"aou"
+    end
+  end
+
   it "leaves non-alphabetic ASCII characters as they were" do
     "Glark?!?".to_sym.downcase.should == :"glark?!?"
   end

--- a/core/symbol/swapcase_spec.rb
+++ b/core/symbol/swapcase_spec.rb
@@ -28,6 +28,13 @@ describe "Symbol#swapcase" do
     end
   end
 
+  ruby_version_is '2.4' do
+    it "swaps the case regardless of if it is Unicode"
+      "äÖü".to_sym.swapcase.should == :"ÄöÜ"
+      "aOu".to_sym.swapcase.should == :"AoU"
+    end
+  end
+
   it "leaves non-alphabetic ASCII characters as they were" do
     "Glark?!?".to_sym.swapcase.should == :"gLARK?!?"
   end

--- a/core/symbol/swapcase_spec.rb
+++ b/core/symbol/swapcase_spec.rb
@@ -29,7 +29,7 @@ describe "Symbol#swapcase" do
   end
 
   ruby_version_is '2.4' do
-    it "swaps the case regardless of if it is Unicode" do
+    it "swaps the case for Unicode characters" do
       "äÖü".to_sym.swapcase.should == :"ÄöÜ"
       "aOu".to_sym.swapcase.should == :"AoU"
     end

--- a/core/symbol/swapcase_spec.rb
+++ b/core/symbol/swapcase_spec.rb
@@ -29,7 +29,7 @@ describe "Symbol#swapcase" do
   end
 
   ruby_version_is '2.4' do
-    it "swaps the case regardless of if it is Unicode"
+    it "swaps the case regardless of if it is Unicode" do
       "äÖü".to_sym.swapcase.should == :"ÄöÜ"
       "aOu".to_sym.swapcase.should == :"AoU"
     end

--- a/core/symbol/upcase_spec.rb
+++ b/core/symbol/upcase_spec.rb
@@ -17,7 +17,7 @@ describe "Symbol#upcase" do
   end
 
   ruby_version_is '2.4' do
-    it "capitalizes all characters regardless of if it is Unicode"
+    it "capitalizes all characters regardless of if it is Unicode" do
       "äöü".to_sym.upcase.should == :"ÄÖÜ"
       "aou".to_sym.upcase.should == :"AOU"
     end

--- a/core/symbol/upcase_spec.rb
+++ b/core/symbol/upcase_spec.rb
@@ -16,6 +16,13 @@ describe "Symbol#upcase" do
     end
   end
 
+  ruby_version_is '2.4' do
+    it "capitalizes all characters regardless of if it is Unicode"
+      "äöü".to_sym.upcase.should == :"ÄÖÜ"
+      "aou".to_sym.upcase.should == :"AOU"
+    end
+  end
+
   it "leaves non-alphabetic ASCII characters as they were" do
     "Glark?!?".to_sym.upcase.should == :"GLARK?!?"
   end

--- a/core/symbol/upcase_spec.rb
+++ b/core/symbol/upcase_spec.rb
@@ -17,7 +17,7 @@ describe "Symbol#upcase" do
   end
 
   ruby_version_is '2.4' do
-    it "capitalizes all characters regardless of if it is Unicode" do
+    it "capitalizes all Unicode characters" do
       "äöü".to_sym.upcase.should == :"ÄÖÜ"
       "aou".to_sym.upcase.should == :"AOU"
     end


### PR DESCRIPTION
Symbol#upcase, Symbol#downcase, Symbol#capitalize, and Symbol#swapcase now
work for all of Unicode. #473 