### PR TITLE
[Ruby 2.5] Range#initialize no longer hides exceptions when comparing begin and end

### DIFF
--- a/core/range/fixtures/classes.rb
+++ b/core/range/fixtures/classes.rb
@@ -62,4 +62,7 @@ module RangeSpecs
 
   class MyRange < Range
   end
+
+  class ComparisionError < RuntimeError
+  end
 end

--- a/core/range/fixtures/classes.rb
+++ b/core/range/fixtures/classes.rb
@@ -63,6 +63,6 @@ module RangeSpecs
   class MyRange < Range
   end
 
-  class ComparisionError < RuntimeError
+  class ComparisonError < RuntimeError
   end
 end

--- a/core/range/new_spec.rb
+++ b/core/range/new_spec.rb
@@ -37,9 +37,9 @@ describe "Range.new" do
     it "does not rescue exception raised in #<=> when compares the given start and end" do
       b = mock('a')
       a = mock('b')
-      a.should_receive(:<=>).with(b).and_raise(RangeSpecs::ComparisionError)
+      a.should_receive(:<=>).with(b).and_raise(RangeSpecs::ComparisonError)
 
-      -> { Range.new(a, b) }.should raise_error(RangeSpecs::ComparisionError)
+      -> { Range.new(a, b) }.should raise_error(RangeSpecs::ComparisonError)
     end
   end
 end

--- a/core/range/new_spec.rb
+++ b/core/range/new_spec.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../fixtures/classes', __FILE__)
 
 describe "Range.new" do
   it "constructs a range using the given start and end" do
@@ -30,5 +31,15 @@ describe "Range.new" do
     b = mock('x')
     (a = mock('nil')).should_receive(:<=>).with(b).and_return(nil)
     lambda { Range.new(a, b) }.should raise_error(ArgumentError)
+  end
+
+  ruby_version_is "2.5" do
+    it "does not rescue exception raised in #<=> when compares the given start and end" do
+      b = mock('a')
+      a = mock('b')
+      a.should_receive(:<=>).with(b).and_raise(RangeSpecs::ComparisionError)
+
+      -> { Range.new(a, b) }.should raise_error(RangeSpecs::ComparisionError)
+    end
   end
 end


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/7688