### PR TITLE
Add specs for refinements

### DIFF
--- a/core/main/fixtures/classes.rb
+++ b/core/main/fixtures/classes.rb
@@ -4,7 +4,10 @@ module MainSpecs
 
   module WrapIncludeModule
   end
+
+  DATA = {}
 end
+
 
 def main_public_method
 end

--- a/core/main/fixtures/string_refinement.rb
+++ b/core/main/fixtures/string_refinement.rb
@@ -1,0 +1,7 @@
+module StringRefinement
+  refine(String) do
+    def foo
+      'foo'
+    end
+  end
+end

--- a/core/main/fixtures/string_refinement_user.rb
+++ b/core/main/fixtures/string_refinement_user.rb
@@ -1,0 +1,11 @@
+using StringRefinement
+
+module MainSpecs
+  DATA[:in_module] = 'hello'.foo
+
+  def self.call_foo(x)
+    x.foo
+  end
+end
+
+MainSpecs::DATA[:toplevel] = 'hello'.foo

--- a/core/main/using_spec.rb
+++ b/core/main/using_spec.rb
@@ -1,0 +1,132 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+ruby_version_is "2.0.0" do
+  require File.expand_path('../fixtures/classes', __FILE__)
+  require File.expand_path('../fixtures/string_refinement', __FILE__)
+
+  describe "main.using" do
+    it "requires one Module argument" do
+      lambda do
+        eval('using', TOPLEVEL_BINDING)
+      end.should raise_error(ArgumentError)
+
+      lambda do
+        eval('using "foo"', TOPLEVEL_BINDING)
+      end.should raise_error(TypeError)
+    end
+
+    it "uses refinements from the given module only in the target file" do
+      load File.expand_path('../fixtures/string_refinement_user.rb', __FILE__)
+      MainSpecs::DATA[:in_module].should == 'foo'
+      MainSpecs::DATA[:toplevel].should == 'foo'
+      lambda do
+        'hello'.foo
+      end.should raise_error(NoMethodError)
+    end
+
+    it "uses refinements from the given module for method calls in the target file" do
+      load File.expand_path('../fixtures/string_refinement_user.rb', __FILE__)
+      lambda do
+        'hello'.foo
+      end.should raise_error(NoMethodError)
+      MainSpecs.call_foo('hello').should == 'foo'
+    end
+
+    it "uses refinements from the given module in the eval string" do
+      cls = MainSpecs::DATA[:cls] = Class.new {def foo; 'foo'; end}
+      MainSpecs::DATA[:mod] = Module.new do
+        refine(cls) do
+          def foo; 'bar'; end
+        end
+      end
+      eval(<<-EOS, TOPLEVEL_BINDING).should == 'bar'
+        using MainSpecs::DATA[:mod]
+        MainSpecs::DATA[:cls].new.foo
+      EOS
+    end
+
+    it "does not affect methods defined before it is called" do
+      cls = Class.new {def foo; 'foo'; end}
+      MainSpecs::DATA[:mod] = Module.new do
+        refine(cls) do
+          def foo; 'bar'; end
+        end
+      end
+      x = MainSpecs::DATA[:x] = Object.new
+      eval <<-EOS, TOPLEVEL_BINDING
+        x = MainSpecs::DATA[:x]
+        def x.before_using(obj)
+          obj.foo
+        end
+        using MainSpecs::DATA[:mod]
+        def x.after_using(obj)
+          obj.foo
+        end
+      EOS
+
+      x.before_using(cls.new).should == 'foo'
+      x.after_using(cls.new).should == 'bar'
+    end
+
+    it "propagates refinements added to existing modules after it is called" do
+      cls = Class.new {def foo; 'foo'; end}
+      mod = MainSpecs::DATA[:mod] = Module.new do
+        refine(cls) do
+          def foo; 'quux'; end
+        end
+      end
+      x = MainSpecs::DATA[:x] = Object.new
+      eval <<-EOS, TOPLEVEL_BINDING
+        using MainSpecs::DATA[:mod]
+        x = MainSpecs::DATA[:x]
+        def x.call_foo(obj)
+          obj.foo
+        end
+        def x.call_bar(obj)
+          obj.bar
+        end
+      EOS
+
+      x.call_foo(cls.new).should == 'quux'
+
+      mod.module_eval do
+        refine(cls) do
+          def bar; 'quux'; end
+        end
+      end
+
+      x.call_bar(cls.new).should == 'quux'
+    end
+
+    it "does not propagate refinements of new modules added after it is called" do
+      cls = Class.new {def foo; 'foo'; end}
+      cls2 = Class.new {def bar; 'bar'; end}
+      mod = MainSpecs::DATA[:mod] = Module.new do
+        refine(cls) do
+          def foo; 'quux'; end
+        end
+      end
+      x = MainSpecs::DATA[:x] = Object.new
+      eval <<-EOS, TOPLEVEL_BINDING
+        using MainSpecs::DATA[:mod]
+        x = MainSpecs::DATA[:x]
+        def x.call_foo(obj)
+          obj.foo
+        end
+        def x.call_bar(obj)
+          obj.bar
+        end
+      EOS
+
+      x.call_foo(cls.new).should == 'quux'
+
+      mod.module_eval do
+        refine(cls2) do
+          def bar; 'quux'; end
+        end
+      end
+
+      x.call_bar(cls2.new).should == 'bar'
+    end
+  end
+end

--- a/core/main/using_spec.rb
+++ b/core/main/using_spec.rb
@@ -64,8 +64,9 @@ ruby_version_is "2.0.0" do
         end
       EOS
 
-      x.before_using(cls.new).should == 'foo'
-      x.after_using(cls.new).should == 'bar'
+      obj = cls.new
+      x.before_using(obj).should == 'foo'
+      x.after_using(obj).should == 'bar'
     end
 
     it "propagates refinements added to existing modules after it is called" do
@@ -87,7 +88,8 @@ ruby_version_is "2.0.0" do
         end
       EOS
 
-      x.call_foo(cls.new).should == 'quux'
+      obj = cls.new
+      x.call_foo(obj).should == 'quux'
 
       mod.module_eval do
         refine(cls) do
@@ -95,7 +97,7 @@ ruby_version_is "2.0.0" do
         end
       end
 
-      x.call_bar(cls.new).should == 'quux'
+      x.call_bar(obj).should == 'quux'
     end
 
     it "does not propagate refinements of new modules added after it is called" do

--- a/core/module/fixtures/refine.rb
+++ b/core/module/fixtures/refine.rb
@@ -1,0 +1,13 @@
+module ModuleSpecs
+  class ClassWithFoo
+    def foo; "foo" end
+  end
+
+  module PrependedModule
+    def foo; "foo from prepended module"; end
+  end
+
+  module IncludedModule
+    def foo; "foo from included module"; end
+  end
+end

--- a/core/module/fixtures/using.rb
+++ b/core/module/fixtures/using.rb
@@ -1,0 +1,10 @@
+module ModuleSpecs
+  module EmptyRefinement
+  end
+
+  module RefinementForStringToS
+    refine String do
+      def to_s; "hello from refinement"; end
+    end
+  end
+end

--- a/core/module/refine_spec.rb
+++ b/core/module/refine_spec.rb
@@ -1,0 +1,104 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+ruby_version_is "2.0.0" do
+  describe "Module#refine" do
+    it "runs its block in an anonymous Module" do
+      selves = nil
+      mod = Module.new do
+        outer_self = self
+        refine String do
+          selves = [outer_self, self]
+        end
+      end
+
+      selves[0].should == mod
+      selves[0].should_not == selves[1]
+      selves[1].should be_kind_of(Module)
+    end
+
+    it "uses the same anonymous module for future refines of the same class" do
+      selves = []
+      mod = Module.new do
+        selves << self
+        refine String do
+          selves << self
+        end
+      end
+
+      mod.module_eval do
+        refine String do
+          selves << self
+        end
+      end
+
+      selves[1].should == selves[2]
+    end
+
+    it "adds methods defined in its block to the anon module's public instance methods" do
+      inner_self = nil
+      mod = Module.new do
+        refine String do
+          def blah
+            "blah"
+          end
+          inner_self = self
+        end
+      end
+
+      inner_self.public_instance_methods.should include(:blah)
+    end
+
+    it "raises ArgumentError if not passed an argument" do
+      lambda do
+        Module.new do
+          refine {}
+        end
+      end.should raise_error(ArgumentError)
+    end
+
+    it "raises TypeError if not passed a class or module" do
+      lambda do
+        Module.new do
+          refine('foo') {}
+        end
+      end.should raise_error(TypeError)
+    end
+
+    it "raises ArgumentError if not given a block" do
+      lambda do
+        Module.new do
+          refine String
+        end
+      end.should raise_error(ArgumentError)
+    end
+
+    it "applies refinements to calls in the refine block" do
+      result = nil
+      Module.new do
+        refine(String) do
+          def foo; 'foo'; end
+          result = 'hello'.foo
+        end
+      end
+      result.should == 'foo'
+    end
+
+    it "doesn't apply refinements outside the refine block" do
+      Module.new do
+        refine(String) {def foo; 'foo'; end}
+        lambda do
+          'hello'.foo
+        end
+        should raise_error(NoMethodError)
+      end
+    end
+
+    it "does not apply refinements to external scopes not using the module" do
+      Module.new do
+        refine(String) {def foo; 'foo'; end}
+      end
+
+      lambda {'hello'.foo}.should raise_error(NoMethodError)
+    end
+  end
+end

--- a/core/module/refine_spec.rb
+++ b/core/module/refine_spec.rb
@@ -1,44 +1,95 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/refine', __FILE__)
 
-ruby_version_is "2.2" do
-  describe "Module#refine" do
-    it "runs its block in an anonymous module" do
-      inner_self = nil
-      mod = Module.new do
-        refine String do
-          inner_self = self
-        end
+describe "Module#refine" do
+  it "runs its block in an anonymous module" do
+    inner_self = nil
+    mod = Module.new do
+      refine String do
+        inner_self = self
       end
-
-      mod.should_not == inner_self
-      inner_self.should be_kind_of(Module)
-      inner_self.name.should == nil
     end
 
-    it "uses the same anonymous module for future refines of the same class" do
-      selves = []
-      mod = Module.new do
-        refine String do
-          selves << self
-        end
-      end
+    mod.should_not == inner_self
+    inner_self.should be_kind_of(Module)
+    inner_self.name.should == nil
+  end
 
-      mod.module_eval do
-        refine String do
-          selves << self
-        end
+  it "uses the same anonymous module for future refines of the same class" do
+    selves = []
+    mod = Module.new do
+      refine String do
+        selves << self
       end
-
-      selves[0].should == selves[1]
     end
 
-    it "adds methods defined in its block to the anonymous module's public instance methods" do
+    mod.module_eval do
+      refine String do
+        selves << self
+      end
+    end
+
+    selves[0].should == selves[1]
+  end
+
+  it "adds methods defined in its block to the anonymous module's public instance methods" do
+    inner_self = nil
+    mod = Module.new do
+      refine String do
+        def blah
+          "blah"
+        end
+        inner_self = self
+      end
+    end
+
+    inner_self.public_instance_methods.should include(:blah)
+  end
+
+  it "returns created anonymous module" do
+    inner_self = nil
+    result = nil
+    mod = Module.new do
+      result = refine String do
+        inner_self = self
+      end
+    end
+
+    result.should == inner_self
+  end
+
+  it "raises ArgumentError if not passed an argument" do
+    lambda do
+      Module.new do
+        refine {}
+      end
+    end.should raise_error(ArgumentError)
+  end
+
+  it "raises TypeError if not passed a class" do
+    lambda do
+      Module.new do
+        refine("foo") {}
+      end
+    end.should raise_error(TypeError)
+  end
+
+  ruby_version_is "" ... "2.4" do
+    it "raises TypeError if passed a module" do
+      lambda do
+        Module.new do
+          refine(Enumerable) {}
+        end
+      end.should raise_error(TypeError)
+    end
+  end
+
+  ruby_version_is "2.4" do
+    it "accepts a module as argument" do
       inner_self = nil
-      mod = Module.new do
-        refine String do
+      Module.new do
+        refine(Enumerable) do
           def blah
-            "blah"
           end
           inner_self = self
         end
@@ -46,266 +97,119 @@ ruby_version_is "2.2" do
 
       inner_self.public_instance_methods.should include(:blah)
     end
+  end
 
-    it "returns created anonymous module" do
-      inner_self = nil
-      result = nil
-      mod = Module.new do
-        result = refine String do
-          inner_self = self
-        end
-      end
-
-      result.should == inner_self
-    end
-
-    it "raises ArgumentError if not passed an argument" do
-      lambda do
-        Module.new do
-          refine {}
-        end
-      end.should raise_error(ArgumentError)
-    end
-
-    it "raises TypeError if not passed a class" do
-      lambda do
-        Module.new do
-          refine("foo") {}
-        end
-      end.should raise_error(TypeError)
-    end
-
-    ruby_version_is "" ... "2.4" do
-      it "raises TypeError if passed a module" do
-        lambda do
-          Module.new do
-            refine(Enumerable) {}
-          end
-        end.should raise_error(TypeError)
-      end
-    end
-
-    ruby_version_is "2.4" do
-      it "accepts a module as argument" do
-        inner_self = nil
-        Module.new do
-          refine(Enumerable) do
-            def blah
-            end
-            inner_self = self
-          end
-        end
-
-        inner_self.public_instance_methods.should include(:blah)
-      end
-    end
-
-    it "raises ArgumentError if not given a block" do
-      lambda do
-        Module.new do
-          refine String
-        end
-      end.should raise_error(ArgumentError)
-    end
-
-    it "applies refinements to calls in the refine block" do
-      result = nil
+  it "raises ArgumentError if not given a block" do
+    lambda do
       Module.new do
-        refine(String) do
-          def foo; "foo"; end
-          result = "hello".foo
-        end
+        refine String
       end
-      result.should == "foo"
-    end
+    end.should raise_error(ArgumentError)
+  end
 
-    it "doesn't apply refinements outside the refine block" do
-      Module.new do
-        refine(String) {def foo; "foo"; end}
-        -> () {
-          "hello".foo
-        }.should raise_error(NoMethodError)
+  it "applies refinements to calls in the refine block" do
+    result = nil
+    Module.new do
+      refine(String) do
+        def foo; "foo"; end
+        result = "hello".foo
       end
     end
+    result.should == "foo"
+  end
 
-    it "does not apply refinements to external scopes not using the module" do
-      Module.new do
-        refine(String) {def foo; 'foo'; end}
-      end
-
-      lambda {"hello".foo}.should raise_error(NoMethodError)
-    end
-
-    # When defining multiple refinements in the same module,
-    # inside a refine block all refinements from the same
-    # module are active when a refined method is called
-    it "makes available all refinements from the same module" do
-      refinement = Module.new do
-        refine Integer do
-          def to_json_format
-            to_s
-          end
-        end
-
-        refine Array do
-          def to_json_format
-            "[" + map { |i| i.to_json_format }.join(", ") + "]"
-          end
-        end
-
-        refine Hash do
-          def to_json_format
-            "{" + map { |k, v| k.to_s.dump + ": " + v.to_json_format }.join(", ") + "}"
-          end
-        end
-      end
-
-      result = nil
-
-      Module.new do
-        using refinement
-
-        result = [{1 => 2}, {3 => 4}].to_json_format
-      end
-
-      result.should == '[{"1": 2}, {"3": 4}]'
-    end
-
-    it "does not make available methods from another refinement module" do
-      refinery_integer = Module.new do
-        refine Integer do
-          def to_json_format
-            to_s
-          end
-        end
-      end
-
-      refinery_array = Module.new do
-        refine Array do
-          def to_json_format
-            "[" + map { |i| i.to_json_format }.join(",") + "]"
-          end
-        end
-      end
-
-      result = nil
-
+  it "doesn't apply refinements outside the refine block" do
+    Module.new do
+      refine(String) {def foo; "foo"; end}
       -> () {
-        Module.new do
-          using refinery_integer
-          using refinery_array
-
-          [1, 2].to_json_format
-        end
+        "hello".foo
       }.should raise_error(NoMethodError)
     end
+  end
 
-    # method lookup:
-    #   * The prepended modules from the refinement for C
-    #   * The refinement for C
-    #   * The included modules from the refinement for C
-    #   * The prepended modules of C
-    #   * C
-    #   * The included modules of C
-    describe "method lookup" do
-      it "looks in the object singleton class first" do
-        refinement = Module.new do
-          refine ModuleSpecs::ClassWithFoo  do
-            def foo; "foo from refinement"; end
-          end
+  it "does not apply refinements to external scopes not using the module" do
+    Module.new do
+      refine(String) {def foo; 'foo'; end}
+    end
+
+    lambda {"hello".foo}.should raise_error(NoMethodError)
+  end
+
+  # When defining multiple refinements in the same module,
+  # inside a refine block all refinements from the same
+  # module are active when a refined method is called
+  it "makes available all refinements from the same module" do
+    refinement = Module.new do
+      refine Integer do
+        def to_json_format
+          to_s
         end
-
-        result = nil
-        Module.new do
-          using refinement
-
-          obj = ModuleSpecs::ClassWithFoo.new
-          class << obj
-            def foo; "foo from singleton class"; end
-          end
-          result = obj.foo
-        end
-
-        result.should == "foo from singleton class"
       end
 
-      it "looks in prepended modules from the refinement first" do
-        refinement = Module.new do
-          refine ModuleSpecs::ClassWithFoo  do
-            include ModuleSpecs::IncludedModule
-            prepend ModuleSpecs::PrependedModule
-
-            def foo; "foo from refinement"; end
-          end
+      refine Array do
+        def to_json_format
+          "[" + map { |i| i.to_json_format }.join(", ") + "]"
         end
-
-        result = nil
-        Module.new do
-          using refinement
-          result = ModuleSpecs::ClassWithFoo.new.foo
-        end
-
-        result.should == "foo from prepended module"
       end
 
-      it "looks in refinement then" do
-        refinement = Module.new do
-          refine(ModuleSpecs::ClassWithFoo) do
-            include ModuleSpecs::IncludedModule
-
-            def foo; "foo from refinement"; end
-          end
+      refine Hash do
+        def to_json_format
+          "{" + map { |k, v| k.to_s.dump + ": " + v.to_json_format }.join(", ") + "}"
         end
-
-        result = nil
-        Module.new do
-          using refinement
-          result = ModuleSpecs::ClassWithFoo.new.foo
-        end
-
-        result.should == "foo from refinement"
-      end
-
-      it "looks in included modules from the refinement then" do
-        refinement = Module.new do
-          refine ModuleSpecs::ClassWithFoo  do
-            include ModuleSpecs::IncludedModule
-          end
-        end
-
-        result = nil
-        Module.new do
-          using refinement
-          result = ModuleSpecs::ClassWithFoo.new.foo
-        end
-
-        result.should == "foo from included module"
-      end
-
-      it "looks in the class then" do
-        refinement = Module.new do
-          refine(ModuleSpecs::ClassWithFoo) { }
-        end
-
-        result = nil
-        Module.new do
-          using refinement
-          result = ModuleSpecs::ClassWithFoo.new.foo
-        end
-
-        result.should == "foo"
       end
     end
 
+    result = nil
 
-    # methods in a subclass have priority over refinements in a superclass
-    it "does not override methods in subclasses" do
-      subclass = Class.new(ModuleSpecs::ClassWithFoo) do
-        def foo; "foo from subclass"; end
+    Module.new do
+      using refinement
+
+      result = [{1 => 2}, {3 => 4}].to_json_format
+    end
+
+    result.should == '[{"1": 2}, {"3": 4}]'
+  end
+
+  it "does not make available methods from another refinement module" do
+    refinery_integer = Module.new do
+      refine Integer do
+        def to_json_format
+          to_s
+        end
       end
+    end
 
+    refinery_array = Module.new do
+      refine Array do
+        def to_json_format
+          "[" + map { |i| i.to_json_format }.join(",") + "]"
+        end
+      end
+    end
+
+    result = nil
+
+    -> () {
+      Module.new do
+        using refinery_integer
+        using refinery_array
+
+        [1, 2].to_json_format
+      end
+    }.should raise_error(NoMethodError)
+  end
+
+  # method lookup:
+  #   * The prepended modules from the refinement for C
+  #   * The refinement for C
+  #   * The included modules from the refinement for C
+  #   * The prepended modules of C
+  #   * C
+  #   * The included modules of C
+  describe "method lookup" do
+    it "looks in the object singleton class first" do
       refinement = Module.new do
-        refine ModuleSpecs::ClassWithFoo do
+        refine ModuleSpecs::ClassWithFoo  do
           def foo; "foo from refinement"; end
         end
       end
@@ -313,305 +217,400 @@ ruby_version_is "2.2" do
       result = nil
       Module.new do
         using refinement
-        result = subclass.new.foo
+
+        obj = ModuleSpecs::ClassWithFoo.new
+        class << obj
+          def foo; "foo from singleton class"; end
+        end
+        result = obj.foo
       end
 
-      result.should == "foo from subclass"
+      result.should == "foo from singleton class"
     end
 
-    context "for methods accesses indirectly" do
-      ruby_version_is "" ... "2.4" do
-        it "is not honored by Kernel#send" do
-          refinement = Module.new do
-            refine ModuleSpecs::ClassWithFoo do
-              def foo; "foo from refinement"; end
-            end
-          end
+    it "looks in prepended modules from the refinement first" do
+      refinement = Module.new do
+        refine ModuleSpecs::ClassWithFoo  do
+          include ModuleSpecs::IncludedModule
+          prepend ModuleSpecs::PrependedModule
 
-          result = nil
-          Module.new do
-            using refinement
-            result = ModuleSpecs::ClassWithFoo.new.send :foo
-          end
-
-          result.should == "foo"
-        end
-
-        it "is not honored by BasicObject#__send__" do
-          refinement = Module.new do
-            refine ModuleSpecs::ClassWithFoo do
-              def foo; "foo from refinement"; end
-            end
-          end
-
-          result = nil
-          Module.new do
-            using refinement
-            result = ModuleSpecs::ClassWithFoo.new.__send__ :foo
-          end
-
-          result.should == "foo"
-        end
-
-        it "is not honored by Symbol#to_proc" do
-          refinement = Module.new do
-            refine Integer do
-              def to_s
-                "(#{super})"
-              end
-            end
-          end
-
-          result = nil
-          Module.new do
-            using refinement
-            result = [1, 2, 3].map(&:to_s)
-          end
-
-          result.should == ["1", "2", "3"]
+          def foo; "foo from refinement"; end
         end
       end
 
-      ruby_version_is "2.4" do
-        it "is honored by Kernel#send" do
-          refinement = Module.new do
-            refine ModuleSpecs::ClassWithFoo do
-              def foo; "foo from refinement"; end
-            end
-          end
+      result = nil
+      Module.new do
+        using refinement
+        result = ModuleSpecs::ClassWithFoo.new.foo
+      end
 
-          result = nil
-          Module.new do
-            using refinement
-            result = ModuleSpecs::ClassWithFoo.new.send :foo
-          end
+      result.should == "foo from prepended module"
+    end
 
-          result.should == "foo from refinement"
-        end
+    it "looks in refinement then" do
+      refinement = Module.new do
+        refine(ModuleSpecs::ClassWithFoo) do
+          include ModuleSpecs::IncludedModule
 
-        it "is honored by BasicObject#__send__" do
-          refinement = Module.new do
-            refine ModuleSpecs::ClassWithFoo do
-              def foo; "foo from refinement"; end
-            end
-          end
-
-          result = nil
-          Module.new do
-            using refinement
-            result = ModuleSpecs::ClassWithFoo.new.__send__ :foo
-          end
-
-          result.should == "foo from refinement"
-        end
-
-        it "is honored by Symbol#to_proc" do
-          refinement = Module.new do
-            refine Integer do
-              def to_s
-                "(#{super})"
-              end
-            end
-          end
-
-          result = nil
-          Module.new do
-            using refinement
-            result = [1, 2, 3].map(&:to_s)
-          end
-
-          result.should == ["(1)", "(2)", "(3)"]
+          def foo; "foo from refinement"; end
         end
       end
 
-      it "is honored by Kernel#binding" do
+      result = nil
+      Module.new do
+        using refinement
+        result = ModuleSpecs::ClassWithFoo.new.foo
+      end
+
+      result.should == "foo from refinement"
+    end
+
+    it "looks in included modules from the refinement then" do
+      refinement = Module.new do
+        refine ModuleSpecs::ClassWithFoo  do
+          include ModuleSpecs::IncludedModule
+        end
+      end
+
+      result = nil
+      Module.new do
+        using refinement
+        result = ModuleSpecs::ClassWithFoo.new.foo
+      end
+
+      result.should == "foo from included module"
+    end
+
+    it "looks in the class then" do
+      refinement = Module.new do
+        refine(ModuleSpecs::ClassWithFoo) { }
+      end
+
+      result = nil
+      Module.new do
+        using refinement
+        result = ModuleSpecs::ClassWithFoo.new.foo
+      end
+
+      result.should == "foo"
+    end
+  end
+
+
+  # methods in a subclass have priority over refinements in a superclass
+  it "does not override methods in subclasses" do
+    subclass = Class.new(ModuleSpecs::ClassWithFoo) do
+      def foo; "foo from subclass"; end
+    end
+
+    refinement = Module.new do
+      refine ModuleSpecs::ClassWithFoo do
+        def foo; "foo from refinement"; end
+      end
+    end
+
+    result = nil
+    Module.new do
+      using refinement
+      result = subclass.new.foo
+    end
+
+    result.should == "foo from subclass"
+  end
+
+  context "for methods accesses indirectly" do
+    ruby_version_is "" ... "2.4" do
+      it "is not honored by Kernel#send" do
         refinement = Module.new do
-          refine String do
+          refine ModuleSpecs::ClassWithFoo do
+            def foo; "foo from refinement"; end
+          end
+        end
+
+        result = nil
+        Module.new do
+          using refinement
+          result = ModuleSpecs::ClassWithFoo.new.send :foo
+        end
+
+        result.should == "foo"
+      end
+
+      it "is not honored by BasicObject#__send__" do
+        refinement = Module.new do
+          refine ModuleSpecs::ClassWithFoo do
+            def foo; "foo from refinement"; end
+          end
+        end
+
+        result = nil
+        Module.new do
+          using refinement
+          result = ModuleSpecs::ClassWithFoo.new.__send__ :foo
+        end
+
+        result.should == "foo"
+      end
+
+      it "is not honored by Symbol#to_proc" do
+        refinement = Module.new do
+          refine Integer do
             def to_s
-              "hello from refinement"
+              "(#{super})"
             end
           end
         end
 
-        klass = Class.new do
+        result = nil
+        Module.new do
           using refinement
+          result = [1, 2, 3].map(&:to_s)
+        end
+
+        result.should == ["1", "2", "3"]
+      end
+    end
+
+    ruby_version_is "2.4" do
+      it "is honored by Kernel#send" do
+        refinement = Module.new do
+          refine ModuleSpecs::ClassWithFoo do
+            def foo; "foo from refinement"; end
+          end
+        end
+
+        result = nil
+        Module.new do
+          using refinement
+          result = ModuleSpecs::ClassWithFoo.new.send :foo
+        end
+
+        result.should == "foo from refinement"
+      end
+
+      it "is honored by BasicObject#__send__" do
+        refinement = Module.new do
+          refine ModuleSpecs::ClassWithFoo do
+            def foo; "foo from refinement"; end
+          end
+        end
+
+        result = nil
+        Module.new do
+          using refinement
+          result = ModuleSpecs::ClassWithFoo.new.__send__ :foo
+        end
+
+        result.should == "foo from refinement"
+      end
+
+      it "is honored by Symbol#to_proc" do
+        refinement = Module.new do
+          refine Integer do
+            def to_s
+              "(#{super})"
+            end
+          end
+        end
+
+        result = nil
+        Module.new do
+          using refinement
+          result = [1, 2, 3].map(&:to_s)
+        end
+
+        result.should == ["(1)", "(2)", "(3)"]
+      end
+    end
+
+    it "is honored by Kernel#binding" do
+      refinement = Module.new do
+        refine String do
+          def to_s
+            "hello from refinement"
+          end
+        end
+      end
+
+      klass = Class.new do
+        using refinement
+
+        def foo
+          "foo".to_s
+        end
+
+        def get_binding
+          binding
+        end
+      end
+
+      result = Kernel.eval("self.foo()", klass.new.get_binding)
+      result.should == "hello from refinement"
+    end
+
+    it "is not honored by Kernel#method" do
+      klass = Class.new
+      refinement = Module.new do
+        refine klass do
+          def foo; end
+        end
+      end
+
+      -> {
+        Module.new do
+          using refinement
+          klass.new.method(:foo)
+        end
+      }.should raise_error(NameError, /undefined method `foo'/)
+    end
+
+    it "is not honored by Kernel#respond_to?" do
+      klass = Class.new
+      refinement = Module.new do
+        refine klass do
+          def foo; end
+        end
+      end
+
+      result = nil
+      Module.new do
+        using refinement
+        result = klass.new.respond_to?(:foo)
+      end
+
+      result.should == false
+    end
+  end
+
+  context "when super is called in a refinement" do
+    it "looks in the included to refinery module" do
+      refinement = Module.new do
+        refine ModuleSpecs::ClassWithFoo  do
+          include ModuleSpecs::IncludedModule
 
           def foo
-            "foo".to_s
-          end
-
-          def get_binding
-            binding
+            super
           end
         end
-
-        result = Kernel.eval("self.foo()", klass.new.get_binding)
-        result.should == "hello from refinement"
       end
 
-      it "is not honored by Kernel#method" do
-        klass = Class.new
-        refinement = Module.new do
-          refine klass do
-            def foo; end
-          end
-        end
-
-        -> {
-          Module.new do
-            using refinement
-            klass.new.method(:foo)
-          end
-        }.should raise_error(NameError, /undefined method `foo'/)
+      result = nil
+      Module.new do
+        using refinement
+        result = ModuleSpecs::ClassWithFoo.new.foo
       end
 
-      it "is not honored by Kernel#respond_to?" do
-        klass = Class.new
-        refinement = Module.new do
-          refine klass do
-            def foo; end
-          end
-        end
-
-        result = nil
-        Module.new do
-          using refinement
-          result = klass.new.respond_to?(:foo)
-        end
-
-        result.should == false
-      end
+      result.should == "foo from included module"
     end
 
-    context "when super is called in a refinement" do
-      it "looks in the included to refinery module" do
-        refinement = Module.new do
-          refine ModuleSpecs::ClassWithFoo  do
-            include ModuleSpecs::IncludedModule
-
-            def foo
-              super
-            end
+    it "looks in the refined class" do
+      refinement = Module.new do
+        refine ModuleSpecs::ClassWithFoo  do
+          def foo
+            super
           end
         end
-
-        result = nil
-        Module.new do
-          using refinement
-          result = ModuleSpecs::ClassWithFoo.new.foo
-        end
-
-        result.should == "foo from included module"
       end
 
-      it "looks in the refined class" do
-        refinement = Module.new do
-          refine ModuleSpecs::ClassWithFoo  do
-            def foo
-              super
-            end
-          end
-        end
-
-        result = nil
-        Module.new do
-          using refinement
-          result = ModuleSpecs::ClassWithFoo.new.foo
-        end
-
-        result.should == "foo"
+      result = nil
+      Module.new do
+        using refinement
+        result = ModuleSpecs::ClassWithFoo.new.foo
       end
 
-      # super in a method of a refinement invokes the method in the refined
-      # class even if there is another refinement which has been activated
-      # in the same context.
-      it "looks in the refined class even if there is another active refinement" do
-        refinement = Module.new do
-          refine ModuleSpecs::ClassWithFoo  do
-            def foo
-              "foo from refinement"
-            end
-          end
-        end
-
-        refinement_with_super = Module.new do
-          refine ModuleSpecs::ClassWithFoo  do
-            def foo
-              super
-            end
-          end
-        end
-
-        result = nil
-        Module.new do
-          using refinement
-          using refinement_with_super
-          result = ModuleSpecs::ClassWithFoo.new.foo
-        end
-
-        result.should == "foo"
-      end
+      result.should == "foo"
     end
 
-    # Refinements are inherited by module inclusion.
-    # That is, using activates all refinements in the ancestors of the specified module.
-    # Refinements in a descendant have priority over refinements in an ancestor.
-    context "module inclusion" do
-      it "activates all refinements from all ancestors" do
-        refinement_included = Module.new do
-          refine Integer do
-            def to_json_format
-              to_s
-            end
+    # super in a method of a refinement invokes the method in the refined
+    # class even if there is another refinement which has been activated
+    # in the same context.
+    it "looks in the refined class even if there is another active refinement" do
+      refinement = Module.new do
+        refine ModuleSpecs::ClassWithFoo  do
+          def foo
+            "foo from refinement"
           end
         end
-
-        refinement = Module.new do
-          include refinement_included
-
-          refine Array do
-            def to_json_format
-              "[" + map { |i| i.to_s }.join(", ") + "]"
-            end
-          end
-        end
-
-        result = nil
-        Module.new do
-          using refinement
-          result = [5.to_json_format, [1, 2, 3].to_json_format]
-        end
-
-        result.should == ["5", "[1, 2, 3]"]
       end
 
-      it "overrides methods of ancestors by methods in descendants" do
-        refinement_included = Module.new do
-          refine Integer do
-            def to_json_format
-              to_s
-            end
+      refinement_with_super = Module.new do
+        refine ModuleSpecs::ClassWithFoo  do
+          def foo
+            super
           end
         end
-
-        refinement = Module.new do
-          include refinement_included
-
-          refine Integer do
-            def to_json_format
-              "hello from refinement"
-            end
-          end
-        end
-
-        result = nil
-        Module.new do
-          using refinement
-          result = 5.to_json_format
-        end
-
-        result.should == "hello from refinement"
       end
+
+      result = nil
+      Module.new do
+        using refinement
+        using refinement_with_super
+        result = ModuleSpecs::ClassWithFoo.new.foo
+      end
+
+      result.should == "foo"
+    end
+  end
+
+  # Refinements are inherited by module inclusion.
+  # That is, using activates all refinements in the ancestors of the specified module.
+  # Refinements in a descendant have priority over refinements in an ancestor.
+  context "module inclusion" do
+    it "activates all refinements from all ancestors" do
+      refinement_included = Module.new do
+        refine Integer do
+          def to_json_format
+            to_s
+          end
+        end
+      end
+
+      refinement = Module.new do
+        include refinement_included
+
+        refine Array do
+          def to_json_format
+            "[" + map { |i| i.to_s }.join(", ") + "]"
+          end
+        end
+      end
+
+      result = nil
+      Module.new do
+        using refinement
+        result = [5.to_json_format, [1, 2, 3].to_json_format]
+      end
+
+      result.should == ["5", "[1, 2, 3]"]
+    end
+
+    it "overrides methods of ancestors by methods in descendants" do
+      refinement_included = Module.new do
+        refine Integer do
+          def to_json_format
+            to_s
+          end
+        end
+      end
+
+      refinement = Module.new do
+        include refinement_included
+
+        refine Integer do
+          def to_json_format
+            "hello from refinement"
+          end
+        end
+      end
+
+      result = nil
+      Module.new do
+        using refinement
+        result = 5.to_json_format
+      end
+
+      result.should == "hello from refinement"
     end
   end
 end
+

--- a/core/module/refine_spec.rb
+++ b/core/module/refine_spec.rb
@@ -1,25 +1,23 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 
-ruby_version_is "2.0.0" do
+ruby_version_is "2.2" do
   describe "Module#refine" do
-    it "runs its block in an anonymous Module" do
-      selves = nil
+    it "runs its block in an anonymous module" do
+      inner_self = nil
       mod = Module.new do
-        outer_self = self
         refine String do
-          selves = [outer_self, self]
+          inner_self = self
         end
       end
 
-      selves[0].should == mod
-      selves[0].should_not == selves[1]
-      selves[1].should be_kind_of(Module)
+      mod.should_not == inner_self
+      inner_self.should be_kind_of(Module)
+      inner_self.name.should == nil
     end
 
     it "uses the same anonymous module for future refines of the same class" do
       selves = []
       mod = Module.new do
-        selves << self
         refine String do
           selves << self
         end
@@ -31,10 +29,10 @@ ruby_version_is "2.0.0" do
         end
       end
 
-      selves[1].should == selves[2]
+      selves[0].should == selves[1]
     end
 
-    it "adds methods defined in its block to the anon module's public instance methods" do
+    it "adds methods defined in its block to the anonymous module's public instance methods" do
       inner_self = nil
       mod = Module.new do
         refine String do
@@ -48,6 +46,18 @@ ruby_version_is "2.0.0" do
       inner_self.public_instance_methods.should include(:blah)
     end
 
+    it "returns created anonymous module" do
+      inner_self = nil
+      result = nil
+      mod = Module.new do
+        result = refine String do
+          inner_self = self
+        end
+      end
+
+      result.should == inner_self
+    end
+
     it "raises ArgumentError if not passed an argument" do
       lambda do
         Module.new do
@@ -56,10 +66,18 @@ ruby_version_is "2.0.0" do
       end.should raise_error(ArgumentError)
     end
 
-    it "raises TypeError if not passed a class or module" do
+    it "raises TypeError if not passed a class" do
       lambda do
         Module.new do
-          refine('foo') {}
+          refine("foo") {}
+        end
+      end.should raise_error(TypeError)
+    end
+
+    it "raises TypeError if passed a module" do
+      lambda do
+        Module.new do
+          refine(Enumerable) {}
         end
       end.should raise_error(TypeError)
     end
@@ -76,20 +94,19 @@ ruby_version_is "2.0.0" do
       result = nil
       Module.new do
         refine(String) do
-          def foo; 'foo'; end
-          result = 'hello'.foo
+          def foo; "foo"; end
+          result = "hello".foo
         end
       end
-      result.should == 'foo'
+      result.should == "foo"
     end
 
     it "doesn't apply refinements outside the refine block" do
       Module.new do
-        refine(String) {def foo; 'foo'; end}
-        lambda do
-          'hello'.foo
-        end
-        should raise_error(NoMethodError)
+        refine(String) {def foo; "foo"; end}
+        -> () {
+          "hello".foo
+        }.should raise_error(NoMethodError)
       end
     end
 
@@ -98,7 +115,7 @@ ruby_version_is "2.0.0" do
         refine(String) {def foo; 'foo'; end}
       end
 
-      lambda {'hello'.foo}.should raise_error(NoMethodError)
+      lambda {"hello".foo}.should raise_error(NoMethodError)
     end
   end
 end

--- a/core/module/using_spec.rb
+++ b/core/module/using_spec.rb
@@ -1,0 +1,276 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../fixtures/using', __FILE__)
+
+describe "Module#using" do
+  it "imports class refinements from module into the current class/module" do
+    refinement = Module.new do
+      refine Integer do
+        def foo; "foo"; end
+      end
+    end
+
+    result = nil
+    Module.new do
+      using refinement
+      result = 1.foo
+    end
+
+    result.should == "foo"
+  end
+
+  it "accepts module as argument" do
+    refinement = Module.new do
+      refine Integer do
+        def foo; "foo"; end
+      end
+    end
+
+    -> () {
+      Module.new do
+        using refinement
+      end
+    }.should_not raise_error
+  end
+
+  it "accepts module without refinements" do
+    mod = Module.new
+
+    -> () {
+      Module.new do
+        using mod
+      end
+    }.should_not raise_error
+  end
+
+  it "does not accept class" do
+    klass = Class.new
+
+    -> () {
+      Module.new do
+        using klass
+      end
+    }.should raise_error(TypeError)
+  end
+
+  it "raises TypeError if passed something other than module" do
+    -> () {
+      Module.new do
+        using "foo"
+      end
+    }.should raise_error(TypeError)
+  end
+
+  it "returns self" do
+    refinement = Module.new
+
+    result = nil
+    mod = Module.new do
+      result = using refinement
+    end
+
+    result.should equal(mod)
+  end
+
+  it "works in classes too" do
+    refinement = Module.new do
+      refine Integer do
+        def foo; "foo"; end
+      end
+    end
+
+    result = nil
+    Class.new do
+      using refinement
+      result = 1.foo
+    end
+
+    result.should == "foo"
+  end
+
+  it "raises error in method scope" do
+    mod = Module.new do
+      def self.foo
+        using ModuleSpecs::EmptyRefinement
+      end
+    end
+
+    -> () {
+      mod.foo
+    }.should raise_error(RuntimeError, /Module#using is not permitted in methods/)
+  end
+
+  it "activates refinement even for existed objects" do
+    result = nil
+
+    Module.new do
+      klass = Class.new do
+        def foo; "foo"; end
+      end
+
+      refinement = Module.new do
+        refine klass do
+          def foo; "foo from refinement"; end
+        end
+      end
+
+      obj = klass.new
+      using refinement
+      result = obj.foo
+    end
+
+    result.should == "foo from refinement"
+  end
+
+  it "activates updates when refinement reopens later" do
+    result = nil
+
+    Module.new do
+      klass = Class.new do
+        def foo; "foo"; end
+      end
+
+      refinement = Module.new do
+        refine klass do
+          def foo; "foo from refinement"; end
+        end
+      end
+
+      using refinement
+
+      refinement.class_eval do
+        refine klass do
+          def foo; "foo from reopened refinement"; end
+        end
+      end
+
+      obj = klass.new
+      result = obj.foo
+    end
+
+    result.should == "foo from reopened refinement"
+  end
+
+  describe "scope of refinement" do
+    it "is active until the end of current class/module" do
+      ScratchPad.record []
+
+      Module.new do
+        Class.new do
+          using ModuleSpecs::RefinementForStringToS
+          ScratchPad << "1".to_s
+        end
+
+        ScratchPad << "1".to_s
+      end
+
+      ScratchPad.recorded.should == ["hello from refinement", "1"]
+    end
+
+    # Refinements are lexical in scope.
+    # Refinements are only active within a scope after the call to using.
+    # Any code before the using statement will not have the refinement activated.
+    it "is not active before the `using` call" do
+      ScratchPad.record []
+
+      Module.new do
+        Class.new do
+          ScratchPad << "1".to_s
+          using ModuleSpecs::RefinementForStringToS
+          ScratchPad << "1".to_s
+        end
+      end
+
+      ScratchPad.recorded.should == ["1", "hello from refinement"]
+    end
+
+    # If you call a method that is defined outside the current scope
+    # the refinement will be deactivated
+    it "is not active for code defined outside the current scope" do
+      result = nil
+
+      Module.new do
+        klass = Class.new do
+          def foo; "foo"; end
+        end
+
+        refinement = Module.new do
+          refine klass do
+            def foo; "foo from refinement"; end
+          end
+        end
+
+        def self.call_foo(c)
+          c.foo
+        end
+
+        using refinement
+
+        result = call_foo(klass.new)
+      end
+
+      result.should == "foo"
+    end
+
+    # If a method is defined in a scope where a refinement is active
+    # the refinement will be active when the method is called.
+    it "is active for method defined in a scope wherever it's called" do
+      klass = Class.new do
+        def foo; "foo"; end
+      end
+
+      mod = Module.new do
+        refinement = Module.new do
+          refine klass do
+            def foo; "foo from refinement"; end
+          end
+        end
+
+        using refinement
+
+        def self.call_foo(c)
+          c.foo
+        end
+      end
+
+      c = klass.new
+      mod.call_foo(c).should == "foo from refinement"
+    end
+
+    it "is not active if `using` call is not evaluated" do
+      result = nil
+
+      Module.new do
+        if false
+          using ModuleSpecs::RefinementForStringToS
+        end
+        result = "1".to_s
+      end
+
+      result.should == "1"
+    end
+
+    # The refinements in module are not activated automatically
+    # if the class is reopened later
+    it "is not active when class/module reopens" do
+      refinement = Module.new do
+        refine String do
+          def to_s
+            "hello from refinement"
+          end
+        end
+      end
+
+      result = []
+      klass = Class.new do
+        using refinement
+        result << "1".to_s
+      end
+
+      klass.class_eval do
+        result << "1".to_s
+      end
+
+      result.should == ["hello from refinement", "1"]
+    end
+  end
+end


### PR DESCRIPTION
Restore old specs for main#using and Module#refine. Add new specs for Module#using and Module#refine. Also add specs for Ruby 2.4.

New specs are based on [documentation](http://ruby-doc.org/core-2.2.0/doc/syntax/refinements_rdoc.html)

Related issue https://github.com/ruby/spec/issues/514