### PR TITLE
Add specs for CSV liberal parsing

### DIFF
--- a/library/csv/liberal_parsing_spec.rb
+++ b/library/csv/liberal_parsing_spec.rb
@@ -1,0 +1,21 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+require 'csv'
+
+ruby_version_is '2.4' do
+  describe "CSV#liberal_parsing?" do
+    it "returns true if illegal input is handled" do
+      csv = CSV.new("", liberal_parsing: true)
+      csv.liberal_parsing?.should == true
+    end
+
+    it "returns false if illegal input is not handled" do
+      csv = CSV.new("", liberal_parsing: false)
+      csv.liberal_parsing?.should == false
+    end
+
+    it "returns false by default" do
+      csv = CSV.new("")
+      csv.liberal_parsing?.should == false
+    end
+  end
+end

--- a/library/csv/parse_spec.rb
+++ b/library/csv/parse_spec.rb
@@ -86,7 +86,7 @@ describe "CSV.parse" do
   end
 
   ruby_version_is '2.4' do
-    it "handles illegal input" do
+    it "handles illegal input with the liberal_parsing option" do
       illegal_input = '"Johnson, Dwayne",Dwayne "The Rock" Johnson'
       result = CSV.parse(illegal_input, liberal_parsing: true)
       result.should == [["Johnson, Dwayne", 'Dwayne "The Rock" Johnson']]

--- a/library/csv/parse_spec.rb
+++ b/library/csv/parse_spec.rb
@@ -78,4 +78,18 @@ describe "CSV.parse" do
     result = CSV.parse "foo;bar\nbaz;quz", col_sep: ?;
     result.should == [['foo','bar'],['baz','quz']]
   end
+
+  it "raises CSV::MalformedCSVError exception if input is illegal" do
+    -> {
+      CSV.parse('"quoted" field')
+    }.should raise_error(CSV::MalformedCSVError)
+  end
+
+  ruby_version_is '2.4' do
+    it "handles illegal input" do
+      illegal_input = '"Johnson, Dwayne",Dwayne "The Rock" Johnson'
+      result = CSV.parse(illegal_input, liberal_parsing: true)
+      result.should == [["Johnson, Dwayne", 'Dwayne "The Rock" Johnson']]
+    end
+  end
 end

--- a/library/csv/readlines_spec.rb
+++ b/library/csv/readlines_spec.rb
@@ -20,4 +20,18 @@ describe "CSV#readlines" do
     file = CSV.new "a,, b, c"
     file.readlines.should == [["a", nil, " b", " c"]]
   end
+
+  it "raises CSV::MalformedCSVError exception if input is illegal" do
+    csv = CSV.new('"quoted" field')
+    -> { csv.readlines }.should raise_error(CSV::MalformedCSVError)
+  end
+
+  ruby_version_is '2.4' do
+    it "handles illegal input" do
+      illegal_input = '"Johnson, Dwayne",Dwayne "The Rock" Johnson'
+      csv = CSV.new(illegal_input, liberal_parsing: true)
+      result = csv.readlines
+      result.should == [["Johnson, Dwayne", 'Dwayne "The Rock" Johnson']]
+    end
+  end
 end

--- a/library/csv/readlines_spec.rb
+++ b/library/csv/readlines_spec.rb
@@ -27,7 +27,7 @@ describe "CSV#readlines" do
   end
 
   ruby_version_is '2.4' do
-    it "handles illegal input" do
+    it "handles illegal input with the liberal_parsing option" do
       illegal_input = '"Johnson, Dwayne",Dwayne "The Rock" Johnson'
       csv = CSV.new(illegal_input, liberal_parsing: true)
       result = csv.readlines


### PR DESCRIPTION
CSV
Add a liberal_parsing option. [Feature #11839](https://bugs.ruby-lang.org/issues/11839)

Specs are based on original PR https://github.com/ruby/ruby/pull/1160

Related issue https://github.com/ruby/spec/issues/473