### PR TITLE
Process::Status#termsig: Add SignalException spec

### DIFF
--- a/core/process/status/exitstatus_spec.rb
+++ b/core/process/status/exitstatus_spec.rb
@@ -1,7 +1,6 @@
 require_relative '../../../spec_helper'
 
 describe "Process::Status#exitstatus" do
-
   before :each do
     ruby_exe("exit(42)")
   end
@@ -10,4 +9,17 @@ describe "Process::Status#exitstatus" do
     $?.exitstatus.should == 42
   end
 
+  describe "for a child that raised SignalException" do
+    before :each do
+      ruby_exe("raise SignalException, 'SIGTERM'")
+    end
+
+    platform_is_not :windows do
+      # The exitstatus is not set in these cases. See the termsig_spec
+      # for info on where the signal number (SIGTERM) is available.
+      it "returns nil" do
+        $?.exitstatus.should == nil
+      end
+    end
+  end
 end

--- a/core/process/status/termsig_spec.rb
+++ b/core/process/status/termsig_spec.rb
@@ -13,6 +13,18 @@ describe "Process::Status#termsig" do
     end
   end
 
+  describe "for a child that raised SignalException" do
+    before :each do
+      ruby_exe("raise SignalException, 'SIGTERM'")
+    end
+
+    platform_is_not :windows do
+      it "returns the signal" do
+        $?.termsig.should == Signal.list["TERM"]
+      end
+    end
+  end
+
   describe "for a child that was sent a signal" do
 
     before :each do


### PR DESCRIPTION
We found a case in JRuby where this was not working as expected: https://github.com/jruby/jruby/issues/5134

This spec describes the expected behavior in this scenario. It works on MRI, but fails on the currently released JRuby version (because of the bug, which is fixed in jruby master.)