### PR TITLE
[Ruby 2.5] String#-@

### DIFF
--- a/core/string/uminus_spec.rb
+++ b/core/string/uminus_spec.rb
@@ -25,6 +25,10 @@ ruby_version_is "2.3" do
 
         origin.should equal dynamic
       end
+
+      it "returns the same object when it's called on the same String literal" do
+        (-"unfrozen string").should equal(-"unfrozen string")
+      end
     end
   end
 end

--- a/core/string/uminus_spec.rb
+++ b/core/string/uminus_spec.rb
@@ -17,5 +17,14 @@ ruby_version_is "2.3" do
       output.frozen?.should == true
       output.should == 'foo'
     end
+
+    ruby_version_is "2.5" do
+      it "returns the same object for equal unfrozen strings" do
+        origin = -"this string is frozen"
+        dynamic = -%w(this string is frozen).join(' ')
+
+        origin.should equal dynamic
+      end
+    end
   end
 end

--- a/core/string/uminus_spec.rb
+++ b/core/string/uminus_spec.rb
@@ -20,14 +20,16 @@ ruby_version_is "2.3" do
 
     ruby_version_is "2.5" do
       it "returns the same object for equal unfrozen strings" do
-        origin = -"this string is frozen"
-        dynamic = -%w(this string is frozen).join(' ')
+        origin = "this string is frozen"
+        dynamic = %w(this string is frozen).join(' ')
 
-        origin.should equal dynamic
+        origin.should_not equal(dynamic)
+        (-origin).should equal(-dynamic)
       end
 
       it "returns the same object when it's called on the same String literal" do
         (-"unfrozen string").should equal(-"unfrozen string")
+        (-"unfrozen string").should_not equal(-"another unfrozen string")
       end
     end
   end


### PR DESCRIPTION
Done: 
* String#-@ deduplicates unfrozen strings. Already-frozen strings remain unchanged for compatibility
* -"literal" (String#-@) optimized to return the same object

Issue https://github.com/ruby/spec/issues/565