### PR TITLE
test Fiber#transfer between fibers in a non-main thread

### DIFF
--- a/library/fiber/transfer_spec.rb
+++ b/library/fiber/transfer_spec.rb
@@ -47,5 +47,24 @@ with_feature :fiber_library do
       fiber = Fiber.new { fiber.resume }
       lambda { fiber.transfer }.should raise_error(FiberError)
     end
+
+    it "transfers control between a non-main thread's root fiber to a child fiber and back again" do
+      states = []
+      thread = Thread.new do
+        f1 = Fiber.new do |f0|
+          states << 0
+          value2 = f0.transfer(1)
+          states << value2
+          3
+        end
+
+        value1 = f1.transfer(Fiber.current)
+        states << value1
+        value3 = f1.transfer(2)
+        states << value3
+      end
+      thread.join
+      states.should == [0, 1, 2, 3]
+    end
   end
 end


### PR DESCRIPTION
Discovered a bug with `Fiber#transfer` that existed in [JRuby issue](https://github.com/jruby/jruby/issues/4920), [TruffleRuby issue](https://github.com/graalvm/truffleruby/issues/903), and [Rubinius issue](https://github.com/rubinius/rubinius/issues/3776). This spec reproduces the problem to catch regressions.