### PR TITLE
Moves KeyError into Shared spec

### DIFF
--- a/core/env/fetch_spec.rb
+++ b/core/env/fetch_spec.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../../../shared/hash/key_error', __FILE__)
 
 describe "ENV.fetch" do
   it "returns a value" do
@@ -12,31 +13,7 @@ describe "ENV.fetch" do
   end
 
   context "when the key is not found" do
-    before :each do
-      @key = "should_never_be_set"
-    end
-
-    it "raises a KeyError" do
-      lambda { ENV.fetch @key }.should raise_error(KeyError)
-    end
-
-    ruby_version_is "2.5" do
-      it "sets the ENV as the receiver of KeyError" do
-        -> {
-          ENV.fetch @key
-        }.should raise_error(KeyError) { |err|
-          err.receiver.should == ENV
-        }
-      end
-
-      it "sets the non-existent key as the key of KeyError" do
-        -> {
-          ENV.fetch @key
-        }.should raise_error(KeyError) { |err|
-          err.key.should == @key
-        }
-      end
-    end
+    it_behaves_like :key_error, ->(obj, key) { obj.fetch(key) }, ENV
   end
 
   it "provides the given default parameter" do

--- a/core/hash/fetch_spec.rb
+++ b/core/hash/fetch_spec.rb
@@ -1,40 +1,14 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
+require File.expand_path('../../../shared/hash/key_error', __FILE__)
 
 describe "Hash#fetch" do
-  it "returns the value for key" do
-    { a: 1, b: -1 }.fetch(:b).should == -1
+  context "when the key is not found" do
+    it_behaves_like :key_error, ->(obj, key) { obj.fetch(key) }, Hash.new(a: 5)
   end
 
-  context "when the key is not found" do
-    it "raises a KeyError" do
-      lambda { {}.fetch(:a)       }.should raise_error(KeyError)
-      lambda { Hash.new(5).fetch(:a)    }.should raise_error(KeyError)
-      lambda { Hash.new { 5 }.fetch(:a) }.should raise_error(KeyError)
-    end
-
-    ruby_version_is "2.5" do
-      before :each do
-        @hsh = { }
-        @key = :a
-      end
-
-      it "sets the Hash as the receiver of KeyError" do
-        -> {
-          @hsh.fetch(@key)
-        }.should raise_error(KeyError) { |err|
-          err.receiver.should == @hsh
-        }
-      end
-
-      it "sets the not-found key as key of KeyError" do
-        -> {
-          @hsh.fetch(@key)
-        }.should raise_error(KeyError) { |err|
-          err.key.should == @key
-        }
-      end
-    end
+  it "returns the value for key" do
+    { a: 1, b: -1 }.fetch(:b).should == -1
   end
 
   it "returns default if key is not found when passed a default" do

--- a/core/hash/fetch_spec.rb
+++ b/core/hash/fetch_spec.rb
@@ -7,6 +7,7 @@ describe "Hash#fetch" do
     it_behaves_like :key_error, ->(obj, key) { obj.fetch(key) }, Hash.new(a: 5)
     it_behaves_like :key_error, ->(obj, key) { obj.fetch(key) }, {}
     it_behaves_like :key_error, ->(obj, key) { obj.fetch(key) }, Hash.new { 5 }
+    it_behaves_like :key_error, ->(obj, key) { obj.fetch(key) }, Hash.new(5)
   end
 
   it "returns the value for key" do

--- a/core/hash/fetch_spec.rb
+++ b/core/hash/fetch_spec.rb
@@ -5,6 +5,8 @@ require File.expand_path('../../../shared/hash/key_error', __FILE__)
 describe "Hash#fetch" do
   context "when the key is not found" do
     it_behaves_like :key_error, ->(obj, key) { obj.fetch(key) }, Hash.new(a: 5)
+    it_behaves_like :key_error, ->(obj, key) { obj.fetch(key) }, {}
+    it_behaves_like :key_error, ->(obj, key) { obj.fetch(key) }, Hash.new { 5 }
   end
 
   it "returns the value for key" do

--- a/core/hash/fetch_values_spec.rb
+++ b/core/hash/fetch_values_spec.rb
@@ -17,39 +17,16 @@ ruby_version_is "2.3" do
 
     describe "with unmatched keys" do
       it_behaves_like :key_error, ->(obj, key) { obj.fetch_values(key) }, Hash.new(a: 5)
+
+      it "returns the default value from block" do
+        @hash.fetch_values(:z) { |key| "`#{key}' is not found" }.should == ["`z' is not found"]
+        @hash.fetch_values(:a, :z) { |key| "`#{key}' is not found" }.should == [1, "`z' is not found"]
+      end
     end
 
     describe "without keys" do
       it "returns an empty Array" do
         @hash.fetch_values.should == []
-      end
-    end
-  end
-end
-
-ruby_version_is "2.5" do
-  describe "Hash#fetch_values" do
-    before :each do
-      @hash = { a: 1, b: 2, c: 3 }
-    end
-
-    describe "with unmatched keys" do
-      before :each do
-      end
-      it "sets the Hash as the receiver of KeyError" do
-        -> {
-          @hash.fetch_values :a, :z
-        }.should raise_error(KeyError) { |err|
-          err.receiver.should == @hash
-        }
-      end
-
-      it "sets the unmatched key as the key of KeyError" do
-        -> {
-          @hash.fetch_values :a, :z
-        }.should raise_error(KeyError) { |err|
-          err.key.should == :z
-        }
       end
     end
   end

--- a/core/hash/fetch_values_spec.rb
+++ b/core/hash/fetch_values_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
+require File.expand_path('../../../shared/hash/key_error', __FILE__)
 
 ruby_version_is "2.3" do
   describe "Hash#fetch_values" do
@@ -15,15 +16,7 @@ ruby_version_is "2.3" do
     end
 
     describe "with unmatched keys" do
-      it "raises a KeyError" do
-        ->{ @hash.fetch_values :z }.should raise_error(KeyError)
-        ->{ @hash.fetch_values :a, :z }.should raise_error(KeyError)
-      end
-
-      it "returns the default value from block" do
-        @hash.fetch_values(:z) { |key| "`#{key}' is not found" }.should == ["`z' is not found"]
-        @hash.fetch_values(:a, :z) { |key| "`#{key}' is not found" }.should == [1, "`z' is not found"]
-      end
+      it_behaves_like :key_error, ->(obj, key) { obj.fetch_values(key) }, Hash.new(a: 5)
     end
 
     describe "without keys" do

--- a/core/kernel/shared/sprintf.rb
+++ b/core/kernel/shared/sprintf.rb
@@ -1,3 +1,5 @@
+require File.expand_path('../../../../shared/hash/key_error', __FILE__)
+
 describe :kernel_sprintf, shared: true do
   def format(*args)
     @method.call(*args)
@@ -823,36 +825,6 @@ describe :kernel_sprintf, shared: true do
           format("%d %<foo>d", 1, foo: "123")
         }.should raise_error(ArgumentError)
       end
-
-      context "when there is no matching key" do
-        it "raises KeyError" do
-          -> () {
-            format("%<foo>s", {})
-          }.should raise_error(KeyError)
-        end
-
-        ruby_version_is "2.5" do
-          before :each do
-            @hash = { fooo: 1 }
-          end
-
-          it "sets the Hash attempting to format on as receiver of KeyError" do
-            -> () {
-              format("%<foo>s", @hash)
-            }.should raise_error(KeyError) { |err|
-                err.receiver.should == @hash
-            }
-          end
-
-          it "sets the faulty key in the formatter as key of KeyError" do
-            -> () {
-              format("%<foo>s", @hash)
-            }.should raise_error(KeyError) { |err|
-              err.key.should == :foo
-            }
-          end
-        end
-      end
     end
 
     describe "%{name} style" do
@@ -891,5 +863,15 @@ describe :kernel_sprintf, shared: true do
         format("%{foo}", foo: obj).should == "42"
       end
     end
+  end
+
+  describe "faulty key" do
+    before :all do
+      @base_method = @method
+    end
+
+    it_behaves_like :key_error, -> (obj, key) {
+      @base_method.call("%<#{key}>s", obj)
+    }, { foooo: 1 }
   end
 end

--- a/core/string/modulo_spec.rb
+++ b/core/string/modulo_spec.rb
@@ -1,7 +1,12 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes.rb', __FILE__)
+require File.expand_path('../../../shared/hash/key_error', __FILE__)
 
 describe "String#%" do
+  context "when key is missing from passed-in hash" do
+    it_behaves_like :key_error, -> (obj, key) { "%{#{key}}" % obj }, { a: 5 }
+  end
+
   it "formats multiple expressions" do
     ("%b %x %d %s" % [10, 10, 10, 10]).should == "1010 a 10 10"
   end
@@ -762,34 +767,6 @@ describe "String#%" do
   describe "when format string contains %{} sections" do
     it "replaces %{} sections with values from passed-in hash" do
       ("%{foo}bar" % {foo: 'oof'}).should == "oofbar"
-    end
-
-    context "when key is missing from passed-in hash" do
-      it "raises KeyError" do
-        lambda {"%{foo}" % {}}.should raise_error(KeyError)
-      end
-
-      ruby_version_is "2.5" do
-        before :each do
-          @hash = { fooo: 1 }
-        end
-
-        it "sets the passed-in hash as receiver for KeyError" do
-          -> {
-            "%{foo}" % @hash
-          }.should raise_error(KeyError) { |err|
-            err.receiver.should == @hash
-          }
-        end
-
-        it "sets the missing key as key in KeyError" do
-          -> {
-            "%{foo}" % @hash
-          }.should raise_error(KeyError) { |err|
-            err.key.should == :foo
-          }
-        end
-      end
     end
 
     it "should raise ArgumentError if no hash given" do

--- a/optional/capi/hash_spec.rb
+++ b/optional/capi/hash_spec.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../spec_helper', __FILE__)
+require File.expand_path('../../../shared/hash/key_error', __FILE__)
 
 load_extension("hash")
 
@@ -138,23 +139,9 @@ describe "C-API Hash function" do
     end
 
     context "when key is not found" do
-      ruby_version_is "2.5" do
-        it "sets the hash as receiver for KeyError" do
-          -> {
-            @s.rb_hash_fetch(@hsh, :c)
-          }.should raise_error(KeyError) { |err|
-            err.receiver.should == @hsh
-          }
-        end
-
-        it "sets the key as key for KeyError" do
-          -> {
-            @s.rb_hash_fetch(@hsh, :c)
-          }.should raise_error(KeyError) { |err|
-            err.key.should == :c
-          }
-        end
-      end
+      it_behaves_like :key_error, -> (obj, key) {
+        @s.rb_hash_fetch(obj, key)
+      }, { a: 1 }
     end
   end
 

--- a/shared/hash/key_error.rb
+++ b/shared/hash/key_error.rb
@@ -10,7 +10,7 @@ describe :key_error, shared: true do
       -> {
         @method.call(@object, 'foo')
       }.should raise_error(KeyError) { |err|
-        err.receiver.should == @object
+        err.receiver.should equal(@object)
       }
     end
 

--- a/shared/hash/key_error.rb
+++ b/shared/hash/key_error.rb
@@ -1,0 +1,25 @@
+describe :key_error, shared: true do
+  it "raises a KeyError" do
+    -> {
+      @method.call(@object, 'foo')
+    }.should raise_error(KeyError)
+  end
+
+  ruby_version_is "2.5" do
+    it "sets the Hash as the receiver of KeyError" do
+      -> {
+        @method.call(@object, 'foo')
+      }.should raise_error(KeyError) { |err|
+        err.receiver.should == @object
+      }
+    end
+
+    it "sets the unmatched key as the key of KeyError" do
+      -> {
+        @method.call(@object, 'foo')
+      }.should raise_error(KeyError) { |err|
+        err.key.to_s.should == 'foo'
+      }
+    end
+  end
+end


### PR DESCRIPTION
This refactors my work on KeyError (#574) features into a shared spec to reduce the duplication.  

There are two oddities that I should point out, both are limitations I've found with the implementation of `it_behaves_like`:

1. All `it_behaves_like` calls must have an identical `@method` and `@object` calls within a given scope, or they will affect each others' state.  To overcome this, you have to wrap the differing parameter in a `context` or `describe` block.
2. If you have a shared spec that relies upon another shared spec, the above issue gets more complex, because even if you've wrapped it in a describe block, the `@method` has shared scope. To get around this here, I have saved the outer `@method` into a new `@base_method` inside a `before` and referred to it via `@base_method` to solve the collision.

I'm not sure if the two above issues are intentional side-effects of mspec's implementation or unintended bugs so I'm not sure if I should file an issue, but I thought I'd bring it up since it was relevant to my work on this.