### PR TITLE
[Ruby 2.5] Add specs for Hash#slice

### DIFF
--- a/core/hash/slice_spec.rb
+++ b/core/hash/slice_spec.rb
@@ -1,0 +1,17 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+ruby_version_is "2.5" do
+  describe "Hash#slice" do
+    before :each do
+      @hsh = { a: 1, b: 2, c: 3 }
+    end
+
+    it "returns a Hash of the sliced keys" do
+      @hsh.slice(:a, :c).should == { a: 1, c: 3 }
+    end
+
+    it "returns only the keys of the original hash" do
+      @hsh.slice(:a, :chunky_bacon).should == { a: 1 }
+    end
+  end
+end


### PR DESCRIPTION
This PR adds specs for _[Feature #8499](https://bugs.ruby-lang.org/issues/8499): Hash#slice_.