### PR TITLE
[Ruby 2.5] Numerical comparison operators no longer hide exceptions from #coerce

### DIFF
--- a/core/float/divide_spec.rb
+++ b/core/float/divide_spec.rb
@@ -1,7 +1,10 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/coerce.rb', __FILE__)
+require File.expand_path('../shared/arithmetic_exception_in_coerce', __FILE__)
 
 describe "Float#/" do
+  it_behaves_like :float_arithmetic_exception_in_coerce, :/
+
   it "returns self divided by other" do
     (5.75 / -2).should be_close(-2.875,TOLERANCE)
     (451.0 / 9.3).should be_close(48.494623655914,TOLERANCE)

--- a/core/float/fixtures/classes.rb
+++ b/core/float/fixtures/classes.rb
@@ -1,0 +1,4 @@
+module FloatSpecs
+  class CoerceError < StandardError
+  end
+end

--- a/core/float/gt_spec.rb
+++ b/core/float/gt_spec.rb
@@ -1,6 +1,9 @@
 require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../shared/comparison_exception_in_coerce', __FILE__)
 
 describe "Float#>" do
+  it_behaves_like :float_comparison_exception_in_coerce, :>
+
   it "returns true if self is greater than other" do
     (1.5 > 1).should == true
     (2.5 > 3).should == false

--- a/core/float/gte_spec.rb
+++ b/core/float/gte_spec.rb
@@ -1,6 +1,9 @@
 require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../shared/comparison_exception_in_coerce', __FILE__)
 
 describe "Float#>=" do
+  it_behaves_like :float_comparison_exception_in_coerce, :>=
+
   it "returns true if self is greater than or equal to other" do
     (5.2 >= 5.2).should == true
     (9.71 >= 1).should == true

--- a/core/float/lt_spec.rb
+++ b/core/float/lt_spec.rb
@@ -1,6 +1,9 @@
 require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../shared/comparison_exception_in_coerce', __FILE__)
 
 describe "Float#<" do
+  it_behaves_like :float_comparison_exception_in_coerce, :<
+
   it "returns true if self is less than other" do
     (71.3 < 91.8).should == true
     (192.6 < -500).should == false

--- a/core/float/lte_spec.rb
+++ b/core/float/lte_spec.rb
@@ -1,6 +1,9 @@
 require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../shared/comparison_exception_in_coerce', __FILE__)
 
 describe "Float#<=" do
+  it_behaves_like :float_comparison_exception_in_coerce, :>=
+
   it "returns true if self is less than or equal to other" do
     (2.0 <= 3.14159).should == true
     (-2.7183 <= -24).should == false

--- a/core/float/minus_spec.rb
+++ b/core/float/minus_spec.rb
@@ -1,6 +1,9 @@
 require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../shared/arithmetic_exception_in_coerce', __FILE__)
 
 describe "Float#-" do
+  it_behaves_like :float_arithmetic_exception_in_coerce, :-
+
   it "returns self minus other" do
     (9_237_212.5280 - 5_280).should be_close(9231932.528, TOLERANCE)
     (2_560_496.1691 - bignum_value).should be_close(-9223372036852215808.000, TOLERANCE)

--- a/core/float/multiply_spec.rb
+++ b/core/float/multiply_spec.rb
@@ -1,6 +1,9 @@
 require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../shared/arithmetic_exception_in_coerce', __FILE__)
 
 describe "Float#*" do
+  it_behaves_like :float_arithmetic_exception_in_coerce, :*
+
   it "returns self multiplied by other" do
     (4923.98221 * 2).should be_close(9847.96442, TOLERANCE)
     (6712.5 * 0.25).should be_close(1678.125, TOLERANCE)

--- a/core/float/plus_spec.rb
+++ b/core/float/plus_spec.rb
@@ -1,6 +1,9 @@
 require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../shared/arithmetic_exception_in_coerce', __FILE__)
 
 describe "Float#+" do
+  it_behaves_like :float_arithmetic_exception_in_coerce, :+
+
   it "returns self plus other" do
     (491.213 + 2).should be_close(493.213, TOLERANCE)
     (9.99 + bignum_value).should be_close(9223372036854775808.000, TOLERANCE)

--- a/core/float/shared/arithmetic_exception_in_coerce.rb
+++ b/core/float/shared/arithmetic_exception_in_coerce.rb
@@ -1,0 +1,24 @@
+require File.expand_path('../../fixtures/classes', __FILE__)
+
+describe :float_arithmetic_exception_in_coerce, shared: true do
+  ruby_version_is "" ... "2.5" do
+    it "rescues exception raised in other#coerce and raises TypeError" do
+      b = mock("numeric with failed #coerce")
+      b.should_receive(:coerce).and_raise(RuntimeError)
+
+      # e.g. 1.0 > b
+      -> { 1.0.send(@method, b) }.should raise_error(TypeError, /MockObject can't be coerced into Float/)
+    end
+  end
+
+  ruby_version_is "2.5" do
+    it "does not rescue exception raised in other#coerce" do
+      b = mock("numeric with failed #coerce")
+      b.should_receive(:coerce).and_raise(FloatSpecs::CoerceError)
+
+      # e.g. 1.0 > b
+      -> { 1.0.send(@method, b) }.should raise_error(FloatSpecs::CoerceError)
+    end
+  end
+end
+

--- a/core/float/shared/arithmetic_exception_in_coerce.rb
+++ b/core/float/shared/arithmetic_exception_in_coerce.rb
@@ -11,9 +11,7 @@ describe :float_arithmetic_exception_in_coerce, shared: true do
     end
 
     it "does not rescue Exception and StandardError siblings raised in other#coerce" do
-      [ Exception.new, NoMemoryError.new, ScriptError.new, SecurityError.new,
-        SignalException.new('INT'), SystemExit.new, SystemStackError.new
-      ].each do |exception|
+      [Exception, NoMemoryError].each do |exception|
         b = mock("numeric with failed #coerce")
         b.should_receive(:coerce).and_raise(exception)
 

--- a/core/float/shared/arithmetic_exception_in_coerce.rb
+++ b/core/float/shared/arithmetic_exception_in_coerce.rb
@@ -1,13 +1,25 @@
 require File.expand_path('../../fixtures/classes', __FILE__)
 
 describe :float_arithmetic_exception_in_coerce, shared: true do
-  ruby_version_is "" ... "2.5" do
-    it "rescues exception raised in other#coerce and raises TypeError" do
+  ruby_version_is ""..."2.5" do
+    it "rescues exception (StandardError and subclasses) raised in other#coerce and raises TypeError" do
       b = mock("numeric with failed #coerce")
-      b.should_receive(:coerce).and_raise(RuntimeError)
+      b.should_receive(:coerce).and_raise(FloatSpecs::CoerceError)
 
       # e.g. 1.0 > b
       -> { 1.0.send(@method, b) }.should raise_error(TypeError, /MockObject can't be coerced into Float/)
+    end
+
+    it "does not rescue Exception and StandardError siblings raised in other#coerce" do
+      [ Exception.new, NoMemoryError.new, ScriptError.new, SecurityError.new,
+        SignalException.new('INT'), SystemExit.new, SystemStackError.new
+      ].each do |exception|
+        b = mock("numeric with failed #coerce")
+        b.should_receive(:coerce).and_raise(exception)
+
+        # e.g. 1.0 > b
+        -> { 1.0.send(@method, b) }.should raise_error(exception)
+      end
     end
   end
 

--- a/core/float/shared/comparison_exception_in_coerce.rb
+++ b/core/float/shared/comparison_exception_in_coerce.rb
@@ -1,15 +1,27 @@
 require File.expand_path('../../fixtures/classes', __FILE__)
 
 describe :float_comparison_exception_in_coerce, shared: true do
-  ruby_version_is "" ... "2.5" do
-    it "rescues exception raised in other#coerce and raises ArgumentError" do
+  ruby_version_is ""..."2.5" do
+    it "rescues exception (StandardError and subclasses) raised in other#coerce and raises ArgumentError" do
       b = mock("numeric with failed #coerce")
-      b.should_receive(:coerce).and_raise(RuntimeError)
+      b.should_receive(:coerce).and_raise(FloatSpecs::CoerceError)
 
       # e.g. 1.0 > b
       -> {
         -> { 1.0.send(@method, b) }.should raise_error(ArgumentError, /comparison of Float with MockObject failed/)
       }.should complain(/Numerical comparison operators will no more rescue exceptions of #coerce/)
+    end
+
+    it "does not rescue Exception and StandardError siblings raised in other#coerce" do
+      [ Exception.new, NoMemoryError.new, ScriptError.new, SecurityError.new,
+        SignalException.new('INT'), SystemExit.new, SystemStackError.new
+      ].each do |exception|
+        b = mock("numeric with failed #coerce")
+        b.should_receive(:coerce).and_raise(exception)
+
+        # e.g. 1.0 > b
+        -> { 1.0.send(@method, b) }.should raise_error(exception)
+      end
     end
   end
 

--- a/core/float/shared/comparison_exception_in_coerce.rb
+++ b/core/float/shared/comparison_exception_in_coerce.rb
@@ -13,9 +13,7 @@ describe :float_comparison_exception_in_coerce, shared: true do
     end
 
     it "does not rescue Exception and StandardError siblings raised in other#coerce" do
-      [ Exception.new, NoMemoryError.new, ScriptError.new, SecurityError.new,
-        SignalException.new('INT'), SystemExit.new, SystemStackError.new
-      ].each do |exception|
+      [Exception, NoMemoryError].each do |exception|
         b = mock("numeric with failed #coerce")
         b.should_receive(:coerce).and_raise(exception)
 

--- a/core/float/shared/comparison_exception_in_coerce.rb
+++ b/core/float/shared/comparison_exception_in_coerce.rb
@@ -1,0 +1,26 @@
+require File.expand_path('../../fixtures/classes', __FILE__)
+
+describe :float_comparison_exception_in_coerce, shared: true do
+  ruby_version_is "" ... "2.5" do
+    it "rescues exception raised in other#coerce and raises ArgumentError" do
+      b = mock("numeric with failed #coerce")
+      b.should_receive(:coerce).and_raise(RuntimeError)
+
+      # e.g. 1.0 > b
+      -> {
+        -> { 1.0.send(@method, b) }.should raise_error(ArgumentError, /comparison of Float with MockObject failed/)
+      }.should complain(/Numerical comparison operators will no more rescue exceptions of #coerce/)
+    end
+  end
+
+  ruby_version_is "2.5" do
+    it "does not rescue exception raised in other#coerce" do
+      b = mock("numeric with failed #coerce")
+      b.should_receive(:coerce).and_raise(FloatSpecs::CoerceError)
+
+      # e.g. 1.0 > b
+      -> { 1.0.send(@method, b) }.should raise_error(FloatSpecs::CoerceError)
+    end
+  end
+end
+

--- a/core/integer/divide_spec.rb
+++ b/core/integer/divide_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../shared/arithmetic_exception_in_coerce', __FILE__)
+
+describe "Integer#/" do
+  it_behaves_like :integer_arithmetic_exception_in_coerce, :/
+end
+

--- a/core/integer/fixtures/classes.rb
+++ b/core/integer/fixtures/classes.rb
@@ -1,0 +1,4 @@
+module IntegerSpecs
+  class CoerceError < StandardError
+  end
+end

--- a/core/integer/gt_spec.rb
+++ b/core/integer/gt_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../shared/comparison_exception_in_coerce', __FILE__)
+
+describe "Integer#>" do
+  it_behaves_like :integer_comparison_exception_in_coerce, :>
+end
+

--- a/core/integer/gte_spec.rb
+++ b/core/integer/gte_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../shared/comparison_exception_in_coerce', __FILE__)
+
+describe "Integer#>=" do
+  it_behaves_like :integer_comparison_exception_in_coerce, :>=
+end
+

--- a/core/integer/lt_spec.rb
+++ b/core/integer/lt_spec.rb
@@ -1,0 +1,6 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../shared/comparison_exception_in_coerce', __FILE__)
+
+describe "Integer#<" do
+  it_behaves_like :integer_comparison_exception_in_coerce, :<
+end

--- a/core/integer/lte_spec.rb
+++ b/core/integer/lte_spec.rb
@@ -1,0 +1,6 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../shared/comparison_exception_in_coerce', __FILE__)
+
+describe "Integer#<=" do
+  it_behaves_like :integer_comparison_exception_in_coerce, :<=
+end

--- a/core/integer/minus_spec.rb
+++ b/core/integer/minus_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../shared/arithmetic_exception_in_coerce', __FILE__)
+
+describe "Integer#-" do
+  it_behaves_like :integer_arithmetic_exception_in_coerce, :-
+end
+

--- a/core/integer/multiply_spec.rb
+++ b/core/integer/multiply_spec.rb
@@ -1,0 +1,6 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../shared/arithmetic_exception_in_coerce', __FILE__)
+
+describe "Integer#*" do
+  it_behaves_like :integer_arithmetic_exception_in_coerce, :*
+end

--- a/core/integer/plus_spec.rb
+++ b/core/integer/plus_spec.rb
@@ -1,0 +1,6 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../shared/arithmetic_exception_in_coerce', __FILE__)
+
+describe "Integer#+" do
+  it_behaves_like :integer_arithmetic_exception_in_coerce, :+
+end

--- a/core/integer/shared/arithmetic_exception_in_coerce.rb
+++ b/core/integer/shared/arithmetic_exception_in_coerce.rb
@@ -11,9 +11,7 @@ describe :integer_arithmetic_exception_in_coerce, shared: true do
     end
 
     it "does not rescue Exception and StandardError siblings raised in other#coerce" do
-      [ Exception.new, NoMemoryError.new, ScriptError.new, SecurityError.new,
-        SignalException.new('INT'), SystemExit.new, SystemStackError.new
-      ].each do |exception|
+      [Exception, NoMemoryError].each do |exception|
         b = mock("numeric with failed #coerce")
         b.should_receive(:coerce).and_raise(exception)
 

--- a/core/integer/shared/arithmetic_exception_in_coerce.rb
+++ b/core/integer/shared/arithmetic_exception_in_coerce.rb
@@ -1,0 +1,23 @@
+require File.expand_path('../../fixtures/classes', __FILE__)
+
+describe :integer_arithmetic_exception_in_coerce, shared: true do
+  ruby_version_is "" ... "2.5" do
+    it "rescues exception raised in other#coerce and raises TypeError" do
+      b = mock("numeric with failed #coerce")
+      b.should_receive(:coerce).and_raise(RuntimeError)
+
+      # e.g. 1 + b
+      -> { 1.send(@method, b) }.should raise_error(TypeError, /MockObject can't be coerced into #{1.class}/)
+    end
+  end
+
+  ruby_version_is "2.5" do
+    it "does not rescue exception raised in other#coerce" do
+      b = mock("numeric with failed #coerce")
+      b.should_receive(:coerce).and_raise(IntegerSpecs::CoerceError)
+
+      # e.g. 1 + b
+      -> { 1.send(@method, b) }.should raise_error(IntegerSpecs::CoerceError)
+    end
+  end
+end

--- a/core/integer/shared/arithmetic_exception_in_coerce.rb
+++ b/core/integer/shared/arithmetic_exception_in_coerce.rb
@@ -1,13 +1,25 @@
 require File.expand_path('../../fixtures/classes', __FILE__)
 
 describe :integer_arithmetic_exception_in_coerce, shared: true do
-  ruby_version_is "" ... "2.5" do
-    it "rescues exception raised in other#coerce and raises TypeError" do
+  ruby_version_is ""..."2.5" do
+    it "rescues exception (StandardError and subclasses) raised in other#coerce and raises TypeError" do
       b = mock("numeric with failed #coerce")
-      b.should_receive(:coerce).and_raise(RuntimeError)
+      b.should_receive(:coerce).and_raise(IntegerSpecs::CoerceError)
 
       # e.g. 1 + b
       -> { 1.send(@method, b) }.should raise_error(TypeError, /MockObject can't be coerced into #{1.class}/)
+    end
+
+    it "does not rescue Exception and StandardError siblings raised in other#coerce" do
+      [ Exception.new, NoMemoryError.new, ScriptError.new, SecurityError.new,
+        SignalException.new('INT'), SystemExit.new, SystemStackError.new
+      ].each do |exception|
+        b = mock("numeric with failed #coerce")
+        b.should_receive(:coerce).and_raise(exception)
+
+        # e.g. 1 + b
+        -> { 1.send(@method, b) }.should raise_error(exception)
+      end
     end
   end
 

--- a/core/integer/shared/comparison_exception_in_coerce.rb
+++ b/core/integer/shared/comparison_exception_in_coerce.rb
@@ -13,9 +13,7 @@ describe :integer_comparison_exception_in_coerce, shared: true do
     end
 
     it "does not rescue Exception and StandardError siblings raised in other#coerce" do
-      [ Exception.new, NoMemoryError.new, ScriptError.new, SecurityError.new,
-        SignalException.new('INT'), SystemExit.new, SystemStackError.new
-      ].each do |exception|
+      [Exception, NoMemoryError].each do |exception|
         b = mock("numeric with failed #coerce")
         b.should_receive(:coerce).and_raise(exception)
 

--- a/core/integer/shared/comparison_exception_in_coerce.rb
+++ b/core/integer/shared/comparison_exception_in_coerce.rb
@@ -1,15 +1,27 @@
 require File.expand_path('../../fixtures/classes', __FILE__)
 
 describe :integer_comparison_exception_in_coerce, shared: true do
-  ruby_version_is "" ... "2.5" do
-    it "rescues exception raised in other#coerce and raises ArgumentError" do
+  ruby_version_is ""..."2.5" do
+    it "rescues exception (StandardError and subclasses) raised in other#coerce and raises ArgumentError" do
       b = mock("numeric with failed #coerce")
-      b.should_receive(:coerce).and_raise(RuntimeError)
+      b.should_receive(:coerce).and_raise(IntegerSpecs::CoerceError)
 
       # e.g. 1 > b
       -> {
         -> { 1.send(@method, b) }.should raise_error(ArgumentError, /comparison of #{1.class} with MockObject failed/)
       }.should complain(/Numerical comparison operators will no more rescue exceptions of #coerce/)
+    end
+
+    it "does not rescue Exception and StandardError siblings raised in other#coerce" do
+      [ Exception.new, NoMemoryError.new, ScriptError.new, SecurityError.new,
+        SignalException.new('INT'), SystemExit.new, SystemStackError.new
+      ].each do |exception|
+        b = mock("numeric with failed #coerce")
+        b.should_receive(:coerce).and_raise(exception)
+
+        # e.g. 1 > b
+        -> { 1.send(@method, b) }.should raise_error(exception)
+      end
     end
   end
 

--- a/core/integer/shared/comparison_exception_in_coerce.rb
+++ b/core/integer/shared/comparison_exception_in_coerce.rb
@@ -1,0 +1,25 @@
+require File.expand_path('../../fixtures/classes', __FILE__)
+
+describe :integer_comparison_exception_in_coerce, shared: true do
+  ruby_version_is "" ... "2.5" do
+    it "rescues exception raised in other#coerce and raises ArgumentError" do
+      b = mock("numeric with failed #coerce")
+      b.should_receive(:coerce).and_raise(RuntimeError)
+
+      # e.g. 1 > b
+      -> {
+        -> { 1.send(@method, b) }.should raise_error(ArgumentError, /comparison of #{1.class} with MockObject failed/)
+      }.should complain(/Numerical comparison operators will no more rescue exceptions of #coerce/)
+    end
+  end
+
+  ruby_version_is "2.5" do
+    it "does not rescue exception raised in other#coerce" do
+      b = mock("numeric with failed #coerce")
+      b.should_receive(:coerce).and_raise(IntegerSpecs::CoerceError)
+
+      # e.g. 1 > b
+      -> { 1.send(@method, b) }.should raise_error(IntegerSpecs::CoerceError)
+    end
+  end
+end

--- a/core/rational/comparison_spec.rb
+++ b/core/rational/comparison_spec.rb
@@ -14,6 +14,7 @@ end
 
 describe "Rational#<=> when passed an Object that responds to #coerce" do
   it_behaves_like(:rational_cmp_coerce, :<=>)
+  it_behaves_like(:rational_cmp_coerce_exception, :<=>)
 end
 
 describe "Rational#<=> when passed a non-Numeric Object that doesn't respond to #coerce" do

--- a/core/rational/divide_spec.rb
+++ b/core/rational/divide_spec.rb
@@ -1,7 +1,9 @@
 require File.expand_path('../../../shared/rational/divide', __FILE__)
+require File.expand_path('../../../shared/rational/arithmetic_exception_in_coerce', __FILE__)
 
 describe "Rational#/" do
   it_behaves_like(:rational_divide, :/)
+  it_behaves_like :rational_arithmetic_exception_in_coerce, :/
 end
 
 describe "Rational#/ when passed an Integer" do

--- a/core/rational/minus_spec.rb
+++ b/core/rational/minus_spec.rb
@@ -1,5 +1,7 @@
 require File.expand_path('../../../shared/rational/minus', __FILE__)
+require File.expand_path('../../../shared/rational/arithmetic_exception_in_coerce', __FILE__)
 
 describe "Rational#-" do
   it_behaves_like(:rational_minus, :-)
+  it_behaves_like :rational_arithmetic_exception_in_coerce, :-
 end

--- a/core/rational/multiply_spec.rb
+++ b/core/rational/multiply_spec.rb
@@ -1,7 +1,9 @@
 require File.expand_path('../../../shared/rational/multiply', __FILE__)
+require File.expand_path('../../../shared/rational/arithmetic_exception_in_coerce', __FILE__)
 
 describe "Rational#*" do
   it_behaves_like(:rational_multiply, :*)
+  it_behaves_like :rational_arithmetic_exception_in_coerce, :*
 end
 
 describe "Rational#* passed a Rational" do

--- a/core/rational/plus_spec.rb
+++ b/core/rational/plus_spec.rb
@@ -1,7 +1,9 @@
 require File.expand_path('../../../shared/rational/plus', __FILE__)
+require File.expand_path('../../../shared/rational/arithmetic_exception_in_coerce', __FILE__)
 
 describe "Rational#+" do
   it_behaves_like(:rational_plus, :+)
+  it_behaves_like :rational_arithmetic_exception_in_coerce, :+
 end
 
 describe "Rational#+ with a Rational" do

--- a/fixtures/rational.rb
+++ b/fixtures/rational.rb
@@ -8,4 +8,7 @@ module RationalSpecs
       @value
     end
   end
+
+  class CoerceError < StandardError
+  end
 end

--- a/shared/rational/arithmetic_exception_in_coerce.rb
+++ b/shared/rational/arithmetic_exception_in_coerce.rb
@@ -1,13 +1,25 @@
 require File.expand_path('../../../fixtures/rational', __FILE__)
 
 describe :rational_arithmetic_exception_in_coerce, shared: true do
-  ruby_version_is "" ... "2.5" do
-    it "rescues exception raised in other#coerce and raises TypeError" do
+  ruby_version_is ""..."2.5" do
+    it "rescues exception (StandardError and subclasses) raised in other#coerce and raises TypeError" do
       b = mock("numeric with failed #coerce")
-      b.should_receive(:coerce).and_raise(RuntimeError)
+      b.should_receive(:coerce).and_raise(RationalSpecs::CoerceError)
 
       # e.g. Rational(3, 4) + b
       -> { Rational(3, 4).send(@method, b) }.should raise_error(TypeError, /MockObject can't be coerced into Rational/)
+    end
+
+    it "does not rescue Exception and StandardError siblings raised in other#coerce" do
+      [ Exception.new, NoMemoryError.new, ScriptError.new, SecurityError.new,
+        SignalException.new('INT'), SystemExit.new, SystemStackError.new
+      ].each do |exception|
+        b = mock("numeric with failed #coerce")
+        b.should_receive(:coerce).and_raise(exception)
+
+        # e.g. Rational(3, 4) + b
+        -> { Rational(3, 4).send(@method, b) }.should raise_error(exception)
+      end
     end
   end
 

--- a/shared/rational/arithmetic_exception_in_coerce.rb
+++ b/shared/rational/arithmetic_exception_in_coerce.rb
@@ -11,9 +11,7 @@ describe :rational_arithmetic_exception_in_coerce, shared: true do
     end
 
     it "does not rescue Exception and StandardError siblings raised in other#coerce" do
-      [ Exception.new, NoMemoryError.new, ScriptError.new, SecurityError.new,
-        SignalException.new('INT'), SystemExit.new, SystemStackError.new
-      ].each do |exception|
+      [Exception, NoMemoryError].each do |exception|
         b = mock("numeric with failed #coerce")
         b.should_receive(:coerce).and_raise(exception)
 

--- a/shared/rational/arithmetic_exception_in_coerce.rb
+++ b/shared/rational/arithmetic_exception_in_coerce.rb
@@ -1,0 +1,23 @@
+require File.expand_path('../../../fixtures/rational', __FILE__)
+
+describe :rational_arithmetic_exception_in_coerce, shared: true do
+  ruby_version_is "" ... "2.5" do
+    it "rescues exception raised in other#coerce and raises TypeError" do
+      b = mock("numeric with failed #coerce")
+      b.should_receive(:coerce).and_raise(RuntimeError)
+
+      # e.g. Rational(3, 4) + b
+      -> { Rational(3, 4).send(@method, b) }.should raise_error(TypeError, /MockObject can't be coerced into Rational/)
+    end
+  end
+
+  ruby_version_is "2.5" do
+    it "does not rescue exception raised in other#coerce" do
+      b = mock("numeric with failed #coerce")
+      b.should_receive(:coerce).and_raise(RationalSpecs::CoerceError)
+
+      # e.g. Rational(3, 4) + b
+      -> { Rational(3, 4).send(@method, b) }.should raise_error(RationalSpecs::CoerceError)
+    end
+  end
+end

--- a/shared/rational/comparison.rb
+++ b/shared/rational/comparison.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../../../fixtures/rational', __FILE__)
 
 describe :rational_cmp_rat, shared: true do
   it "returns 1 when self is greater than the passed argument" do
@@ -75,6 +76,28 @@ describe :rational_cmp_coerce, shared: true do
     obj.should_receive(:coerce).and_return([coerced_rational, coerced_obj])
 
     (rational <=> obj).should == :result
+  end
+end
+
+describe :rational_cmp_coerce_exception, shared: true do
+  ruby_version_is "" ... "2.5" do
+    it "rescues exception raised in other#coerce and returns nil" do
+      b = mock("numeric with failed #coerce")
+      b.should_receive(:coerce).and_raise(RuntimeError)
+
+      -> {
+        (Rational(3, 4) <=> b).should == nil
+      }.should complain(/Numerical comparison operators will no more rescue exceptions of #coerce/)
+    end
+  end
+
+  ruby_version_is "2.5" do
+    it "does not rescue exception raised in other#coerce" do
+      b = mock("numeric with failed #coerce")
+      b.should_receive(:coerce).and_raise(RationalSpecs::CoerceError)
+
+      -> { Rational(3, 4) <=> b }.should raise_error(RationalSpecs::CoerceError)
+    end
   end
 end
 

--- a/shared/rational/comparison.rb
+++ b/shared/rational/comparison.rb
@@ -91,9 +91,7 @@ describe :rational_cmp_coerce_exception, shared: true do
     end
 
     it "does not rescue Exception and StandardError siblings raised in other#coerce" do
-      [ Exception.new, NoMemoryError.new, ScriptError.new, SecurityError.new,
-        SignalException.new('INT'), SystemExit.new, SystemStackError.new
-      ].each do |exception|
+      [Exception, NoMemoryError].each do |exception|
         b = mock("numeric with failed #coerce")
         b.should_receive(:coerce).and_raise(exception)
 


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/7688

Related specs from ruby/ruby https://github.com/ruby/ruby/commit/bc1827e8825c558bcda14a214280caf83dc1215b#diff-715114ab5128543f66318d6fa6acffae

Related specs for `Bignum#<=>` https://github.com/ruby/spec/commit/f125a5d745748c340a0636222370b1ebdd412c7c