### PR TITLE
Add specs for Net::HTTP.post

### DIFF
--- a/library/net/http/http/fixtures/http_server.rb
+++ b/library/net/http/http/fixtures/http_server.rb
@@ -42,6 +42,17 @@ module NetHTTPSpecs
     end
   end
 
+  class RequestBasicAuthServlet < SpecServlet
+    def reply(req, res)
+      res.content_type = "text/plain"
+
+      WEBrick::HTTPAuth.basic_auth(req, res, "realm") do |user, pass|
+        res.body = "username: #{user}\npassword: #{pass}"
+        true
+      end
+    end
+  end
+
   class << self
     @server = nil
     @server_thread = nil
@@ -69,6 +80,7 @@ module NetHTTPSpecs
       @server.mount('/request', RequestServlet)
       @server.mount("/request/body", RequestBodyServlet)
       @server.mount("/request/header", RequestHeaderServlet)
+      @server.mount("/request/basic_auth", RequestBasicAuthServlet)
 
       @server_thread = @server.start
     end

--- a/library/net/http/http/post_spec.rb
+++ b/library/net/http/http/post_spec.rb
@@ -1,6 +1,44 @@
 require File.expand_path('../../../../../spec_helper', __FILE__)
 require 'net/http'
+require 'uri'
 require File.expand_path('../fixtures/http_server', __FILE__)
+
+ruby_version_is '2.4' do
+  describe "Net::HTTP.post" do
+    before :each do
+      NetHTTPSpecs.start_server
+    end
+
+    after :each do
+      NetHTTPSpecs.stop_server
+    end
+
+    it "sends post request to the specified URI and returns response" do
+      response = Net::HTTP.post(
+        URI("http://localhost:#{NetHTTPSpecs.port}/request"),
+        '{ "q": "ruby", "max": "50" }',
+        "Content-Type" => "application/json")
+      response.body.should == "Request type: POST"
+    end
+
+    it "returns a Net::HTTPResponse" do
+      response = Net::HTTP.post(URI("http://localhost:#{NetHTTPSpecs.port}/request"), "test=test")
+      response.should be_kind_of(Net::HTTPResponse)
+    end
+
+    it "sends Content-Type: application/x-www-form-urlencoded by default" do
+      response = Net::HTTP.post(URI("http://localhost:#{NetHTTPSpecs.port}/request/header"), "test=test")
+      response.body.should include('"content-type"=>["application/x-www-form-urlencoded"]')
+    end
+
+    it "does not support HTTP Basic Auth" do
+      response = Net::HTTP.post(
+        URI("http://john:qwerty@localhost:#{NetHTTPSpecs.port}/request/basic_auth"),
+        "test=test")
+      response.body.should == "username: \npassword: "
+    end
+  end
+end
 
 describe "Net::HTTP#post" do
   before :each do
@@ -36,3 +74,4 @@ describe "Net::HTTP#post" do
     end
   end
 end
+


### PR DESCRIPTION
New method: Net::HTTP.post [Feature #12375](https://bugs.ruby-lang.org/issues/12375)
Related issue https://github.com/ruby/spec/issues/473