### PR TITLE
Date, DateTime, and Time expanded coverage

### DIFF
--- a/core/time/shared/now.rb
+++ b/core/time/shared/now.rb
@@ -5,4 +5,14 @@ describe :time_now, shared: true do
     TimeSpecs::SubTime.send(@method).should be_an_instance_of(TimeSpecs::SubTime)
     TimeSpecs::MethodHolder.send(@method).should be_an_instance_of(Time)
   end
+
+  it "sets the current time" do
+    check = `date "+%H:%M:%S"`.strip
+    time = check.match(/(\d{2})\:(\d{2})\:(\d{2})/)
+    now = TimeSpecs::MethodHolder.send(@method)
+
+    now.hour.should == time[1].to_i
+    now.min.should == time[2].to_i
+    now.sec.should == time[3].to_i
+  end
 end

--- a/core/time/shared/now.rb
+++ b/core/time/shared/now.rb
@@ -7,16 +7,11 @@ describe :time_now, shared: true do
   end
 
   it "sets the current time" do
-    check = `date "+%H:%M:%S"`.strip
-    time = check.match(/(\d{2})\:(\d{2})\:(\d{2})/)
     now = TimeSpecs::MethodHolder.send(@method)
-
-    now.hour.should == time[1].to_i
-    now.min.should == time[2].to_i
-    now.sec.should == time[3].to_i
+    now.to_f.should be_close(Process.clock_gettime(Process::CLOCK_REALTIME), 10.0)
   end
 
-  it "preserves the local timezone" do
+  it "uses the local timezone" do
     with_timezone("PDT", -8) do
       now = TimeSpecs::MethodHolder.send(@method)
       now.utc_offset.should == (-8 * 60 * 60)

--- a/core/time/shared/now.rb
+++ b/core/time/shared/now.rb
@@ -15,4 +15,11 @@ describe :time_now, shared: true do
     now.min.should == time[2].to_i
     now.sec.should == time[3].to_i
   end
+
+  it "preserves the local timezone" do
+    with_timezone("PDT", -8) do
+      now = TimeSpecs::MethodHolder.send(@method)
+      now.utc_offset.should == (-8 * 60 * 60)
+    end
+  end
 end

--- a/library/date/today_spec.rb
+++ b/library/date/today_spec.rb
@@ -2,5 +2,16 @@ require File.expand_path('../../../spec_helper', __FILE__)
 require 'date'
 
 describe "Date.today" do
-  it "needs to be reviewed for spec completeness"
+  it "returns a Date object" do
+    Date.today.should be_kind_of Date
+  end
+
+  it "sets Date object to the current date" do
+    check = `date "+%Y-%m-%d"`.strip
+    date = check.match(/(\d{4})-(\d{2})-(\d{2})/)
+    today = Date.today
+    today.year.should == date[1].to_i
+    today.mon.should == date[2].to_i
+    today.day.should == date[3].to_i
+  end
 end

--- a/library/date/today_spec.rb
+++ b/library/date/today_spec.rb
@@ -7,11 +7,11 @@ describe "Date.today" do
   end
 
   it "sets Date object to the current date" do
-    check = `date "+%Y-%m-%d"`.strip
-    date = check.match(/(\d{4})-(\d{2})-(\d{2})/)
     today = Date.today
-    today.year.should == date[1].to_i
-    today.mon.should == date[2].to_i
-    today.day.should == date[3].to_i
+    
+    now = Time.now
+    today.year.should == now.year
+    today.mon.should == now.mon
+    today.day.should == now.day
   end
 end

--- a/library/date/today_spec.rb
+++ b/library/date/today_spec.rb
@@ -9,6 +9,6 @@ describe "Date.today" do
   it "sets Date object to the current date" do
     today = Date.today
     now = Time.now
-    (today.to_time - now).should be_close(24 * 60 * 60)
+    (now - today.to_time).should be_close(0.0, 24 * 60 * 60)
   end
 end

--- a/library/date/today_spec.rb
+++ b/library/date/today_spec.rb
@@ -8,10 +8,7 @@ describe "Date.today" do
 
   it "sets Date object to the current date" do
     today = Date.today
-    
     now = Time.now
-    today.year.should == now.year
-    today.mon.should == now.mon
-    today.day.should == now.day
+    (today.to_time - now).should be_close(24 * 60 * 60)
   end
 end

--- a/library/datetime/now_spec.rb
+++ b/library/datetime/now_spec.rb
@@ -5,4 +5,28 @@ describe "DateTime.now" do
   it "creates an instance of DateTime" do
     DateTime.now.should be_an_instance_of(DateTime)
   end
+
+  it "sets the current date" do
+    dt = DateTime.now
+    d = Date.today
+
+    dt.year.should == d.year
+    dt.mon.should == d.mon
+    dt.day.should == d.day
+  end
+
+  it "sets the current time" do
+    dt = DateTime.now
+    t = Time.now
+
+    dt.hour.should == t.hour
+    dt.min.should == t.min
+    dt.sec.should == t.sec
+  end
+
+  it "grabs the local timezone" do
+    dt = DateTime.now
+    t = Time.local(dt.year, dt.mon, dt.mday, dt.hour, dt.min, dt.sec)
+    dt.offset.to_i.should == t.utc_offset
+  end
 end

--- a/library/datetime/now_spec.rb
+++ b/library/datetime/now_spec.rb
@@ -8,22 +8,20 @@ describe "DateTime.now" do
 
   it "sets the current date" do
     dt = DateTime.now
-    check = `date "+%Y-%m-%d"`.strip
-    date = check.match(/(\d{4})-(\d{2})-(\d{2})/)
+    date = Date.today
 
-    dt.year.should == date[1].to_i
-    dt.mon.should == date[2].to_i
-    dt.day.should == date[3].to_i
+    dt.year.should == date.year
+    dt.mon.should == date.mon
+    dt.day.should == date.day
   end
 
   it "sets the current time" do
     dt = DateTime.now
-    check = `date "+%H:%M:%S"`.strip
-    time = check.match(/(\d{2})\:(\d{2})\:(\d{2})/)
+    time = Time.now
 
-    dt.hour.should == time[1].to_i
-    dt.min.should == time[2].to_i
-    dt.sec.should == time[3].to_i
+    dt.hour.should == time.hour
+    dt.min.should == time.min
+    dt.sec.should == time.sec
   end
 
   it "grabs the local timezone" do

--- a/library/datetime/now_spec.rb
+++ b/library/datetime/now_spec.rb
@@ -8,25 +8,28 @@ describe "DateTime.now" do
 
   it "sets the current date" do
     dt = DateTime.now
-    d = Date.today
+    check = `date "+%Y-%m-%d"`.strip
+    date = check.match(/(\d{4})-(\d{2})-(\d{2})/)
 
-    dt.year.should == d.year
-    dt.mon.should == d.mon
-    dt.day.should == d.day
+    dt.year.should == date[1].to_i
+    dt.mon.should == date[2].to_i
+    dt.day.should == date[3].to_i
   end
 
   it "sets the current time" do
     dt = DateTime.now
-    t = Time.now
+    check = `date "+%H:%M:%S"`.strip
+    time = check.match(/(\d{2})\:(\d{2})\:(\d{2})/)
 
-    dt.hour.should == t.hour
-    dt.min.should == t.min
-    dt.sec.should == t.sec
+    dt.hour.should == time[1].to_i
+    dt.min.should == time[2].to_i
+    dt.sec.should == time[3].to_i
   end
 
   it "grabs the local timezone" do
-    dt = DateTime.now
-    t = Time.local(dt.year, dt.mon, dt.mday, dt.hour, dt.min, dt.sec)
-    dt.offset.to_i.should == t.utc_offset
+    with_timezone("PDT", -8) do
+      dt = DateTime.now
+      dt.zone.should == "-08:00"
+    end
   end
 end

--- a/library/datetime/now_spec.rb
+++ b/library/datetime/now_spec.rb
@@ -7,11 +7,7 @@ describe "DateTime.now" do
   end
 
   it "sets the current date" do
-    dt = DateTime.now
-    date = Date.today
-    dt.year.should == date.year
-    dt.mon.should == date.mon
-    dt.day.should == date.day
+    (DateTime.now - Date.today).to_f.should be_close(0.0, 1.0)
   end
 
   it "sets the current time" do

--- a/library/datetime/now_spec.rb
+++ b/library/datetime/now_spec.rb
@@ -9,7 +9,6 @@ describe "DateTime.now" do
   it "sets the current date" do
     dt = DateTime.now
     date = Date.today
-
     dt.year.should == date.year
     dt.mon.should == date.mon
     dt.day.should == date.day
@@ -17,11 +16,8 @@ describe "DateTime.now" do
 
   it "sets the current time" do
     dt = DateTime.now
-    time = Time.now
-
-    dt.hour.should == time.hour
-    dt.min.should == time.min
-    dt.sec.should == time.sec
+    now = Time.now
+    (dt.to_time - now).should be_close(24 * 60 * 60)
   end
 
   it "grabs the local timezone" do

--- a/library/datetime/now_spec.rb
+++ b/library/datetime/now_spec.rb
@@ -17,7 +17,7 @@ describe "DateTime.now" do
   it "sets the current time" do
     dt = DateTime.now
     now = Time.now
-    (dt.to_time - now).should be_close(24 * 60 * 60)
+    (dt.to_time - now).should be_close(0.0, 10.0)
   end
 
   it "grabs the local timezone" do

--- a/library/datetime/to_date_spec.rb
+++ b/library/datetime/to_date_spec.rb
@@ -2,5 +2,36 @@ require File.expand_path('../../../spec_helper', __FILE__)
 require 'date'
 
 describe "DateTime#to_date" do
-  it "needs to be reviewed for spec completeness"
+  it "returns an instance of Date" do
+    dt = DateTime.new(2012, 12, 24, 12, 23, 00, '+05:00')
+    dt.to_date.should be_kind_of(Date)
+  end
+
+  it "maintains the same year" do
+    dt = DateTime.new(2012, 12, 24, 12, 23, 00, '+05:00')
+    dt.to_date.year.should == dt.year
+  end
+
+  it "maintains the same month" do
+    dt = DateTime.new(2012, 12, 24, 12, 23, 00, '+05:00')
+    dt.to_date.mon.should == dt.mon
+  end
+
+  it "maintains the same day" do
+    dt = DateTime.new(2012, 12, 24, 12, 23, 00, '+05:00')
+    dt.to_date.day.should == dt.day
+  end
+
+  it "maintains the same mday" do
+    dt = DateTime.new(2012, 12, 24, 12, 23, 00, '+05:00')
+    dt.to_date.mday.should == dt.mday
+  end
+
+  it "maintains the same julian day regardless of local time or zone" do
+    dt = DateTime.new(2012, 12, 24, 12, 23, 00, '+05:00')
+
+    with_timezone("Pactific/Pago_Pago", -11) do
+      dt.to_date.jd.should == dt.jd
+    end
+  end
 end

--- a/library/datetime/to_datetime_spec.rb
+++ b/library/datetime/to_datetime_spec.rb
@@ -2,5 +2,8 @@ require File.expand_path('../../../spec_helper', __FILE__)
 require 'date'
 
 describe "DateTime#to_datetime" do
-  it "needs to be reviewed for spec completeness"
+  it "returns itself" do
+    dt = DateTime.new(2012, 12, 24, 12, 23, 00, '+05:00')
+    dt.to_datetime.should == dt
+  end
 end

--- a/library/datetime/to_s_spec.rb
+++ b/library/datetime/to_s_spec.rb
@@ -2,5 +2,16 @@ require File.expand_path('../../../spec_helper', __FILE__)
 require 'date'
 
 describe "DateTime#to_s" do
-  it "needs to be reviewed for spec completeness"
+  it "returns a new String object" do
+    dt = DateTime.new(2012, 12, 24, 1, 2, 3, "+03:00")
+    dt.to_s.should be_kind_of(String)
+  end
+
+  it "maintains timezone regardless of local time" do
+    dt = DateTime.new(2012, 12, 24, 1, 2, 3, "+03:00")
+
+    with_timezone("Pactific/Pago_Pago", -11) do
+      dt.to_s.should == "2012-12-24T01:02:03+03:00"
+    end
+  end
 end


### PR DESCRIPTION
While I was working on `DateTime#to_time` in #490, I noticed stubs in the DateTime, Date, and Time specs.  I have added coverage to the following:

- `DateTime#to_s`
- `DateTime#to_date`
- `DateTime#to_datetime`
- `DateTime.now`
- `Date.today`
- `Time.now`

There are some backtick'd calls to prevent circular logic of DateTime / Time / Date.  If that's an issue, I can revert them to using Time.new / Date.new.