### PR TITLE
Add spec for Shelwords.shelwords bug with backslash escaping

### DIFF
--- a/library/shellwords/shellwords_spec.rb
+++ b/library/shellwords/shellwords_spec.rb
@@ -29,8 +29,8 @@ describe "Shellwords#shellwords" do
 
   ruby_version_is '2.4' do
     # https://bugs.ruby-lang.org/issues/10055
-    it %Q{ treats the backslash as escape character only when followed by one of the following characters: $ ` " \ " } do
-      shellsplit('printf "%s\\n"').should == ['printf', '%s\n']
+    it "matches POSIX sh behavior for backslashes within double quoted strings" do
+      shellsplit('printf "%s\n"').should == ['printf', '%s\n']
     end
   end
 end

--- a/library/shellwords/shellwords_spec.rb
+++ b/library/shellwords/shellwords_spec.rb
@@ -26,4 +26,11 @@ describe "Shellwords#shellwords" do
   it "raises ArgumentError when single quoted strings are misquoted" do
     lambda { shellwords("a 'b c d e") }.should raise_error(ArgumentError)
   end
+
+  ruby_version_is '2.4' do
+    # https://bugs.ruby-lang.org/issues/10055
+    it %Q{ treats the backslash as escape character only when followed by one of the following characters: $ ` " \ " } do
+      shellsplit('printf "%s\\n"').should == ['printf', '%s\n']
+    end
+  end
 end


### PR DESCRIPTION
Shellwords.shellwords (shellsplit) treats the backslash as escape character only when followed by one of the following characters: $ ` " \ 

[Bug #10055](https://bugs.ruby-lang.org/issues/10055)

Related issue https://github.com/ruby/spec/issues/473