### PR TITLE
Use `equal` matcher instead of manual comparing of `object_id`

### DIFF
--- a/core/array/clear_spec.rb
+++ b/core/array/clear_spec.rb
@@ -10,8 +10,7 @@ describe "Array#clear" do
 
   it "returns self" do
     a = [1]
-    oid = a.object_id
-    a.clear.object_id.should == oid
+    a.should equal a.clear
   end
 
   it "leaves the Array empty" do

--- a/core/array/compact_spec.rb
+++ b/core/array/compact_spec.rb
@@ -50,7 +50,7 @@ describe "Array#compact!" do
 
   it "returns self if some nil elements are removed" do
     a = ['a', nil, 'b', false, 'c']
-    a.compact!.object_id.should == a.object_id
+    a.compact!.should equal a
   end
 
   it "returns nil if there are no nil elements to remove" do

--- a/core/array/reject_spec.rb
+++ b/core/array/reject_spec.rb
@@ -9,9 +9,9 @@ describe "Array#reject" do
     ary = [1, 2, 3, 4, 5]
     ary.reject { true }.should == []
     ary.reject { false }.should == ary
-    ary.reject { false }.object_id.should_not == ary.object_id
+    ary.reject { false }.should_not equal ary
     ary.reject { nil }.should == ary
-    ary.reject { nil }.object_id.should_not == ary.object_id
+    ary.reject { nil }.should_not equal ary
     ary.reject { 5 }.should == []
     ary.reject { |i| i < 3 }.should == [3, 4, 5]
     ary.reject { |i| i % 2 == 0 }.should == [1, 3, 5]

--- a/core/array/shared/clone.rb
+++ b/core/array/shared/clone.rb
@@ -7,8 +7,8 @@ describe :array_clone, shared: true do
   it "produces a shallow copy where the references are directly copied" do
     a = [mock('1'), mock('2')]
     b = a.send @method
-    b.first.object_id.should == a.first.object_id
-    b.last.object_id.should == a.last.object_id
+    b.first.should equal a.first
+    b.last.should equal a.last
   end
 
   it "creates a new array containing all elements or the original" do

--- a/core/array/shared/collect.rb
+++ b/core/array/shared/collect.rb
@@ -5,7 +5,7 @@ describe :array_collect, shared: true do
     a = ['a', 'b', 'c', 'd']
     b = a.send(@method) { |i| i + '!' }
     b.should == ["a!", "b!", "c!", "d!"]
-    b.object_id.should_not == a.object_id
+    b.should_not equal a
   end
 
   it "does not return subclass instance" do
@@ -70,7 +70,7 @@ describe :array_collect_b, shared: true do
   it "returns self" do
     a = [1, 2, 3, 4, 5]
     b = a.send(@method) {|i| i+1 }
-    a.object_id.should == b.object_id
+    a.should equal b
   end
 
   it "returns the evaluated value of block but its contents is partially modified, if it broke in the block" do

--- a/core/env/shared/to_hash.rb
+++ b/core/env/shared/to_hash.rb
@@ -17,6 +17,6 @@ describe :env_to_hash, shared: true do
 
   it "duplicates the ENV when converting to a Hash" do
     h = ENV.send(@method)
-    h.object_id.should_not == ENV.object_id
+    h.should_not equal ENV
   end
 end

--- a/core/exception/no_method_error_spec.rb
+++ b/core/exception/no_method_error_spec.rb
@@ -26,7 +26,7 @@ describe "NoMethodError#args" do
       NoMethodErrorSpecs::NoMethodErrorB.new.foo(1,a)
     rescue Exception => e
       e.args.should == [1,a]
-      e.args[1].object_id.should == a.object_id
+      e.args[1].should equal a
     end
   end
 end

--- a/core/hash/clone_spec.rb
+++ b/core/hash/clone_spec.rb
@@ -7,7 +7,7 @@ describe "Hash#clone" do
     clone = hash.clone
 
     clone.should == hash
-    clone.object_id.should_not == hash.object_id
+    clone.should_not equal hash
   end
 end
 

--- a/core/hash/compare_by_identity_spec.rb
+++ b/core/hash/compare_by_identity_spec.rb
@@ -105,7 +105,7 @@ describe "Hash#compare_by_identity" do
     @idh[foo] = true
     @idh[foo] = true
     @idh.size.should == 1
-    @idh.keys.first.object_id.should == foo.object_id
+    @idh.keys.first.should equal foo
   end
 
   ruby_bug "#12855", "2.2.0"..."2.4.1" do

--- a/core/io/read_spec.rb
+++ b/core/io/read_spec.rb
@@ -257,7 +257,7 @@ describe "IO#read" do
   it "returns the given buffer" do
     buf = ""
 
-    @io.read(nil, buf).object_id.should == buf.object_id
+    @io.read(nil, buf).should equal buf
   end
 
   it "coerces the second argument to string and uses it as a buffer" do
@@ -265,7 +265,7 @@ describe "IO#read" do
     obj = mock("buff")
     obj.should_receive(:to_str).any_number_of_times.and_return(buf)
 
-    @io.read(15, obj).object_id.should_not == obj.object_id
+    @io.read(15, obj).should_not equal obj
     buf.should == @contents
   end
 

--- a/core/kernel/Float_spec.rb
+++ b/core/kernel/Float_spec.rb
@@ -6,7 +6,7 @@ describe :kernel_float, shared: true do
     float = 1.12
     float2 = @object.send(:Float, float)
     float2.should == float
-    float2.object_id.should == float.object_id
+    float2.should equal float
   end
 
   it "returns a Float for Fixnums" do

--- a/core/proc/block_pass_spec.rb
+++ b/core/proc/block_pass_spec.rb
@@ -8,14 +8,14 @@ describe "Proc as a block pass argument" do
   it "remains the same object if re-vivified by the target method" do
     p = Proc.new {}
     p2 = revivify(&p)
-    p.object_id.should == p2.object_id
+    p.should equal p2
     p.should == p2
   end
 
   it "remains the same object if reconstructed with Proc.new" do
     p = Proc.new {}
     p2 = Proc.new(&p)
-    p.object_id.should == p2.object_id
+    p.should equal p2
     p.should == p2
   end
 end
@@ -28,14 +28,14 @@ describe "Proc as an implicit block pass argument" do
   it "remains the same object if re-vivified by the target method" do
     p = Proc.new {}
     p2 = revivify(&p)
-    p.object_id.should == p2.object_id
+    p.should equal p2
     p.should == p2
   end
 
   it "remains the same object if reconstructed with Proc.new" do
     p = Proc.new {}
     p2 = Proc.new(&p)
-    p.object_id.should == p2.object_id
+    p.should equal p2
     p.should == p2
   end
 end

--- a/core/string/chr_spec.rb
+++ b/core/string/chr_spec.rb
@@ -4,7 +4,7 @@ with_feature :encoding do
   describe "String#chr" do
     it "returns a copy of self" do
       s = 'e'
-      s.object_id.should_not == s.chr.object_id
+      s.should_not equal s.chr
     end
 
     it "returns a String" do

--- a/core/string/clear_spec.rb
+++ b/core/string/clear_spec.rb
@@ -14,7 +14,7 @@ with_feature :encoding do
     it "returns self after emptying it" do
       cleared = @s.clear
       cleared.should == ""
-      cleared.object_id.should == @s.object_id
+      cleared.should equal @s
     end
 
     it "preserves its encoding" do

--- a/core/string/freeze_spec.rb
+++ b/core/string/freeze_spec.rb
@@ -3,12 +3,11 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe "String#freeze" do
 
   it "produces the same object whenever called on an instance of a literal in the source" do
-    ids = Array.new(2) { "abc".freeze.object_id }
-    ids.first.should == ids.last
+    "abc".freeze.should equal "abc".freeze
   end
 
   it "doesn't produce the same object for different instances of literals in the source" do
-    "abc".object_id.should_not == "abc".object_id
+    "abc".should_not equal "abc"
   end
 
   it "being a special form doesn't change the value of defined?" do

--- a/core/time/at_spec.rb
+++ b/core/time/at_spec.rb
@@ -48,7 +48,7 @@ describe "Time.at" do
     it "creates a dup time object with the value given by time" do
       t1 = Time.new
       t2 = Time.at(t1)
-      t1.object_id.should_not == t2.object_id
+      t1.should_not equal t2
     end
 
     it "returns a UTC time if the argument is UTC" do

--- a/core/time/succ_spec.rb
+++ b/core/time/succ_spec.rb
@@ -14,6 +14,6 @@ describe "Time#succ" do
     -> {
       t2 = t1.succ
     }.should complain(/Time#succ is obsolete/)
-    t1.object_id.should_not == t2.object_id
+    t1.should_not equal t2
   end
 end

--- a/language/predefined_spec.rb
+++ b/language/predefined_spec.rb
@@ -44,11 +44,11 @@ describe "Predefined global $~" do
   it "is set to contain the MatchData object of the last match if successful" do
     md = /foo/.match 'foo'
     $~.should be_kind_of(MatchData)
-    $~.object_id.should == md.object_id
+    $~.should equal md
 
     /bar/ =~ 'bar'
     $~.should be_kind_of(MatchData)
-    $~.object_id.should_not == md.object_id
+    $~.should_not equal md
   end
 
   it "is set to nil if the last match was unsuccessful" do
@@ -828,7 +828,7 @@ end
 
 describe "Global variable $\"" do
   it "is an alias for $LOADED_FEATURES" do
-    $".object_id.should == $LOADED_FEATURES.object_id
+    $".should equal $LOADED_FEATURES
   end
 
   it "is read-only" do

--- a/library/csv/generate_spec.rb
+++ b/library/csv/generate_spec.rb
@@ -26,7 +26,7 @@ describe "CSV.generate" do
       csv.add_row [1, 2, 3]
       csv << [4, 5, 6]
     end
-    csv_str.object_id.should == str.object_id
+    csv_str.should equal str
     str.should == "1,2,3\n4,5,6\n"
   end
 end

--- a/optional/capi/gc_spec.rb
+++ b/optional/capi/gc_spec.rb
@@ -9,9 +9,9 @@ describe "CApiGCSpecs" do
 
   it "correctly gets the value from a registered address" do
     @f.registered_tagged_address.should == 10
-    @f.registered_tagged_address.object_id.should == @f.registered_tagged_address.object_id
+    @f.registered_tagged_address.should equal(@f.registered_tagged_address)
     @f.registered_reference_address.should == "Globally registered data"
-    @f.registered_reference_address.object_id.should == @f.registered_reference_address.object_id
+    @f.registered_reference_address.should equal(@f.registered_reference_address)
   end
 
   describe "rb_gc_enable" do

--- a/optional/capi/string_spec.rb
+++ b/optional/capi/string_spec.rb
@@ -188,7 +188,7 @@ describe "C-API String function" do
       str1 = "hi"
       str2 = @s.rb_str_new3 str1
       str1.should == str2
-      str1.object_id.should_not == str2.object_id
+      str1.should_not equal str2
     end
   end
 
@@ -217,7 +217,7 @@ describe "C-API String function" do
       str1 = "hi"
       str2 = @s.rb_str_dup str1
       str1.should == str2
-      str1.object_id.should_not == str2.object_id
+      str1.should_not equal str2
     end
   end
 


### PR DESCRIPTION
Replace expectations like

```ruby
obj1.object_id.should == obj2.object_id
```

with `equal` matcher:

```ruby
obj1.should equal obj2
```