### PR TITLE
Rescue in method arguments

### DIFF
--- a/language/rescue_spec.rb
+++ b/language/rescue_spec.rb
@@ -291,10 +291,20 @@ describe "The rescue keyword" do
     end.should == :expected
   end
 
+  ruby_version_is ""..."2.4" do
+    it "fails when using 'rescue' in method arguments" do
+      lambda { eval '1.+ (1 rescue 1)' }.should raise_error(SyntaxError)
+    end
+  end
+
   ruby_version_is "2.4" do
     it "allows 'rescue' in method arguments" do
       two = eval '1.+ (raise("Error") rescue 1)'
       two.should == 2
+    end
+
+    it "requires the 'rescue' in method arguments to be wrapped in parens" do
+      lambda { eval '1.+(1 rescue 1)' }.should raise_error(SyntaxError)
     end
   end
 end


### PR DESCRIPTION
Follow-up of https://github.com/ruby/spec/pull/509#issuecomment-338435352

I added a spec for prior Ruby versions that ensure that the syntax isn't supported. I also added the suggested spec regarding the fact that parenthesis must still be around the `rescue` expression.

I generally don't like testing absence of behavior, which is both those new specs are doing. I'm not sure I would merge something like that... Do you think it is appropriate?

Regarding the call of block and lambdas, this kind of syntax works:

``` ruby
f = ->(a) { 1 + a }
f.call (raise("Error") rescue 1)
```

After all it is a method call. I'm confused now about what @andrykonchin meant in its comment. If you could tell me more about it here, that would be very appreciated.