### PR TITLE
[Ruby 2.5] Top-level constant look-up is removed

### DIFF
--- a/language/constants_spec.rb
+++ b/language/constants_spec.rb
@@ -425,6 +425,26 @@ describe "Constant resolution within a singleton class (class << obj)" do
   end
 end
 
+describe "top-level constant lookup" do
+  ruby_version_is "" ... "2.5" do
+    it "searches Object successfully when starts from class" do
+      ->() {
+        String::Hash.should == Hash
+      }.should complain(/toplevel constant Hash referenced by/)
+    end
+  end
+
+  it "searches Object unsuccessfully when starts from module" do
+    ->() { Enumerable::Hash }.should raise_error(NameError)
+  end
+
+  ruby_version_is "2.5" do
+    it "does not search Object after searching other scopes" do
+      ->() { String::Hash }.should raise_error(NameError)
+    end
+  end
+end
+
 describe "Module#private_constant marked constants" do
 
   it "remain private even when updated" do

--- a/language/constants_spec.rb
+++ b/language/constants_spec.rb
@@ -426,21 +426,23 @@ describe "Constant resolution within a singleton class (class << obj)" do
 end
 
 describe "top-level constant lookup" do
-  ruby_version_is "" ... "2.5" do
-    it "searches Object successfully when starts from class" do
-      ->() {
-        String::Hash.should == Hash
-      }.should complain(/toplevel constant Hash referenced by/)
+  context "on a class" do
+    ruby_version_is "" ... "2.5" do
+      it "searches Object successfully after searching other scopes" do
+        ->() {
+          String::Hash.should == Hash
+        }.should complain(/toplevel constant Hash referenced by/)
+      end
+    end
+
+    ruby_version_is "2.5" do
+      it "does not search Object after searching other scopes" do
+        ->() { String::Hash }.should raise_error(NameError)
+      end
     end
   end
 
-  ruby_version_is "2.5" do
-    it "does not search Object after searching other scopes" do
-      ->() { String::Hash }.should raise_error(NameError)
-    end
-  end
-
-  it "searches Object unsuccessfully when starts from module" do
+  it "searches Object unsuccessfully when searches on a module" do
     ->() { Enumerable::Hash }.should raise_error(NameError)
   end
 end

--- a/language/constants_spec.rb
+++ b/language/constants_spec.rb
@@ -434,14 +434,14 @@ describe "top-level constant lookup" do
     end
   end
 
-  it "searches Object unsuccessfully when starts from module" do
-    ->() { Enumerable::Hash }.should raise_error(NameError)
-  end
-
   ruby_version_is "2.5" do
     it "does not search Object after searching other scopes" do
       ->() { String::Hash }.should raise_error(NameError)
     end
+  end
+
+  it "searches Object unsuccessfully when starts from module" do
+    ->() { Enumerable::Hash }.should raise_error(NameError)
   end
 end
 


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/11547

Added specs are very short and I have no idea what other cases we can add