### PR TITLE
backtrace should never be nil for a living Thread

### DIFF
--- a/core/thread/backtrace_spec.rb
+++ b/core/thread/backtrace_spec.rb
@@ -26,6 +26,10 @@ describe "Thread#backtrace" do
   end
 
   it "returns an array (which may be empty) immediately after the thread is created" do
-    Thread.new { sleep }.backtrace.should be_kind_of(Array)
+    t = Thread.new { sleep }
+    backtrace = t.backtrace
+    t.kill
+    t.join
+    backtrace.should be_kind_of(Array)
   end
 end

--- a/core/thread/backtrace_spec.rb
+++ b/core/thread/backtrace_spec.rb
@@ -24,4 +24,8 @@ describe "Thread#backtrace" do
     t.join
     t.backtrace.should == nil
   end
+
+  it "returns an array (which may be empty) immediately after the thread is created" do
+    Thread.new { sleep }.backtrace.should be_kind_of(Array)
+  end
 end


### PR DESCRIPTION
On MRI, immediately after a Thread gets created and before it starts
executing, its backtrace is an empty array.

This behavior changed from 2.0 onwards. On 1.9 it returned nil.

Testing for the backtrace of a recently-created Thread is an inherently
racy operation, so instead of specifically testing for an empty Array
let's at least test that we get **an** Array, which seems enough to
guarantee same-ish behavior.

Issue https://github.com/jruby/jruby/issues/4891