### PR TITLE
[Ruby 2.5] Add specs for String#delete_prefix and String#delete_suffix

### DIFF
--- a/core/string/delete_prefix_spec.rb
+++ b/core/string/delete_prefix_spec.rb
@@ -1,0 +1,36 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+ruby_version_is "2.5" do
+  describe "String#delete_prefix" do
+    it "returns a new string with a given string removed from the beginning" do
+      s = "chunky bacon"
+      s.delete_prefix("chunky").should == " bacon"
+      s.should == "chunky bacon"
+
+      s.delete_prefix("bacon").should == "chunky bacon"
+    end
+  end
+end
+
+ruby_version_is "2.5" do
+  describe "String#delete_prefix!" do
+    it "modifies self in place and returns self" do
+      s = "chunky bacon"
+      s.delete_prefix!("chunky").should equal(s)
+      s.should == " bacon"
+    end
+
+    it "returns nil if no modifications were made" do
+      s = "chunky bacon"
+      s.delete_prefix!("bacon").should == nil
+      s.should == "chunky bacon"
+    end
+
+    it "raises a RuntimeError when self is frozen" do
+      s = "chunky bacon".freeze
+
+      lambda { s.delete_prefix!("chunky") }.should raise_error(RuntimeError)
+      lambda { s.delete_prefix!("bacon")  }.should raise_error(RuntimeError)
+    end
+  end
+end

--- a/core/string/delete_suffix_spec.rb
+++ b/core/string/delete_suffix_spec.rb
@@ -1,0 +1,36 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+ruby_version_is "2.5" do
+  describe "String#delete_suffix" do
+    it "returns a new string with a given string removed from the end" do
+      s = "chunky bacon"
+      s.delete_suffix("bacon").should == "chunky "
+      s.should == "chunky bacon"
+
+      s.delete_suffix("chunky").should == "chunky bacon"
+    end
+  end
+end
+
+ruby_version_is "2.5" do
+  describe "String#delete_suffix!" do
+    it "modifies self in place and returns self" do
+      s = "chunky bacon"
+      s.delete_suffix!("bacon").should equal(s)
+      s.should == "chunky "
+    end
+
+    it "returns nil if no modifications were made" do
+      s = "chunky bacon"
+      s.delete_suffix!("chunky").should == nil
+      s.should == "chunky bacon"
+    end
+
+    it "raises a RuntimeError when self is frozen" do
+      s = "chunky bacon".freeze
+
+      lambda { s.delete_suffix!("chunky") }.should raise_error(RuntimeError)
+      lambda { s.delete_suffix!("bacon")  }.should raise_error(RuntimeError)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds specs for _[Feature #12694](https://bugs.ruby-lang.org/issues/12694): `String#delete_prefix` + `String#delete_prefix!`_ and _[Feature #13665](https://bugs.ruby-lang.org/issues/13665): `String#delete_suffix` + `String#delete_suffix!`_.