### PR TITLE
[Ruby 2.5] Dir.glob provides new optional keyword argument, :base

### DIFF
--- a/core/dir/shared/glob.rb
+++ b/core/dir/shared/glob.rb
@@ -275,6 +275,78 @@ describe :dir_glob, shared: true do
       Dir.send(@method, "special/こんにちは{,.txt}").should == ["special/こんにちは.txt"]
     end
   end
+
+  ruby_version_is "2.5" do
+    context ":base option passed" do
+      before :each do
+        @mock_dir = File.expand_path tmp('dir_glob_mock')
+
+        %w[
+          a/b/x
+          a/b/c/y
+          a/b/c/d/z
+        ].each do |path|
+          file = File.join @mock_dir, path
+          mkdir_p File.dirname(file)
+          touch file
+        end
+      end
+
+      after :each do
+        rm_r @mock_dir
+      end
+
+      it "matches entries only from within the specified directory" do
+        path = File.join(@mock_dir, "a/b/c")
+        Dir.send(@method, "*", base: path).sort.should == %w( d y )
+      end
+
+      it "accepts both relative and absolute pathes" do
+        require 'pathname'
+
+        path_abs = File.join(@mock_dir, "a/b/c")
+        path_rel = Pathname.new(path_abs).relative_path_from(Pathname.new(Dir.pwd))
+
+        result_abs = Dir.send(@method, "*", base: path_abs).sort
+        result_rel = Dir.send(@method, "*", base: path_rel).sort
+
+        result_abs.should == %w( d y )
+        result_rel.should == %w( d y )
+      end
+
+      it "returns [] if specified path does not exist" do
+        path = File.join(@mock_dir, "fake-name")
+        File.exist?(path).should == false
+
+        Dir.send(@method, "*", base: path).should == []
+      end
+
+      it "returns [] if specified path is a file" do
+        path = File.join(@mock_dir, "a/b/x")
+        File.exist?(path).should == true
+
+        Dir.send(@method, "*", base: path).should == []
+      end
+
+      it "raises TypeError whene cannot convert value to string" do
+        -> {
+          Dir.send(@method, "*", base: [])
+        }.should raise_error(TypeError)
+      end
+
+      it "handles '' as current directory path" do
+        Dir.chdir @mock_dir do
+          Dir.send(@method, "*", base: "").should == %w( a )
+        end
+      end
+
+      it "handles nil as current directory path" do
+        Dir.chdir @mock_dir do
+          Dir.send(@method, "*", base: nil).should == %w( a )
+        end
+      end
+    end
+  end
 end
 
 describe :dir_glob_recursive, shared: true do


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/13056

Specs are based on https://github.com/ruby/ruby/commit/1ef613dd0b6db1a3df63224803eadd2911ab427d and https://github.com/ruby/ruby/commit/83a31e9e90b978d73cbcfa4c1b5e936bb395bafe