### PR TITLE
Spec for Kernel#autoload and Kernel.autoload from included module

### DIFF
--- a/core/kernel/autoload_spec.rb
+++ b/core/kernel/autoload_spec.rb
@@ -60,6 +60,32 @@ describe "Kernel#autoload" do
       ruby_exe(fixture(__FILE__, "autoload_frozen.rb")).should == "#{frozen_error_class} - nil"
     end
   end
+
+  describe "when called from included module's method" do
+    module KSAutoloadMethod
+      def setup_autoload
+        autoload :KSAutoloadFromIncludedModule, fixture(__FILE__, "autoload_from_included_module.rb")
+      end
+    end
+    class KSAutoloadMethodIncluder
+      include KSAutoloadMethod
+    end
+    KSAutoloadMethodIncluder.new.setup_autoload
+
+    it "setups the autoload on the included module" do
+      path = fixture(__FILE__, "autoload_from_included_module.rb")
+      KSAutoloadMethod.autoload?(:KSAutoloadFromIncludedModule).should == path
+    end
+
+    it "the autoload is reacheable from the class too" do
+      path = fixture(__FILE__, "autoload_from_included_module.rb")
+      KSAutoloadMethodIncluder.autoload?(:KSAutoloadFromIncludedModule).should == path
+    end
+
+    it "the autoload relative to the included module works" do
+      KSAutoloadMethod::KSAutoloadFromIncludedModule.loaded.should == :autoload_from_included_module
+    end
+  end
 end
 
 describe "Kernel#autoload?" do
@@ -106,6 +132,32 @@ describe "Kernel.autoload" do
     p = mock('path')
     p.should_receive(:to_path).and_return @non_existent
     Kernel.autoload :KSAutoloadAA, p
+  end
+
+  describe "when called from included module's method" do
+    module KSAutoloadMethod2
+      def setup_autoload
+        Kernel.autoload :KSAutoloadFromIncludedModule2, fixture(__FILE__, "autoload_from_included_module2.rb")
+      end
+    end
+    class KSAutoloadMethodIncluder2
+      include KSAutoloadMethod2
+    end
+    KSAutoloadMethodIncluder2.new.setup_autoload
+
+    it "setups the autoload on the included module" do
+      path = fixture(__FILE__, "autoload_from_included_module2.rb")
+      KSAutoloadMethod2.autoload?(:KSAutoloadFromIncludedModule2).should == path
+    end
+
+    it "the autoload is reacheable from the class too" do
+      path = fixture(__FILE__, "autoload_from_included_module2.rb")
+      KSAutoloadMethodIncluder2.autoload?(:KSAutoloadFromIncludedModule2).should == path
+    end
+
+    it "the autoload relative to the included module works" do
+      KSAutoloadMethod2::KSAutoloadFromIncludedModule2.loaded.should == :autoload_from_included_module2
+    end
   end
 end
 

--- a/core/kernel/fixtures/autoload_from_included_module.rb
+++ b/core/kernel/fixtures/autoload_from_included_module.rb
@@ -1,0 +1,7 @@
+module KSAutoloadMethod
+  module KSAutoloadFromIncludedModule
+    def self.loaded
+      :autoload_from_included_module
+    end
+  end
+end

--- a/core/kernel/fixtures/autoload_from_included_module2.rb
+++ b/core/kernel/fixtures/autoload_from_included_module2.rb
@@ -1,0 +1,7 @@
+module KSAutoloadMethod2
+  module KSAutoloadFromIncludedModule2
+    def self.loaded
+      :autoload_from_included_module2
+    end
+  end
+end


### PR DESCRIPTION
`Kernel#autoload` and `Kernel.autoload`, in MRI, aren't based on the receiver of the call. They actually get the caller's call frame (or however you call that), and then use the equivalent of Module.nesting.

This has an impact when they are called from a method of a module that was included somewhere.

Here are specs for this behavior.

I know that JRuby has a different behavior, but I would think it would at some point get fixed once the issue is known. Is there anything special that should be done?

