### PR TITLE
OpenBSD uses EISDIR for directory access

### DIFF
--- a/core/file/shared/read.rb
+++ b/core/file/shared/read.rb
@@ -1,13 +1,13 @@
 require File.expand_path('../../../dir/fixtures/common', __FILE__)
 
 describe :file_read_directory, shared: true do
-  platform_is :darwin, :linux, :windows do
+  platform_is :darwin, :linux, :openbsd, :windows do
     it "raises an Errno::EISDIR when passed a path that is a directory" do
       lambda { @object.send(@method, ".") }.should raise_error(Errno::EISDIR)
     end
   end
 
-  platform_is :bsd do
+  platform_is :freebsd, :netbsd do
     it "does not raises any exception when passed a path that is a directory" do
       lambda { @object.send(@method, ".") }.should_not raise_error
     end

--- a/core/process/spawn_spec.rb
+++ b/core/process/spawn_spec.rb
@@ -595,8 +595,10 @@ describe "Process.spawn" do
     end
   end
 
-  it "raises an Errno::EACCES when passed a directory" do
-    lambda { Process.spawn File.dirname(__FILE__) }.should raise_error(Errno::EACCES)
+  it "raises an Errno::EACCES or Errno::EISDIR when passed a directory" do
+    lambda { Process.spawn File.dirname(__FILE__) }.should  raise_error(SystemCallError) { |e|
+      [Errno::EACCES, Errno::EISDIR].should include(e.class)
+    }
   end
 
   it "raises an ArgumentError when passed a string key in options" do


### PR DESCRIPTION
This is true at least for the most recent release of OpenBSD.

I'm not sure if FreeBSD and NetBSD still do not raise for
read(2) on directories.