### PR TITLE
required paths are real paths

### DIFF
--- a/core/method/source_location_spec.rb
+++ b/core/method/source_location_spec.rb
@@ -13,7 +13,7 @@ describe "Method#source_location" do
   it "sets the first value to the path of the file in which the method was defined" do
     file = @method.source_location.first
     file.should be_an_instance_of(String)
-    file.should == File.dirname(__FILE__) + '/fixtures/classes.rb'
+    file.should == File.realpath('../fixtures/classes.rb', __FILE__)
   end
 
   it "sets the last value to a Fixnum representing the line on which the method was defined" do

--- a/core/proc/source_location_spec.rb
+++ b/core/proc/source_location_spec.rb
@@ -19,19 +19,19 @@ describe "Proc#source_location" do
   it "sets the first value to the path of the file in which the proc was defined" do
     file = @proc.source_location.first
     file.should be_an_instance_of(String)
-    file.should == File.dirname(__FILE__) + '/fixtures/source_location.rb'
+    file.should == File.realpath('../fixtures/source_location.rb', __FILE__)
 
     file = @proc_new.source_location.first
     file.should be_an_instance_of(String)
-    file.should == File.dirname(__FILE__) + '/fixtures/source_location.rb'
+    file.should == File.realpath('../fixtures/source_location.rb', __FILE__)
 
     file = @lambda.source_location.first
     file.should be_an_instance_of(String)
-    file.should == File.dirname(__FILE__) + '/fixtures/source_location.rb'
+    file.should == File.realpath('../fixtures/source_location.rb', __FILE__)
 
     file = @method.source_location.first
     file.should be_an_instance_of(String)
-    file.should == File.dirname(__FILE__) + '/fixtures/source_location.rb'
+    file.should == File.realpath('../fixtures/source_location.rb', __FILE__)
   end
 
   it "sets the last value to a Fixnum representing the line on which the proc was defined" do

--- a/core/unboundmethod/source_location_spec.rb
+++ b/core/unboundmethod/source_location_spec.rb
@@ -9,7 +9,7 @@ describe "UnboundMethod#source_location" do
   it "sets the first value to the path of the file in which the method was defined" do
     file = @method.source_location.first
     file.should be_an_instance_of(String)
-    file.should == File.dirname(__FILE__) + '/fixtures/classes.rb'
+    file.should == File.realpath('../fixtures/classes.rb', __FILE__)
   end
 
   it "sets the last value to a Fixnum representing the line on which the method was defined" do


### PR DESCRIPTION
Fix `test-spec` failures when the build directory is a symbolic
link.