### PR TITLE
Add spec for `rescue` in method arguments

### DIFF
--- a/language/rescue_spec.rb
+++ b/language/rescue_spec.rb
@@ -290,4 +290,11 @@ describe "The rescue keyword" do
       :expected
     end.should == :expected
   end
+
+  ruby_version_is "2.4" do
+    it "allows 'rescue' in method arguments" do
+      two = eval '1.+ (raise("Error") rescue 1)'
+      two.should == 2
+    end
+  end
 end


### PR DESCRIPTION
This is a part of #473.

> Rescue modifier now applicable to method arguments. [Feature #12686](https://bugs.ruby-lang.org/issues/12686)

It simply ensure that the new syntax works when evaluated.

Would you prefer something that ensure more specific such as: _doesn't raise any `SyntaxError`_?