### PR TITLE
Add spec for `else` without `rescue` and `ensure`

### DIFF
--- a/language/rescue_spec.rb
+++ b/language/rescue_spec.rb
@@ -195,18 +195,34 @@ describe "The rescue keyword" do
     ScratchPad.recorded.should == [:one, :else_ran, :ensure_ran, :outside_begin]
   end
 
-  it "will execute an else block even without rescue and ensure" do
-    lambda {
-      eval <<-ruby
-        begin
-          ScratchPad << :begin
-        else
-          ScratchPad << :else
-        end
-      ruby
-    }.should complain(/else without rescue is useless/)
+  ruby_version_is ''...'2.6' do
+    it "will execute an else block even without rescue and ensure" do
+      lambda {
+        eval <<-ruby
+          begin
+            ScratchPad << :begin
+          else
+            ScratchPad << :else
+          end
+        ruby
+      }.should complain(/else without rescue is useless/)
 
-    ScratchPad.recorded.should == [:begin, :else]
+      ScratchPad.recorded.should == [:begin, :else]
+    end
+  end
+
+  ruby_version_is '2.6' do
+    it "will not execute an else block even without rescue and ensure" do
+      lambda {
+        eval <<-ruby
+          begin
+            ScratchPad << :begin
+          else
+            ScratchPad << :else
+          end
+        ruby
+      }.should raise_error(SyntaxError, /else without rescue is useless/)
+    end
   end
 
   it "will not execute an else block if an exception was raised" do


### PR DESCRIPTION
Follow up of https://github.com/ruby/ruby/commit/140512d2225e6fd046ba1bdbcd1a27450f55c233.

This PR fixes the following error.

```console
% ../mspec/bin/mspec language/rescue_spec.rb
$ ruby /Users/koic/src/github.com/ruby/mspec/bin/mspec-run
language/rescue_spec.rb
ruby 2.6.0dev (2018-03-23 trunk 62902) [x86_64-darwin17]

1)
The rescue keyword will execute an else block even without rescue and
ensure ERROR
SyntaxError: (eval):3: else without rescue is useless
        else
        ^~~~
/Users/koic/src/github.com/ruby/spec/language/rescue_spec.rb:200:in
`eval'
/Users/koic/src/github.com/ruby/spec/language/rescue_spec.rb:200:in
`block (3 levels) in <top (required)>'
/Users/koic/src/github.com/ruby/spec/language/rescue_spec.rb:199:in
`block (2 levels) in <top (required)>'
/Users/koic/src/github.com/ruby/spec/language/rescue_spec.rb:13:in
`<top (required)>'
[\ | ==================100%================== | 00:00:00]      0F
1E

Finished in 0.007407 seconds

1 file, 40 examples, 70 expectations, 0 failures, 1 error, 0 tagged
```