### PR TITLE
[Ruby 2.5] String#casecmp? returns nil for non-string arguments

### DIFF
--- a/core/string/casecmp_spec.rb
+++ b/core/string/casecmp_spec.rb
@@ -180,5 +180,17 @@ ruby_version_is "2.4" do
         end
       end
     end
+
+    ruby_version_is "2.4" ... "2.5" do
+      it "raises a TypeError if other can't be converted to a string" do
+        lambda { "abc".casecmp?(mock('abc')) }.should raise_error(TypeError)
+      end
+    end
+
+    ruby_version_is "2.5" do
+      it "returns nil if other can't be converted to a string" do
+        "abc".casecmp?(mock('abc')).should be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/13312