### PR TITLE
Fix typos

### DIFF
--- a/core/file/chown_spec.rb
+++ b/core/file/chown_spec.rb
@@ -91,17 +91,17 @@ describe "File#chown" do
   as_superuser do
     platform_is :windows do
       it "does not modify the owner id of the file" do
-        File.chown 0, nil, @fname
-        File.stat(@fname).uid.should == 0
-        File.chown 501, nil, @fname
-        File.stat(@fname).uid.should == 0
+        @file.chown 0, nil
+        @file.stat.uid.should == 0
+        @file.chown 501, nil
+        @file.stat.uid.should == 0
       end
 
       it "does not modify the group id of the file" do
-        File.chown nil, 0, @fname
-        File.stat(@fname).gid.should == 0
-        File.chown nil, 501, @fname
-        File.stat(@fname).gid.should == 0
+        @file.chown nil, 0
+        @file.stat.gid.should == 0
+        @file.chown nil, 501
+        @file.stat.gid.should == 0
       end
     end
 


### PR DESCRIPTION
Use `File#chown` instead of `File.chown` in `describe "File#chown"`