### PR TITLE
Array#append specs

### DIFF
--- a/core/array/append_spec.rb
+++ b/core/array/append_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
+require File.expand_path('../shared/push', __FILE__)
 
 describe "Array#<<" do
   it "pushes the object onto the end of the array" do
@@ -31,5 +32,11 @@ describe "Array#<<" do
 
   it "raises a RuntimeError on a frozen array" do
     lambda { ArraySpecs.frozen_array << 5 }.should raise_error(RuntimeError)
+  end
+end
+
+ruby_version_is "2.5" do
+  describe "Array#append" do
+    it_behaves_like(:array_push, :append)
   end
 end

--- a/core/array/push_spec.rb
+++ b/core/array/push_spec.rb
@@ -1,36 +1,7 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
+require File.expand_path('../shared/push', __FILE__)
 
 describe "Array#push" do
-  it "appends the arguments to the array" do
-    a = [ "a", "b", "c" ]
-    a.push("d", "e", "f").should equal(a)
-    a.push().should == ["a", "b", "c", "d", "e", "f"]
-    a.push(5)
-    a.should == ["a", "b", "c", "d", "e", "f", 5]
-
-    a = [0, 1]
-    a.push(2)
-    a.should == [0, 1, 2]
-  end
-
-  it "isn't confused by previous shift" do
-    a = [ "a", "b", "c" ]
-    a.shift
-    a.push("foo")
-    a.should == ["b", "c", "foo"]
-  end
-
-  it "properly handles recursive arrays" do
-    empty = ArraySpecs.empty_recursive_array
-    empty.push(:last).should == [empty, :last]
-
-    array = ArraySpecs.recursive_array
-    array.push(:last).should == [1, 'two', 3.0, array, array, array, array, array, :last]
-  end
-
-  it "raises a RuntimeError on a frozen array" do
-    lambda { ArraySpecs.frozen_array.push(1) }.should raise_error(RuntimeError)
-    lambda { ArraySpecs.frozen_array.push }.should raise_error(RuntimeError)
-  end
+  it_behaves_like(:array_push, :push)
 end

--- a/core/array/shared/push.rb
+++ b/core/array/shared/push.rb
@@ -1,0 +1,33 @@
+describe :array_push, shared: true do
+  it "appends the arguments to the array" do
+    a = [ "a", "b", "c" ]
+    a.send(@method, "d", "e", "f").should equal(a)
+    a.send(@method).should == ["a", "b", "c", "d", "e", "f"]
+    a.send(@method, 5)
+    a.should == ["a", "b", "c", "d", "e", "f", 5]
+
+    a = [0, 1]
+    a.send(@method, 2)
+    a.should == [0, 1, 2]
+  end
+
+  it "isn't confused by previous shift" do
+    a = [ "a", "b", "c" ]
+    a.shift
+    a.send(@method, "foo")
+    a.should == ["b", "c", "foo"]
+  end
+
+  it "properly handles recursive arrays" do
+    empty = ArraySpecs.empty_recursive_array
+    empty.send(@method, :last).should == [empty, :last]
+
+    array = ArraySpecs.recursive_array
+    array.send(@method, :last).should == [1, 'two', 3.0, array, array, array, array, array, :last]
+  end
+
+  it "raises a RuntimeError on a frozen array" do
+    lambda { ArraySpecs.frozen_array.send(@method, 1) }.should raise_error(RuntimeError)
+    lambda { ArraySpecs.frozen_array.send(@method) }.should raise_error(RuntimeError)
+  end
+end


### PR DESCRIPTION
(New alias in 2.5)

Compared to #538 there is one additional step necessary, viz. renaming the already existing `append_spec.rb`, which contains the specs for Array#<<. I renamed to `shovel_append_spec.rb`, but if you have a better idea, I‘m ok with amending the PR.