### PR TITLE
Thread.report_on_exception and Thread#report_on_exception

### DIFF
--- a/core/mutex/lock_spec.rb
+++ b/core/mutex/lock_spec.rb
@@ -33,14 +33,9 @@ describe "Mutex#lock" do
   # related to this ML thread.
   it "raises a ThreadError when used recursively" do
     m = Mutex.new
-
-    th = Thread.new do
+    m.lock
+    -> {
       m.lock
-      m.lock
-    end
-
-    lambda do
-      th.join
-    end.should raise_error(ThreadError)
+    }.should raise_error(ThreadError)
   end
 end

--- a/core/thread/element_set_spec.rb
+++ b/core/thread/element_set_spec.rb
@@ -9,12 +9,12 @@ describe "Thread#[]=" do
   it "raises a RuntimeError if the thread is frozen" do
     running = false
     t = Thread.new do
-      Thread.pass until running
       t.freeze
-      t[:foo] = "bar"
+      -> {
+        t[:foo] = "bar"
+      }.should raise_error(RuntimeError, /frozen/)
     end
-    running = true
-    lambda { t.join }.should raise_error(RuntimeError)
+    t.join
   end
 
   it "raises exceptions on the wrong type of keys" do

--- a/core/thread/fixtures/classes.rb
+++ b/core/thread/fixtures/classes.rb
@@ -120,7 +120,10 @@ module ThreadSpecs
   end
 
   def self.status_of_thread_with_uncaught_exception
-    t = Thread.new { raise "error" }
+    t = Thread.new {
+      Thread.current.report_on_exception = false
+      raise "error"
+    }
     begin
       t.join
     rescue RuntimeError
@@ -159,6 +162,7 @@ module ThreadSpecs
 
   def self.dying_thread_ensures(kill_method_name=:kill)
     Thread.new do
+      Thread.current.report_on_exception = false
       begin
         Thread.current.send(kill_method_name)
       ensure
@@ -169,6 +173,7 @@ module ThreadSpecs
 
   def self.dying_thread_with_outer_ensure(kill_method_name=:kill)
     Thread.new do
+      Thread.current.report_on_exception = false
       begin
         begin
           Thread.current.send(kill_method_name)

--- a/core/thread/join_spec.rb
+++ b/core/thread/join_spec.rb
@@ -46,7 +46,10 @@ describe "Thread#join" do
   end
 
   it "raises any exceptions encountered in the thread body" do
-    t = Thread.new { raise NotImplementedError.new("Just kidding") }
+    t = Thread.new {
+      Thread.current.report_on_exception = false
+      raise NotImplementedError.new("Just kidding")
+    }
     lambda { t.join }.should raise_error(NotImplementedError)
   end
 

--- a/core/thread/raise_spec.rb
+++ b/core/thread/raise_spec.rb
@@ -51,6 +51,7 @@ describe "Thread#raise on a sleeping thread" do
 
   it "is captured and raised by Thread#value" do
     t = Thread.new do
+      Thread.current.report_on_exception = false
       sleep
     end
 
@@ -62,6 +63,7 @@ describe "Thread#raise on a sleeping thread" do
 
   it "raises a RuntimeError when called with no arguments inside rescue" do
     t = Thread.new do
+      Thread.current.report_on_exception = false
       begin
         1/0
       rescue ZeroDivisionError
@@ -113,6 +115,7 @@ describe "Thread#raise on a running thread" do
 
   it "can go unhandled" do
     t = Thread.new do
+      Thread.current.report_on_exception = false
       loop { Thread.pass }
     end
 
@@ -123,6 +126,7 @@ describe "Thread#raise on a running thread" do
   it "raises the given argument even when there is an active exception" do
     raised = false
     t = Thread.new do
+      Thread.current.report_on_exception = false
       begin
         1/0
       rescue ZeroDivisionError
@@ -142,6 +146,7 @@ describe "Thread#raise on a running thread" do
   it "raises a RuntimeError when called with no arguments inside rescue" do
     raised = false
     t = Thread.new do
+      Thread.current.report_on_exception = false
       begin
         1/0
       rescue ZeroDivisionError
@@ -164,6 +169,7 @@ describe "Thread#raise on same thread" do
 
   it "raises a RuntimeError when called with no arguments inside rescue" do
     t = Thread.new do
+      Thread.current.report_on_exception = false
       begin
         1/0
       rescue ZeroDivisionError

--- a/core/thread/report_on_exception_spec.rb
+++ b/core/thread/report_on_exception_spec.rb
@@ -1,0 +1,102 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+ruby_version_is "2.4" do
+  describe "Thread.report_on_exception" do
+    it "defaults to false" do
+      Thread.report_on_exception.should == false
+    end
+  end
+
+  describe "Thread.report_on_exception=" do
+    before :each do
+      @report_on_exception = Thread.report_on_exception
+    end
+
+    after :each do
+      Thread.report_on_exception = @report_on_exception
+    end
+
+    it "changes the default value for new threads" do
+      Thread.report_on_exception = true
+      Thread.report_on_exception.should == true
+      t = Thread.new {}
+      t.join
+      t.report_on_exception.should == true
+    end
+  end
+
+  describe "Thread#report_on_exception" do
+    it "returns whether the Thread will print a backtrace if it exits with an exception" do
+      t = Thread.new { Thread.current.report_on_exception = true }
+      t.join
+      t.report_on_exception.should == true
+
+      t = Thread.new { Thread.current.report_on_exception = false }
+      t.join
+      t.report_on_exception.should == false
+    end
+  end
+
+  describe "Thread#report_on_exception=" do
+    describe "when set to true" do
+      it "prints a backtrace on $stderr if it terminates with an exception" do
+        t = nil
+        -> {
+          t = Thread.new {
+            Thread.current.report_on_exception = true
+            raise RuntimeError, "Thread#report_on_exception specs"
+          }
+          Thread.pass while t.alive?
+        }.should output("", /Thread.+terminated with exception.+Thread#report_on_exception specs/m)
+
+        -> {
+          t.join
+        }.should raise_error(RuntimeError, "Thread#report_on_exception specs")
+      end
+    end
+
+    describe "when set to false" do
+      it "lets the thread terminates silently with an exception" do
+        t = nil
+        -> {
+          t = Thread.new {
+            Thread.current.report_on_exception = false
+            raise RuntimeError, "Thread#report_on_exception specs"
+          }
+          Thread.pass while t.alive?
+        }.should output("", "")
+
+        -> {
+          t.join
+        }.should raise_error(RuntimeError, "Thread#report_on_exception specs")
+      end
+    end
+
+    ruby_bug "#13163", "2.4"..."2.5" do
+      describe "when used in conjunction with Thread#abort_on_exception" do
+        it "first reports then send the exception back to the main Thread" do
+          t = nil
+          mutex = Mutex.new
+          mutex.lock
+          -> {
+            t = Thread.new {
+              Thread.current.abort_on_exception = true
+              Thread.current.report_on_exception = true
+              mutex.lock
+              mutex.unlock
+              raise RuntimeError, "Thread#report_on_exception specs"
+            }
+
+            -> {
+              mutex.sleep(5)
+            }.should raise_error(RuntimeError, "Thread#report_on_exception specs")
+          }.should output("", /Thread.+terminated with exception.+Thread#report_on_exception specs/m)
+
+          -> {
+            t.join
+          }.should raise_error(RuntimeError, "Thread#report_on_exception specs")
+        end
+      end
+    end
+  end
+end

--- a/core/thread/report_on_exception_spec.rb
+++ b/core/thread/report_on_exception_spec.rb
@@ -3,7 +3,7 @@ require File.expand_path('../../../spec_helper', __FILE__)
 ruby_version_is "2.4" do
   describe "Thread.report_on_exception" do
     it "defaults to false" do
-      Thread.report_on_exception.should == false
+      ruby_exe("p Thread.report_on_exception").should == "false\n"
     end
   end
 

--- a/core/thread/value_spec.rb
+++ b/core/thread/value_spec.rb
@@ -7,7 +7,10 @@ describe "Thread#value" do
   end
 
   it "re-raises an error for an uncaught exception" do
-    t = Thread.new { raise "Hello" }
+    t = Thread.new {
+      Thread.current.report_on_exception = false
+      raise "Hello"
+    }
     lambda { t.value }.should raise_error(RuntimeError, "Hello")
   end
 

--- a/language/break_spec.rb
+++ b/language/break_spec.rb
@@ -63,15 +63,14 @@ describe "The break statement in a captured block" do
 
   describe "from another thread" do
     it "raises a LocalJumpError when getting the value from another thread" do
-      ScratchPad << :a
       thread_with_break = Thread.new do
-        ScratchPad << :b
-        break :break
-        ScratchPad << :c
+        begin
+          break :break
+        rescue LocalJumpError => e
+          e
+        end
       end
-
-      lambda { thread_with_break.value }.should raise_error(LocalJumpError)
-      ScratchPad.recorded.should == [:a, :b]
+      thread_with_break.value.should be_an_instance_of(LocalJumpError)
     end
   end
 end

--- a/language/return_spec.rb
+++ b/language/return_spec.rb
@@ -24,7 +24,14 @@ describe "The return keyword" do
 
   describe "in a Thread" do
     it "raises a LocalJumpError if used to exit a thread" do
-      lambda { Thread.new { return }.join }.should raise_error(LocalJumpError)
+      t = Thread.new {
+        begin
+          return
+        rescue LocalJumpError => e
+          e
+        end
+      }
+      t.value.should be_an_instance_of(LocalJumpError)
     end
   end
 

--- a/language/throw_spec.rb
+++ b/language/throw_spec.rb
@@ -68,13 +68,14 @@ describe "The throw keyword" do
     lambda { catch(:different) { throw :test, 5 } }.should raise_error(ArgumentError)
   end
 
-  it "raises an ArgumentError if used to exit a thread" do
-    lambda {
-      catch(:what) do
-        Thread.new {
+  it "raises an UncaughtThrowError if used to exit a thread" do
+    catch(:what) do
+      t = Thread.new {
+        -> {
           throw :what
-        }.join
-      end
-    }.should raise_error(ArgumentError)
+        }.should raise_error(UncaughtThrowError)
+      }
+      t.join
+    end
   end
 end

--- a/library/socket/tcpserver/accept_spec.rb
+++ b/library/socket/tcpserver/accept_spec.rb
@@ -48,14 +48,15 @@ describe "TCPServer#accept" do
   end
 
   it "can be interrupted by Thread#raise" do
-    t = Thread.new { @server.accept }
+    t = Thread.new {
+      -> {
+        @server.accept
+      }.should raise_error(Exception, "interrupted")
+    }
 
     Thread.pass while t.status and t.status != "sleep"
-
-    # raise in thread, ensure the raise happens
-    ex = Exception.new
-    t.raise ex
-    lambda { t.join }.should raise_error(Exception)
+    t.raise Exception, "interrupted"
+    t.join
   end
 
   it "raises an IOError if the socket is closed" do

--- a/library/socket/unixserver/accept_spec.rb
+++ b/library/socket/unixserver/accept_spec.rb
@@ -48,14 +48,14 @@ platform_is_not :windows do
 
     it "can be interrupted by Thread#raise" do
       t = Thread.new {
-        @server.accept
+        -> {
+          @server.accept
+        }.should raise_error(Exception, "interrupted")
       }
-      Thread.pass while t.status and t.status != "sleep"
 
-      # raise in thread, ensure the raise happens
-      ex = Exception.new
-      t.raise ex
-      lambda { t.join }.should raise_error(Exception)
+      Thread.pass while t.status and t.status != "sleep"
+      t.raise Exception, "interrupted"
+      t.join
     end
   end
 end

--- a/optional/capi/thread_spec.rb
+++ b/optional/capi/thread_spec.rb
@@ -78,8 +78,11 @@ describe "C-API Thread function" do
     end
 
     it "handles throwing an exception in the thread" do
-      proc = lambda { |x| raise "my error" }
-      thr = @t.rb_thread_create(proc, nil)
+      prc = lambda { |x|
+        Thread.current.report_on_exception = false
+        raise "my error"
+      }
+      thr = @t.rb_thread_create(prc, nil)
       thr.should be_kind_of(Thread)
 
       lambda {

--- a/shared/fiber/resume.rb
+++ b/shared/fiber/resume.rb
@@ -10,13 +10,13 @@ describe :fiber_resume, shared: true do
   end
 
   it "raises a FiberError if invoked from a different Thread" do
-    fiber = Fiber.new { }
-    lambda do
-      Thread.new do
+    fiber = Fiber.new { 42 }
+    Thread.new do
+      -> {
         fiber.resume
-      end.join
-    end.should raise_error(FiberError)
-    fiber.resume
+      }.should raise_error(FiberError)
+    end.join
+    fiber.resume.should == 42
   end
 
   it "passes control to the beginning of the block on first invocation" do

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -3,6 +3,17 @@ root = File.dirname(__FILE__)
 dir = "fixtures/code"
 CODE_LOADING_DIR = use_realpath ? File.realpath(dir, root) : File.expand_path(dir, root)
 
+# Enable Thread.report_on_exception by default to catch thread errors earlier
+if Thread.respond_to? :report_on_exception=
+  Thread.report_on_exception = true
+else
+  class Thread
+    def report_on_exception=(value)
+      raise "shim Thread#report_on_exception used with true" if value
+    end
+  end
+end
+
 # Running directly with ruby some_spec.rb
 unless ENV['MSPEC_RUNNER']
   begin


### PR DESCRIPTION
See #473.

Also set `Thread.report_on_exception = true` by default for all specs, so it is clear when a Thread terminates unexpectedly with an exception. 