### PR TITLE
Add spec for #base_label for frame inside block

### DIFF
--- a/core/thread/backtrace/location/base_label_spec.rb
+++ b/core/thread/backtrace/location/base_label_spec.rb
@@ -9,4 +9,14 @@ describe 'Thread::Backtrace::Location#base_label' do
   it 'returns the base label of the call frame' do
     @frame.base_label.should == '<top (required)>'
   end
+
+  describe 'when call frame is inside a block' do
+    before :each do
+      @frame = ThreadBacktraceLocationSpecs.block_location[0]
+    end
+
+    it 'returns the name of the method that contains the block' do
+      @frame.base_label.should == 'block_location'
+    end
+  end
 end


### PR DESCRIPTION
When a given frame is inside a block, #base_label returns the name of the containing method (e.g. `foo`) whereas #label returns the usual `block in foo` label used by the default backtrace format.

Issue jruby/jruby#5162