### PR TITLE
test instantiating logger with keyword arguments

### DIFF
--- a/library/logger/logger/new_spec.rb
+++ b/library/logger/logger/new_spec.rb
@@ -60,4 +60,46 @@ describe "Logger#new" do
     f1.close
     rm_r path, "#{path}.0"
   end
+
+  ruby_version_is "2.4" do
+    it "receives level symbol as keyword argument" do
+      logger = Logger.new(STDERR, level: :info)
+      logger.level.should == Logger::INFO
+    end
+
+    it "receives level as keyword argument" do
+      logger = Logger.new(STDERR, level: Logger::INFO)
+      logger.level.should == Logger::INFO
+    end
+
+    it "receives progname as keyword argument" do
+      progname = "progname"
+
+      logger = Logger.new(STDERR, progname: progname)
+      logger.progname.should == progname
+    end
+
+    it "receives datetime_format as keyword argument" do
+      datetime_format = "%H:%M:%S"
+
+      logger = Logger.new(STDERR, datetime_format: datetime_format)
+      logger.datetime_format.should == datetime_format
+    end
+
+    it "receives formatter as keyword argument" do
+      formatter = Class.new do
+        def call(_severity, _time, _progname, _msg); end
+      end.new
+
+      logger = Logger.new(STDERR, formatter: formatter)
+      logger.formatter.should == formatter
+    end
+
+    it "receives shift_period_suffix as keyword argument" do
+      shift_period_suffix = "%Y-%m-%d"
+
+      lambda { Logger.new(STDERR, shift_period_suffix: shift_period_suffix) }.should_not raise_error
+    end
+  end
+
 end


### PR DESCRIPTION
Allow specifying logger parameters in constructor: `level`, `progname`, `datetime_format`, `formatter`, `shift_period_suffix`.

Related issue #473 