### PR TITLE
Aliased methods on class with a prepended module should have the correct owner

### DIFF
--- a/core/module/prepend_spec.rb
+++ b/core/module/prepend_spec.rb
@@ -104,6 +104,12 @@ describe "Module#prepend" do
     c.new.alias.should == :m
   end
 
+  it "reports the prepended class as the aliased method's owner" do
+    m = Module.new
+    c = Class.new { prepend(m); def meth; :c end; alias_method :alias, :meth }
+    c.instance_method(:alias).owner.should == c
+  end
+
   it "sees an instance of a prepended class as kind of the prepended module" do
     m = Module.new
     c = Class.new { prepend(m) }


### PR DESCRIPTION
We discovered an issue in jruby where a method created via `alias_method` on a class with a prepended module had an owner that was different from the class on which it was defined.

The jruby folks suggested adding a spec here to cover this case. See jruby/jruby#5080.