### PR TITLE
[Ruby 2.5] Time#at receives 3rd argument which specifies the unit of 2nd argument

### DIFF
--- a/core/time/at_spec.rb
+++ b/core/time/at_spec.rb
@@ -142,4 +142,60 @@ describe "Time.at" do
       lambda { Time.at(Time.now, 500000) }.should raise_error(TypeError)
     end
   end
+
+  ruby_version_is "2.5" do
+    describe "passed [Time, Numeric, format]" do
+      context ":nanosecond format" do
+        it "traits second argument as nanoseconds" do
+          Time.at(0, 123456789, :nanosecond).nsec.should == 123456789
+        end
+      end
+
+      context ":nsec format" do
+        it "traits second argument as nanoseconds" do
+          Time.at(0, 123456789, :nsec).nsec.should == 123456789
+        end
+      end
+
+      context ":microsecond format" do
+        it "traits second argument as microseconds" do
+          Time.at(0, 123456, :microsecond).nsec.should == 123456000
+        end
+      end
+
+      context ":usec format" do
+        it "traits second argument as microseconds" do
+          Time.at(0, 123456, :usec).nsec.should == 123456000
+        end
+      end
+
+      context ":millisecond format" do
+        it "traits second argument as milliseconds" do
+          Time.at(0, 123, :millisecond).nsec.should == 123000000
+        end
+      end
+
+      context "not supported format" do
+        it "raises ArgumentError" do
+          ->() { Time.at(0, 123456, 2) }.should raise_error(ArgumentError)
+          ->() { Time.at(0, 123456, nil) }.should raise_error(ArgumentError)
+          ->() { Time.at(0, 123456, :invalid) }.should raise_error(ArgumentError)
+        end
+
+        it "does not try to convert format to Symbol with #to_sym" do
+          format = "usec"
+          format.should_not_receive(:to_sym)
+          -> () { Time.at(0, 123456, format) }.should raise_error(ArgumentError)
+        end
+      end
+
+      it "supports Float second argument" do
+        Time.at(0, 123456789.500, :nanosecond).nsec.should == 123456789
+        Time.at(0, 123456789.500, :nsec).nsec.should == 123456789
+        Time.at(0, 123456.500, :microsecond).nsec.should == 123456500
+        Time.at(0, 123456.500, :usec).nsec.should == 123456500
+        Time.at(0, 123.500, :millisecond).nsec.should == 123500000
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/13919

Specs are based on https://github.com/ruby/ruby/blob/trunk/test/ruby/test_time.rb#L239-L248