### PR TITLE
 Add spec for `IPAddr#==` bug

### DIFF
--- a/library/ipaddr/operator_spec.rb
+++ b/library/ipaddr/operator_spec.rb
@@ -57,6 +57,13 @@ describe "IPAddr Operator" do
     @a.should_not == IPAddr.new("3ffe:505:3::")
   end
 
+  ruby_version_is '2.4' do
+    # https://bugs.ruby-lang.org/issues/12799
+    it "tests for equality correctly if object cannot be converted to IPAddr" do
+      IPAddr.new("1.1.1.1").should_not == "sometext"
+    end
+  end
+
   it "sets a mask" do
     a = @a.mask(32)
     a.to_s.should == "3ffe:505::"


### PR DESCRIPTION
IPAddr#== and IPAddr#<=> no longer raise an exception if coercion fails. Bug [#12799](https://bugs.ruby-lang.org/issues/12799)

Related issue https://github.com/ruby/spec/issues/473