### PR TITLE
[Ruby 2.5] Hash#transform_keys

### DIFF
--- a/core/hash/transform_keys_spec.rb
+++ b/core/hash/transform_keys_spec.rb
@@ -1,0 +1,115 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+ruby_version_is "2.5" do
+  describe "Hash#transform_keys" do
+    before :each do
+      @hash = { a: 1, b: 2, c: 3 }
+    end
+
+    it "returns new hash" do
+      ret = @hash.transform_keys(&:upcase)
+      ret.should_not equal(@hash)
+      ret.should be_an_instance_of(Hash)
+    end
+
+    it "sets the result as transformed keys with the given block" do
+      @hash.transform_keys(&:upcase).should == { A: 1, B: 2, C: 3 }
+    end
+
+    it "keeps last pair if new keys conflict" do
+      @hash.transform_keys { |_| :a }.should == { a: 3 }
+    end
+
+    it "returns nil if we break from the block" do
+      @hash.transform_keys do |_|
+        break
+      end.should == nil
+    end
+
+    it "makes both hashes to share values" do
+      value = [1, 2, 3]
+      new_hash = { a: value }.transform_keys(&:upcase)
+      new_hash[:A].should equal(value)
+    end
+
+    context "when no block is given" do
+      it "returns a sized Enumerator" do
+        enumerator = @hash.transform_keys
+        enumerator.should be_an_instance_of(Enumerator)
+        enumerator.size.should == @hash.size
+        enumerator.each(&:upcase).should == { A: 1, B: 2, C: 3 }
+      end
+    end
+
+    it "returns a Hash instance, even on subclasses" do
+      klass = Class.new(Hash)
+      h = klass.new
+      h[:foo] = 42
+      r = h.transform_keys(&:to_s)
+      r['foo'].should == 42
+      r[:foo].should == nil
+      r.class.should == Hash
+    end
+  end
+
+  describe "Hash#transform_keys!" do
+    before :each do
+      @hash = { a: 1, b: 2, c: 3 }
+      @initial_pairs = @hash.dup
+    end
+
+    it "returns self" do
+      @hash.transform_keys!(&:upcase).should equal(@hash)
+    end
+
+    it "updates self as transformed keys with the given block" do
+      @hash.transform_keys!(&:upcase).should == { A: 1, B: 2, C: 3 }
+    end
+
+    it "partially modifies the contents if we broke from the block" do
+      @hash.transform_keys! do |k|
+        break if k == :c
+        k.upcase
+      end
+      @hash.should == { A: 1, B: 2, c: 3}
+    end
+
+    it "keeps later pair if new keys conflict" do
+      @hash.transform_keys! { |_| :a }.should == { a: 3 }
+    end
+
+    it "does not prevent conflicts between new keys and old ones" do
+      @hash.transform_keys!(&:succ).should == { d: 1 }
+    end
+
+    context "when no block is given" do
+      it "returns a sized Enumerator" do
+        enumerator = @hash.transform_keys!
+        enumerator.should be_an_instance_of(Enumerator)
+        enumerator.size.should == @hash.size
+        enumerator.each(&:upcase).should == { A: 1, B: 2, C: 3 }
+      end
+    end
+
+    describe "on frozen instance" do
+      before :each do
+        @hash.freeze
+      end
+
+      it "raises a RuntimeError on an empty hash" do
+        ->{ {}.freeze.transform_keys!(&:upcase) }.should raise_error(RuntimeError)
+      end
+
+      it "keeps pairs and raises a RuntimeError" do
+        ->{ @hash.transform_keys!(&:upcase) }.should raise_error(RuntimeError)
+        @hash.should == @initial_pairs
+      end
+
+      context "when no block is given" do
+        it "does not raise an exception" do
+          @hash.transform_keys!.should be_an_instance_of(Enumerator)
+        end
+      end
+    end
+  end
+end

--- a/core/hash/transform_values_spec.rb
+++ b/core/hash/transform_values_spec.rb
@@ -16,6 +16,19 @@ ruby_version_is "2.4" do
       @hash.transform_values(&:succ).should ==  { a: 2, b: 3, c: 4 }
     end
 
+    it "makes both hashes to share keys" do
+      key = [1, 2, 3]
+      new_hash = { key => 1 }.transform_values(&:succ)
+      new_hash[key].should == 2
+      new_hash.keys[0].should equal(key)
+    end
+
+    it "returns nil if we break from the block" do
+      @hash.transform_values do |_|
+        break
+      end.should == nil
+    end
+
     context "when no block is given" do
       it "returns a sized Enumerator" do
         enumerator = @hash.transform_values
@@ -47,7 +60,7 @@ ruby_version_is "2.4" do
 
     it "updates self as transformed values with the given block" do
       @hash.transform_values!(&:succ)
-      @hash.should ==  { a: 2, b: 3, c: 4 }
+      @hash.should == { a: 2, b: 3, c: 4 }
     end
 
     it "partially modifies the contents if we broke from the block" do


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/13583

Specs are based on the specs for `Hash#transform_values`.
There are similar specs in `Rails` [repository](https://github.com/rails/rails/blob/5-1-stable/activesupport/test/core_ext/hash/transform_keys_test.rb). Not sure we should just copy-past them