### PR TITLE
Add spec for multiple assignment conditional

### DIFF
--- a/language/if_spec.rb
+++ b/language/if_spec.rb
@@ -4,16 +4,22 @@ describe "The if expression" do
   ruby_version_is '2.4' do
     it 'allows multiple assignments in conditional expression with non-nil values' do
       c = []
-      if (a,b = [1,2])
-        c << 123
+      begin
+        if (a,b = [1,2])
+          c << 123
+        end
+      rescue SyntaxError
       end
       c.should == [123]
     end
 
     it 'allows multiple assignments in conditional with nil value' do
       c = []
-      if (a,b = nil)
-        c << 123
+      begin
+        if (a,b = nil)
+          c << 123
+        end
+      rescue SyntaxError
       end
       c.should_not == [123]
     end

--- a/language/if_spec.rb
+++ b/language/if_spec.rb
@@ -1,6 +1,24 @@
 require File.expand_path('../../spec_helper', __FILE__)
 
 describe "The if expression" do
+  ruby_version_is '2.4' do
+    it 'allows multiple assignments in conditional expression with non-nil values' do
+      c = []
+      if (a,b = [1,2])
+        c << 123
+      end
+      c.should == [123]
+    end
+
+    it 'allows multiple assignments in conditional with nil value' do
+      c = []
+      if (a,b = nil)
+        c << 123
+      end
+      c.should_not == [123]
+    end
+  end
+
   it "evaluates body if expression is true" do
     a = []
     if true

--- a/language/if_spec.rb
+++ b/language/if_spec.rb
@@ -2,26 +2,21 @@ require File.expand_path('../../spec_helper', __FILE__)
 
 describe "The if expression" do
   ruby_version_is '2.4' do
-    it 'allows multiple assignments in conditional expression with non-nil values' do
-      c = []
-      begin
-        if (a,b = [1,2])
-          c << 123
-        end
-      rescue SyntaxError
-      end
-      c.should == [123]
-    end
+    describe "multiple assignments in conditional expression" do
+      before(:each) { ScratchPad.record([]) }
+      after(:each)  { ScratchPad.clear }
 
-    it 'allows multiple assignments in conditional with nil value' do
-      c = []
-      begin
-        if (a,b = nil)
-          c << 123
-        end
-      rescue SyntaxError
+      it 'with non-nil values' do
+        collector = proc { |i| ScratchPad << i }
+        eval "if (a, b = [1, 2]); collector[123]; end"
+        ScratchPad.recorded.should == [123]
       end
-      c.should_not == [123]
+
+      it 'with nil values' do
+        collector = proc { |i| ScratchPad << i }
+        eval "if (a, b = nil); collector[123]; end"
+        ScratchPad.recorded.should == []
+      end
     end
   end
 

--- a/language/if_spec.rb
+++ b/language/if_spec.rb
@@ -2,19 +2,17 @@ require File.expand_path('../../spec_helper', __FILE__)
 
 describe "The if expression" do
   ruby_version_is '2.4' do
-    describe "multiple assignments in conditional expression" do
+    describe "accepts multiple assignments in conditional expression" do
       before(:each) { ScratchPad.record([]) }
       after(:each)  { ScratchPad.clear }
 
       it 'with non-nil values' do
-        collector = proc { |i| ScratchPad << i }
-        eval "if (a, b = [1, 2]); collector[123]; end"
+        eval "if (a, b = [1, 2]); ScratchPad << 123; end"
         ScratchPad.recorded.should == [123]
       end
 
       it 'with nil values' do
-        collector = proc { |i| ScratchPad << i }
-        eval "if (a, b = nil); collector[123]; end"
+        eval "if (a, b = nil); ScratchPad << 123; end"
         ScratchPad.recorded.should == []
       end
     end


### PR DESCRIPTION
- add specs for multiple assignments within conditional
- for ruby 2.4 this will no longer throw an error, only a warning

relates to: #473 