### PR TITLE
[Ruby 2.5] Add spec for String#start_with? supporting regexp

### DIFF
--- a/core/string/start_with_spec.rb
+++ b/core/string/start_with_spec.rb
@@ -51,5 +51,26 @@ describe "String#start_with?" do
       "foxes are 1337".start_with?(regexp).should be_false
       "chunky\n12bacon".start_with?(/12/).should be_false
     end
+
+    it "supports regexps with ^ and $ modifiers" do
+      regexp1 = /^\d{2}/
+      regexp2 = /\d{2}$/
+      "12test".start_with?(regexp1).should be_true
+      "test12".start_with?(regexp1).should be_false
+      "12test".start_with?(regexp2).should be_false
+      "test12".start_with?(regexp2).should be_false
+    end
+
+    it "sets Regexp.last_match if it returns true" do
+      regexp = /test-(\d+)/
+      "test-1337".start_with?(regexp).should be_true
+      Regexp.last_match.should_not be_nil
+      Regexp.last_match[1].should == "1337"
+      $1.should == "1337"
+
+      "test-asdf".start_with?(regexp).should be_false
+      Regexp.last_match.should be_nil
+      $1.should be_nil
+    end
   end
 end

--- a/core/string/start_with_spec.rb
+++ b/core/string/start_with_spec.rb
@@ -42,4 +42,14 @@ describe "String#start_with?" do
   it "works for multibyte strings" do
     "céréale".start_with?("cér").should be_true
   end
+
+  ruby_version_is "2.5" do
+    it "supports regexps" do
+      regexp = /[h1]/
+      "hello".start_with?(regexp).should be_true
+      "1337".start_with?(regexp).should be_true
+      "foxes are 1337".start_with?(regexp).should be_false
+      "chunky\n12bacon".start_with?(/12/).should be_false
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a spec for _[Feature #13712](https://bugs.ruby-lang.org/issues/13712): String#start_with? with regexp_.