### PR TITLE
Fix failure when running on btrfs

### DIFF
--- a/core/file/stat/blocks_spec.rb
+++ b/core/file/stat/blocks_spec.rb
@@ -11,10 +11,10 @@ describe "File::Stat#blocks" do
   end
 
   platform_is_not :windows do
-    it "returns the blocks of a File::Stat object" do
+    it "returns a non-negative integer" do
       st = File.stat(@file)
       st.blocks.is_a?(Integer).should == true
-      st.blocks.should > 0
+      st.blocks.should >= 0
     end
   end
 

--- a/shared/file/zero.rb
+++ b/shared/file/zero.rb
@@ -55,17 +55,9 @@ describe :file_zero, shared: true do
     end
   end
 
-  platform_is_not :windows do
-    it "returns false for a directory" do
-      @object.send(@method, @dir).should == false
-    end
-  end
-
-  platform_is :windows do
-    # see http://redmine.ruby-lang.org/issues/show/449 for background
-    it "returns true for a directory" do
-      @object.send(@method, @dir).should == true
-    end
+  # See https://bugs.ruby-lang.org/issues/449 for background
+  it "returns true or false for a directory" do
+    @object.send(@method, @dir).should be_true_or_false
   end
 end
 


### PR DESCRIPTION
Fix the following failing specs:

```
k@hibiscus /work/stdgems/spec $ ../mspec/bin/mspec
$ ruby /work/stdgems/mspec/bin/mspec-run
ruby 2.5.0dev (2017-10-30 master 60579) [x86_64-linux]
                                                                                             
1)
File.empty? returns false for a directory FAILED
Expected true
 to equal false

/work/stdgems/spec/shared/file/zero.rb:60:in `block (3 levels) in <top (required)>'
/work/stdgems/spec/core/file/empty_spec.rb:4:in `<top (required)>'
                                                                                             
2)
File::Stat#blocks returns the blocks of a File::Stat object FAILED
Expected 0
 to be greater than 0

/work/stdgems/spec/core/file/stat/blocks_spec.rb:17:in `block (3 levels) in <top (required)>'
/work/stdgems/spec/core/file/stat/blocks_spec.rb:3:in `<top (required)>'
                                                                                             
3)
File::Stat#zero? returns false for a directory FAILED
Expected true
 to equal false

/work/stdgems/spec/shared/file/zero.rb:60:in `block (3 levels) in <top (required)>'
/work/stdgems/spec/core/file/stat/zero_spec.rb:5:in `<top (required)>'
                                                                                             
4)
File.zero? returns false for a directory FAILED
Expected true
 to equal false

/work/stdgems/spec/shared/file/zero.rb:60:in `block (3 levels) in <top (required)>'
/work/stdgems/spec/core/file/zero_spec.rb:4:in `<top (required)>'
                                                                                             
5)
FileTest.zero? returns false for a directory FAILED
Expected true
 to equal false

/work/stdgems/spec/shared/file/zero.rb:60:in `block (3 levels) in <top (required)>'
/work/stdgems/spec/core/filetest/zero_spec.rb:4:in `<top (required)>'
[\ | ==================100%================== | 00:00:00]      5F      0E .

Finished in 36.525742 seconds

3592 files, 26977 examples, 203303 expectations, 5 failures, 0 errors, 0 tagged
```