### PR TITLE
Adds coverage for KeyError#receiver / KeyError#key

### DIFF
--- a/core/env/fetch_spec.rb
+++ b/core/env/fetch_spec.rb
@@ -12,25 +12,29 @@ describe "ENV.fetch" do
   end
 
   context "when the key is not found" do
+    before :each do
+      @key = "should_never_be_set"
+    end
+
     it "raises a KeyError" do
-      lambda { ENV.fetch "should_never_be_set" }.should raise_error(KeyError)
+      lambda { ENV.fetch @key }.should raise_error(KeyError)
     end
 
     ruby_version_is "2.5" do
       it "sets the ENV as the receiver of KeyError" do
-        begin
-          ENV.fetch "should_never_be_set"
-        rescue KeyError => err
+        -> {
+          ENV.fetch @key
+        }.should raise_error(KeyError) { |err|
           err.receiver.should == ENV
-        end
+        }
       end
 
       it "sets the non-existent key as the key of KeyError" do
-        begin
-          ENV.fetch "should_never_be_set"
-        rescue KeyError => err
-          err.key.should == "should_never_be_set"
-        end
+        -> {
+          ENV.fetch @key
+        }.should raise_error(KeyError) { |err|
+          err.key.should == @key
+        }
       end
     end
   end

--- a/core/env/fetch_spec.rb
+++ b/core/env/fetch_spec.rb
@@ -11,8 +11,28 @@ describe "ENV.fetch" do
     lambda { ENV.fetch :should_never_be_set }.should raise_error(TypeError)
   end
 
-  it "raises a KeyError if the key is not found" do
-    lambda { ENV.fetch "should_never_be_set" }.should raise_error(KeyError)
+  context "when the key is not found" do
+    it "raises a KeyError" do
+      lambda { ENV.fetch "should_never_be_set" }.should raise_error(KeyError)
+    end
+
+    ruby_version_is "2.5" do
+      it "sets the ENV as the receiver of KeyError" do
+        begin
+          ENV.fetch "should_never_be_set"
+        rescue KeyError => err
+          err.receiver.should == ENV
+        end
+      end
+
+      it "sets the non-existent key as the key of KeyError" do
+        begin
+          ENV.fetch "should_never_be_set"
+        rescue KeyError => err
+          err.key.should == "should_never_be_set"
+        end
+      end
+    end
   end
 
   it "provides the given default parameter" do

--- a/core/hash/fetch_spec.rb
+++ b/core/hash/fetch_spec.rb
@@ -6,10 +6,32 @@ describe "Hash#fetch" do
     { a: 1, b: -1 }.fetch(:b).should == -1
   end
 
-  it "raises a KeyError if key is not found" do
-    lambda { {}.fetch(:a)       }.should raise_error(KeyError)
-    lambda { Hash.new(5).fetch(:a)    }.should raise_error(KeyError)
-    lambda { Hash.new { 5 }.fetch(:a) }.should raise_error(KeyError)
+  context "when the key is not found" do
+    it "raises a KeyError" do
+      lambda { {}.fetch(:a)       }.should raise_error(KeyError)
+      lambda { Hash.new(5).fetch(:a)    }.should raise_error(KeyError)
+      lambda { Hash.new { 5 }.fetch(:a) }.should raise_error(KeyError)
+    end
+
+    ruby_version_is "2.5" do
+      it "sets the Hash as the reciever of KeyError" do
+        begin
+          hash = {}
+          hash.fetch(:a)
+        rescue KeyError => err
+          err.receiver.should == hash
+        end
+      end
+
+      it "sets the key attempted as key of KeyError" do
+        begin
+          hash = {}
+          hash.fetch(:a)
+        rescue KeyError => err
+          err.key.should == :a
+        end
+      end
+    end
   end
 
   it "returns default if key is not found when passed a default" do

--- a/core/hash/fetch_spec.rb
+++ b/core/hash/fetch_spec.rb
@@ -19,7 +19,7 @@ describe "Hash#fetch" do
         @key = :a
       end
 
-      it "sets the Hash as the reciever of KeyError" do
+      it "sets the Hash as the receiver of KeyError" do
         -> {
           @hsh.fetch(@key)
         }.should raise_error(KeyError) { |err|
@@ -27,7 +27,7 @@ describe "Hash#fetch" do
         }
       end
 
-      it "sets the key attempted as key of KeyError" do
+      it "sets the not-found key as key of KeyError" do
         -> {
           @hsh.fetch(@key)
         }.should raise_error(KeyError) { |err|

--- a/core/hash/fetch_spec.rb
+++ b/core/hash/fetch_spec.rb
@@ -14,22 +14,25 @@ describe "Hash#fetch" do
     end
 
     ruby_version_is "2.5" do
+      before :each do
+        @hsh = { }
+        @key = :a
+      end
+
       it "sets the Hash as the reciever of KeyError" do
-        begin
-          hash = {}
-          hash.fetch(:a)
-        rescue KeyError => err
-          err.receiver.should == hash
-        end
+        -> {
+          @hsh.fetch(@key)
+        }.should raise_error(KeyError) { |err|
+          err.receiver.should == @hsh
+        }
       end
 
       it "sets the key attempted as key of KeyError" do
-        begin
-          hash = {}
-          hash.fetch(:a)
-        rescue KeyError => err
-          err.key.should == :a
-        end
+        -> {
+          @hsh.fetch(@key)
+        }.should raise_error(KeyError) { |err|
+          err.key.should == @key
+        }
       end
     end
   end

--- a/core/hash/fetch_values_spec.rb
+++ b/core/hash/fetch_values_spec.rb
@@ -20,7 +20,6 @@ ruby_version_is "2.3" do
         ->{ @hash.fetch_values :a, :z }.should raise_error(KeyError)
       end
 
-
       it "returns the default value from block" do
         @hash.fetch_values(:z) { |key| "`#{key}' is not found" }.should == ["`z' is not found"]
         @hash.fetch_values(:a, :z) { |key| "`#{key}' is not found" }.should == [1, "`z' is not found"]

--- a/core/hash/fetch_values_spec.rb
+++ b/core/hash/fetch_values_spec.rb
@@ -42,20 +42,22 @@ ruby_version_is "2.5" do
     end
 
     describe "with unmatched keys" do
+      before :each do
+      end
       it "sets the Hash as the receiver of KeyError" do
-        begin
-          @hash.fetch_values :z
-        rescue KeyError => err
+        -> {
+          @hash.fetch_values :a, :z
+        }.should raise_error(KeyError) { |err|
           err.receiver.should == @hash
-        end
+        }
       end
 
       it "sets the unmatched key as the key of KeyError" do
-        begin
+        -> {
           @hash.fetch_values :a, :z
-        rescue KeyError => err
+        }.should raise_error(KeyError) { |err|
           err.key.should == :z
-        end
+        }
       end
     end
   end

--- a/core/hash/fetch_values_spec.rb
+++ b/core/hash/fetch_values_spec.rb
@@ -20,6 +20,7 @@ ruby_version_is "2.3" do
         ->{ @hash.fetch_values :a, :z }.should raise_error(KeyError)
       end
 
+
       it "returns the default value from block" do
         @hash.fetch_values(:z) { |key| "`#{key}' is not found" }.should == ["`z' is not found"]
         @hash.fetch_values(:a, :z) { |key| "`#{key}' is not found" }.should == [1, "`z' is not found"]
@@ -29,6 +30,32 @@ ruby_version_is "2.3" do
     describe "without keys" do
       it "returns an empty Array" do
         @hash.fetch_values.should == []
+      end
+    end
+  end
+end
+
+ruby_version_is "2.5" do
+  describe "Hash#fetch_values" do
+    before :each do
+      @hash = { a: 1, b: 2, c: 3 }
+    end
+
+    describe "with unmatched keys" do
+      it "sets the Hash as the receiver of KeyError" do
+        begin
+          @hash.fetch_values :z
+        rescue KeyError => err
+          err.receiver.should == @hash
+        end
+      end
+
+      it "sets the unmatched key as the key of KeyError" do
+        begin
+          @hash.fetch_values :a, :z
+        rescue KeyError => err
+          err.key.should == :z
+        end
       end
     end
   end

--- a/core/kernel/shared/sprintf.rb
+++ b/core/kernel/shared/sprintf.rb
@@ -824,10 +824,32 @@ describe :kernel_sprintf, shared: true do
         }.should raise_error(ArgumentError)
       end
 
-      it "raises KeyError when there is no matching key" do
-        -> () {
-          format("%<foo>s", {})
-        }.should raise_error(KeyError)
+      context "when there is no matching key" do
+        it "raises KeyError" do
+          -> () {
+            format("%<foo>s", {})
+          }.should raise_error(KeyError)
+        end
+
+        ruby_version_is "2.5" do
+          it "sets the Hash attempting to format on as receiver of KeyError" do
+            begin
+              hash = { fooo: 1 }
+              format("%<foo>s", hash)
+            rescue KeyError => err
+              err.receiver.should == hash
+            end
+          end
+
+          it "sets the faulty key in the formatter as key of KeyError" do
+            begin
+              hash = { fooo: 1 }
+              format("%<foo>s", hash)
+            rescue KeyError => err
+              err.key.should == :foo
+            end
+          end
+        end
       end
     end
 

--- a/core/kernel/shared/sprintf.rb
+++ b/core/kernel/shared/sprintf.rb
@@ -832,22 +832,24 @@ describe :kernel_sprintf, shared: true do
         end
 
         ruby_version_is "2.5" do
+          before :each do
+            @hash = { fooo: 1 }
+          end
+
           it "sets the Hash attempting to format on as receiver of KeyError" do
-            begin
-              hash = { fooo: 1 }
-              format("%<foo>s", hash)
-            rescue KeyError => err
-              err.receiver.should == hash
-            end
+            -> () {
+              format("%<foo>s", @hash)
+            }.should raise_error(KeyError) { |err|
+                err.receiver.should == @hash
+            }
           end
 
           it "sets the faulty key in the formatter as key of KeyError" do
-            begin
-              hash = { fooo: 1 }
-              format("%<foo>s", hash)
-            rescue KeyError => err
+            -> () {
+              format("%<foo>s", @hash)
+            }.should raise_error(KeyError) { |err|
               err.key.should == :foo
-            end
+            }
           end
         end
       end

--- a/core/string/modulo_spec.rb
+++ b/core/string/modulo_spec.rb
@@ -770,22 +770,24 @@ describe "String#%" do
       end
 
       ruby_version_is "2.5" do
+        before :each do
+          @hash = { fooo: 1 }
+        end
+
         it "sets the passed-in hash as receiver for KeyError" do
-          begin
-            hash = {}
-            "%{foo}" % hash
-          rescue KeyError => err
-            err.receiver.should == hash
-          end
+          -> {
+            "%{foo}" % @hash
+          }.should raise_error(KeyError) { |err|
+            err.receiver.should == @hash
+          }
         end
 
         it "sets the missing key as key in KeyError" do
-          begin
-            hash = {}
-            "%{foo}" % hash
-          rescue KeyError => err
+          -> {
+            "%{foo}" % @hash
+          }.should raise_error(KeyError) { |err|
             err.key.should == :foo
-          end
+          }
         end
       end
     end

--- a/core/string/modulo_spec.rb
+++ b/core/string/modulo_spec.rb
@@ -764,8 +764,30 @@ describe "String#%" do
       ("%{foo}bar" % {foo: 'oof'}).should == "oofbar"
     end
 
-    it "raises KeyError if key is missing from passed-in hash" do
-      lambda {"%{foo}" % {}}.should raise_error(KeyError)
+    context "when key is missing from passed-in hash" do
+      it "raises KeyError" do
+        lambda {"%{foo}" % {}}.should raise_error(KeyError)
+      end
+
+      ruby_version_is "2.5" do
+        it "sets the passed-in hash as receiver for KeyError" do
+          begin
+            hash = {}
+            "%{foo}" % hash
+          rescue KeyError => err
+            err.receiver.should == hash
+          end
+        end
+
+        it "sets the missing key as key in KeyError" do
+          begin
+            hash = {}
+            "%{foo}" % hash
+          rescue KeyError => err
+            err.key.should == :foo
+          end
+        end
+      end
     end
 
     it "should raise ArgumentError if no hash given" do

--- a/optional/capi/hash_spec.rb
+++ b/optional/capi/hash_spec.rb
@@ -140,19 +140,19 @@ describe "C-API Hash function" do
     context "when key is not found" do
       ruby_version_is "2.5" do
         it "sets the hash as receiver for KeyError" do
-          begin
+          -> {
             @s.rb_hash_fetch(@hsh, :c)
-          rescue KeyError => err
+          }.should raise_error(KeyError) { |err|
             err.receiver.should == @hsh
-          end
+          }
         end
 
         it "sets the key as key for KeyError" do
-          begin
+          -> {
             @s.rb_hash_fetch(@hsh, :c)
-          rescue KeyError => err
+          }.should raise_error(KeyError) { |err|
             err.key.should == :c
-          end
+          }
         end
       end
     end

--- a/optional/capi/hash_spec.rb
+++ b/optional/capi/hash_spec.rb
@@ -136,6 +136,26 @@ describe "C-API Hash function" do
     it "raises a KeyError if the key is not found and no default is set" do
       lambda { @s.rb_hash_fetch(@hsh, :c) }.should raise_error(KeyError)
     end
+
+    context "when key is not found" do
+      ruby_version_is "2.5" do
+        it "sets the hash as receiver for KeyError" do
+          begin
+            @s.rb_hash_fetch(@hsh, :c)
+          rescue KeyError => err
+            err.receiver.should == @hsh
+          end
+        end
+
+        it "sets the key as key for KeyError" do
+          begin
+            @s.rb_hash_fetch(@hsh, :c)
+          rescue KeyError => err
+            err.key.should == :c
+          end
+        end
+      end
+    end
   end
 
   describe "rb_hash_foreach" do


### PR DESCRIPTION
Part of #565, this implements Feature 12063: KeyError#receiver / KeyError#key from Ruby 2.5.0 release. 