### PR TITLE
Update RuboCop to 0.51.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,7 +22,10 @@ Lint/BooleanSymbol:
 Lint/InterpolationCheck:
   Enabled: false
 
-Lint/LiteralInCondition:
+Lint/LiteralAsCondition:
+  Enabled: false
+
+Lint/UnneededRequireStatement:
   Enabled: false
 
 Lint/RescueWithoutErrorClass:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 install:
   - git clone https://github.com/ruby/mspec.git ../mspec
 script:
-  - if [ -n "$RUBOCOP" ]; then gem install rubocop -v 0.50.0 && rubocop; fi
+  - if [ -n "$RUBOCOP" ]; then gem install rubocop -v 0.51.0 && rubocop; fi
   - ../mspec/bin/mspec $MSPEC_OPTS
 matrix:
   include:


### PR DESCRIPTION
https://github.com/bbatsov/rubocop/releases/tag/v0.51.0


- Rename Lint/LiteralInCondition to Lint/LiteralAsCondition.
- Make Lint/UnneededRequireStatement, that is added in 0.51.0, to disable.




`Lint/UnneededRequireStatement` warns about unneeded `require`.
For example, `enumerator`, `thread`, `rational` and `complex` is already required.

```bash
$ ruby -ve 'p(require "thread")'
ruby 2.4.2p198 (2017-09-14 revision 59899) [x86_64-linux]
false
```

This cop is useful for general use. But I think the cop should be disabled.
Because, this project runs with CRuby, JRuby and other implementations.
And I guess not all implementations load these libraries.
So I think removing these `require` is a little dangerous.