### PR TITLE
Improve specs of Enumerable #all?, #none? and #one?

### DIFF
--- a/core/enumerable/all_spec.rb
+++ b/core/enumerable/all_spec.rb
@@ -72,16 +72,6 @@ describe "Enumerable#all?" do
       multi = EnumerableSpecs::YieldsMultiWithFalse.new
       multi.all?.should be_true
     end
-
-    ruby_version_is "2.5" do
-      describe "given a pattern argument" do
-        # This spec should be replaced by more extensive ones
-        it "returns true iff all match that pattern" do
-          @enum.all?(Integer).should == true
-          @enum2.all?(NilClass).should == false
-        end
-      end
-    end
   end
 
   describe "with block" do
@@ -141,6 +131,69 @@ describe "Enumerable#all?" do
       yielded = []
       multi.all? { |*args| yielded << args }.should == true
       yielded.should == [[1, 2], [3, 4, 5], [6, 7, 8, 9]]
+    end
+  end
+
+  ruby_version_is "2.5" do
+    describe 'when given a pattern argument' do
+      it "calls `===` on the pattern the return value " do
+        pattern = EnumerableSpecs::Pattern.new { |x| x >= 0 }
+        @enum1.all?(pattern).should == false
+        pattern.yielded.should == [[0], [1], [2], [-1]]
+      end
+
+      it "ignores block" do
+        @enum2.all?(NilClass) { raise }.should == false
+        [1, 2, nil].all?(NilClass) { raise }.should == false
+        {a: 1}.all?(Array) { raise }.should == true
+      end
+
+      it "always returns true on empty enumeration" do
+        @empty.all?(Integer).should == true
+        [].all?(Integer).should == true
+        {}.all?(NilClass).should == true
+      end
+
+      it "does not hide exceptions out of #each" do
+        lambda {
+          EnumerableSpecs::ThrowingEach.new.all?(Integer)
+        }.should raise_error(RuntimeError)
+      end
+
+      it "returns true if the pattern never returns false or nil" do
+        pattern = EnumerableSpecs::Pattern.new { |x| 42 }
+        @enum.all?(pattern).should == true
+
+        [1, 42, 3].all?(pattern).should == true
+
+        pattern = EnumerableSpecs::Pattern.new { |x| Array === x }
+        {a: 1, b: 2}.all?(pattern).should == true
+      end
+
+      it "returns false if the pattern ever returns false or nil" do
+        pattern = EnumerableSpecs::Pattern.new { |x| x >= 0 }
+        @enum1.all?(pattern).should == false
+        pattern.yielded.should == [[0], [1], [2], [-1]]
+
+        [1, 2, 3, -1].all?(pattern).should == false
+
+        pattern = EnumerableSpecs::Pattern.new { |x| x[1] >= 0 }
+        {a: 1, b: -1}.all?(pattern).should == false
+      end
+
+      it "does not hide exceptions out of pattern#===" do
+        pattern = EnumerableSpecs::Pattern.new { raise "from pattern" }
+        lambda {
+          @enum.all?(pattern)
+        }.should raise_error(RuntimeError)
+      end
+
+      it "calls the pattern with gathered array when yielded with multiple arguments" do
+        multi = EnumerableSpecs::YieldsMulti.new
+        pattern = EnumerableSpecs::Pattern.new { true }
+        multi.all?(pattern).should == true
+        pattern.yielded.should == [[[1, 2]], [[3, 4, 5]], [[6, 7, 8, 9]]]
+      end
     end
   end
 end

--- a/core/enumerable/all_spec.rb
+++ b/core/enumerable/all_spec.rb
@@ -2,12 +2,11 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
 describe "Enumerable#all?" do
-
   before :each do
     @enum = EnumerableSpecs::Numerous.new
     @empty = EnumerableSpecs::Empty.new()
-    @enum1 = [0, 1, 2, -1]
-    @enum2 = [nil, false, true]
+    @enum1 = EnumerableSpecs::Numerous.new(0, 1, 2, -1)
+    @enum2 = EnumerableSpecs::Numerous.new(nil, false, true)
   end
 
   it "always returns true on empty enumeration" do
@@ -117,14 +116,16 @@ describe "Enumerable#all?" do
 
     it "gathers initial args as elements when each yields multiple" do
       multi = EnumerableSpecs::YieldsMulti.new
-      multi.all? {|e| !(Array === e) }.should be_true
+      yielded = []
+      multi.all? { |e| yielded << e }
+      yielded.should == [1, 3, 6]
     end
 
     it "yields multiple arguments when each yields multiple" do
       multi = EnumerableSpecs::YieldsMulti.new
       yielded = []
-      multi.all? {|e, i| yielded << [e, i] }
-      yielded.should == [[1, 2], [3, 4], [6, 7]]
+      multi.all? { |*args| yielded << args }
+      yielded.should == [[1, 2], [3, 4, 5], [6, 7, 8, 9]]
     end
   end
 end

--- a/core/enumerable/all_spec.rb
+++ b/core/enumerable/all_spec.rb
@@ -20,6 +20,21 @@ describe "Enumerable#all?" do
     {}.all? { nil }.should == true
   end
 
+  it "raises an ArgumentError when more than 1 argument is provided" do
+    lambda { @enum.all?(1, 2, 3) }.should raise_error(ArgumentError)
+    lambda { [].all?(1, 2, 3) }.should raise_error(ArgumentError)
+    lambda { {}.all?(1, 2, 3) }.should raise_error(ArgumentError)
+  end
+
+  ruby_version_is ""..."2.5" do
+    it "raises an ArgumentError when any arguments provided" do
+      lambda { @enum.all?(Proc.new {}) }.should raise_error(ArgumentError)
+      lambda { @enum.all?(nil) }.should raise_error(ArgumentError)
+      lambda { @empty.all?(1) }.should raise_error(ArgumentError)
+      lambda { @enum1.all?(1) {} }.should raise_error(ArgumentError)
+    end
+  end
+
   it "does not hide exceptions out of #each" do
     lambda {
       EnumerableSpecs::ThrowingEach.new.all?
@@ -117,14 +132,14 @@ describe "Enumerable#all?" do
     it "gathers initial args as elements when each yields multiple" do
       multi = EnumerableSpecs::YieldsMulti.new
       yielded = []
-      multi.all? { |e| yielded << e }
+      multi.all? { |e| yielded << e }.should == true
       yielded.should == [1, 3, 6]
     end
 
     it "yields multiple arguments when each yields multiple" do
       multi = EnumerableSpecs::YieldsMulti.new
       yielded = []
-      multi.all? { |*args| yielded << args }
+      multi.all? { |*args| yielded << args }.should == true
       yielded.should == [[1, 2], [3, 4, 5], [6, 7, 8, 9]]
     end
   end

--- a/core/enumerable/any_spec.rb
+++ b/core/enumerable/any_spec.rb
@@ -149,18 +149,6 @@ describe "Enumerable#any?" do
 
   ruby_version_is "2.5" do
     describe 'when given a pattern argument' do
-      class EnumerableSpecs::Pattern
-        attr_reader :yielded
-        def initialize(&block)
-          @block = block
-          @yielded = []
-        end
-        def ===(*args)
-          @yielded << args
-          @block.call(*args)
-        end
-      end
-
       it "calls `===` on the pattern the return value " do
         pattern = EnumerableSpecs::Pattern.new { |x| x == 2 }
         @enum1.any?(pattern).should == true

--- a/core/enumerable/any_spec.rb
+++ b/core/enumerable/any_spec.rb
@@ -86,7 +86,7 @@ describe "Enumerable#any?" do
       @enum2.any? { |i| i == nil }.should == true
     end
 
-    it "any? should return false if the block never returns other than false or nil" do
+    it "returns false if the block never returns other than false or nil" do
       @enum.any? { false }.should == false
       @enum.any? { nil }.should == false
 
@@ -135,14 +135,14 @@ describe "Enumerable#any?" do
     it "gathers initial args as elements when each yields multiple" do
       multi = EnumerableSpecs::YieldsMulti.new
       yielded = []
-      multi.any? { |e| yielded << e; false }
+      multi.any? { |e| yielded << e; false }.should == false
       yielded.should == [1, 3, 6]
     end
 
     it "yields multiple arguments when each yields multiple" do
       multi = EnumerableSpecs::YieldsMulti.new
       yielded = []
-      multi.any? { |*args| yielded << args; false }
+      multi.any? { |*args| yielded << args; false }.should == false
       yielded.should == [[1, 2], [3, 4, 5], [6, 7, 8, 9]]
     end
   end
@@ -196,7 +196,7 @@ describe "Enumerable#any?" do
         {a: 1, b: 2}.any?(pattern).should == true
       end
 
-      it "any? should return false if the block never returns other than false or nil" do
+      it "returns false if the block never returns other than false or nil" do
         pattern = EnumerableSpecs::Pattern.new { |x| nil }
         @enum1.any?(pattern).should == false
         pattern.yielded.should == [[0], [1], [2], [-1]]

--- a/core/enumerable/fixtures/classes.rb
+++ b/core/enumerable/fixtures/classes.rb
@@ -328,4 +328,18 @@ module EnumerableSpecs
       EnumerableMapping.new(self, block)
     end
   end
+
+  class Pattern
+    attr_reader :yielded
+
+    def initialize(&block)
+      @block = block
+      @yielded = []
+    end
+
+    def ===(*args)
+      @yielded << args
+      @block.call(*args)
+    end
+  end
 end # EnumerableSpecs utility classes

--- a/core/enumerable/none_spec.rb
+++ b/core/enumerable/none_spec.rb
@@ -2,20 +2,103 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
 describe "Enumerable#none?" do
-  it "returns true if none of the elements in self are true" do
-    e = EnumerableSpecs::Numerous.new(false, nil, false)
-    e.none?.should be_true
+  before :each do
+    @empty = EnumerableSpecs::Empty.new
+    @enum = EnumerableSpecs::Numerous.new
   end
 
-  it "returns false if at least one of the elements in self are true" do
-    e = EnumerableSpecs::Numerous.new(false, nil, true, false)
-    e.none?.should be_false
+  it "always returns true on empty enumeration" do
+    @empty.none?.should == true
+    @empty.none? { true }.should == true
   end
 
-  it "gathers whole arrays as elements when each yields multiple" do
-    # This spec doesn't spec what it says it does
-    multi = EnumerableSpecs::YieldsMultiWithFalse.new
-    multi.none?.should be_false
+  it "raises an ArgumentError when more than 1 argument is provided" do
+    lambda { @enum.none?(1, 2, 3) }.should raise_error(ArgumentError)
+    lambda { [].none?(1, 2, 3) }.should raise_error(ArgumentError)
+    lambda { {}.none?(1, 2, 3) }.should raise_error(ArgumentError)
+  end
+
+  ruby_version_is ""..."2.5" do
+    it "raises an ArgumentError when any arguments provided" do
+      lambda { @enum.none?(Proc.new {}) }.should raise_error(ArgumentError)
+      lambda { @enum.none?(nil) }.should raise_error(ArgumentError)
+      lambda { @empty.none?(1) }.should raise_error(ArgumentError)
+      lambda { @enum.none?(1) {} }.should raise_error(ArgumentError)
+    end
+  end
+
+  it "does not hide exceptions out of #each" do
+    lambda {
+      EnumerableSpecs::ThrowingEach.new.none?
+    }.should raise_error(RuntimeError)
+
+    lambda {
+      EnumerableSpecs::ThrowingEach.new.none? { false }
+    }.should raise_error(RuntimeError)
+  end
+
+  describe "with no block" do
+    it "returns true if none of the elements in self are true" do
+      e = EnumerableSpecs::Numerous.new(false, nil, false)
+      e.none?.should be_true
+    end
+
+    it "returns false if at least one of the elements in self are true" do
+      e = EnumerableSpecs::Numerous.new(false, nil, true, false)
+      e.none?.should be_false
+    end
+
+    it "gathers whole arrays as elements when each yields multiple" do
+      # This spec doesn't spec what it says it does
+      multi = EnumerableSpecs::YieldsMultiWithFalse.new
+      multi.none?.should be_false
+    end
+  end
+
+  describe "with a block" do
+    before :each do
+      @e = EnumerableSpecs::Numerous.new(1,1,2,3,4)
+    end
+
+    it "passes each element to the block in turn until it returns true" do
+      acc = []
+      @e.none? {|e| acc << e; false }
+      acc.should == [1,1,2,3,4]
+    end
+
+    it "stops passing elements to the block when it returns true" do
+      acc = []
+      @e.none? {|e| acc << e; e == 3 ? true : false }
+      acc.should == [1,1,2,3]
+    end
+
+    it "returns true if the block never returns true" do
+      @e.none? {|e| false }.should be_true
+    end
+
+    it "returns false if the block ever returns true" do
+      @e.none? {|e| e == 3 ? true : false }.should be_false
+    end
+
+    it "does not hide exceptions out of the block" do
+      lambda {
+        @enum.none? { raise "from block" }
+      }.should raise_error(RuntimeError)
+    end
+
+    it "gathers initial args as elements when each yields multiple" do
+      multi = EnumerableSpecs::YieldsMulti.new
+      yielded = []
+      multi.none? { |e| yielded << e; false }
+      yielded.should == [1, 3, 6]
+    end
+
+    it "yields multiple arguments when each yields multiple" do
+      multi = EnumerableSpecs::YieldsMulti.new
+      yielded = []
+      multi.none? { |*args| yielded << args; false }
+      yielded.should == [[1, 2], [3, 4, 5], [6, 7, 8, 9]]
+    end
   end
 
   ruby_version_is "2.5" do
@@ -26,43 +109,5 @@ describe "Enumerable#none?" do
         [nil, false, true].none?(NilClass).should == false
       end
     end
-  end
-end
-
-describe "Enumerable#none? with a block" do
-  before :each do
-    @e = EnumerableSpecs::Numerous.new(1,1,2,3,4)
-  end
-
-  it "passes each element to the block in turn until it returns true" do
-    acc = []
-    @e.none? {|e| acc << e; false }
-    acc.should == [1,1,2,3,4]
-  end
-
-  it "stops passing elements to the block when it returns true" do
-    acc = []
-    @e.none? {|e| acc << e; e == 3 ? true : false }
-    acc.should == [1,1,2,3]
-  end
-
-  it "returns true if the block never returns true" do
-    @e.none? {|e| false }.should be_true
-  end
-
-  it "returns false if the block ever returns true" do
-    @e.none? {|e| e == 3 ? true : false }.should be_false
-  end
-
-  it "gathers initial args as elements when each yields multiple" do
-    multi = EnumerableSpecs::YieldsMulti.new
-    multi.none? {|e| e == [1, 2] }.should be_true
-  end
-
-  it "yields multiple arguments when each yields multiple" do
-    multi = EnumerableSpecs::YieldsMulti.new
-    yielded = []
-    multi.none? {|e, i| yielded << [e, i] }
-    yielded.should == [[1, 2]]
   end
 end

--- a/core/enumerable/one_spec.rb
+++ b/core/enumerable/one_spec.rb
@@ -2,6 +2,41 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
 describe "Enumerable#one?" do
+  before :each do
+    @empty = EnumerableSpecs::Empty.new
+    @enum = EnumerableSpecs::Numerous.new
+  end
+
+  it "always returns false on empty enumeration" do
+    @empty.one?.should == false
+    @empty.one? { true }.should == false
+  end
+
+  it "raises an ArgumentError when more than 1 argument is provided" do
+    lambda { @enum.one?(1, 2, 3) }.should raise_error(ArgumentError)
+    lambda { [].one?(1, 2, 3) }.should raise_error(ArgumentError)
+    lambda { {}.one?(1, 2, 3) }.should raise_error(ArgumentError)
+  end
+
+  ruby_version_is ""..."2.5" do
+    it "raises an ArgumentError when any arguments provided" do
+      lambda { @enum.one?(Proc.new {}) }.should raise_error(ArgumentError)
+      lambda { @enum.one?(nil) }.should raise_error(ArgumentError)
+      lambda { @empty.one?(1) }.should raise_error(ArgumentError)
+      lambda { @enum.one?(1) {} }.should raise_error(ArgumentError)
+    end
+  end
+
+  it "does not hide exceptions out of #each" do
+    lambda {
+      EnumerableSpecs::ThrowingEach.new.one?
+    }.should raise_error(RuntimeError)
+
+    lambda {
+      EnumerableSpecs::ThrowingEach.new.one? { false }
+    }.should raise_error(RuntimeError)
+  end
+
   describe "when passed a block" do
     it "returns true if block returns true once" do
       [:a, :b, :c].one? { |s| s == :a }.should be_true
@@ -15,18 +50,24 @@ describe "Enumerable#one?" do
       [:a, :b, :c].one? { |s| s == :d }.should be_false
     end
 
+    it "does not hide exceptions out of the block" do
+      lambda {
+        @enum.one? { raise "from block" }
+      }.should raise_error(RuntimeError)
+    end
+
     it "gathers initial args as elements when each yields multiple" do
       # This spec doesn't spec what it says it does
       multi = EnumerableSpecs::YieldsMulti.new
       yielded = []
-      multi.one? { |e| yielded << e; false }
+      multi.one? { |e| yielded << e; false }.should == false
       yielded.should == [1, 3, 6]
     end
 
     it "yields multiple arguments when each yields multiple" do
       multi = EnumerableSpecs::YieldsMulti.new
       yielded = []
-      multi.one? { |*args| yielded << args; false }
+      multi.one? { |*args| yielded << args; false }.should == false
       yielded.should == [[1, 2], [3, 4, 5], [6, 7, 8, 9]]
     end
 

--- a/core/enumerable/one_spec.rb
+++ b/core/enumerable/one_spec.rb
@@ -18,14 +18,16 @@ describe "Enumerable#one?" do
     it "gathers initial args as elements when each yields multiple" do
       # This spec doesn't spec what it says it does
       multi = EnumerableSpecs::YieldsMulti.new
-      multi.one? {|e| e == 1 }.should be_true
+      yielded = []
+      multi.one? { |e| yielded << e; false }
+      yielded.should == [1, 3, 6]
     end
 
     it "yields multiple arguments when each yields multiple" do
       multi = EnumerableSpecs::YieldsMulti.new
       yielded = []
-      multi.one? {|e, i| yielded << [e, i] }
-      yielded.should == [[1, 2], [3, 4]]
+      multi.one? { |*args| yielded << args; false }
+      yielded.should == [[1, 2], [3, 4, 5], [6, 7, 8, 9]]
     end
 
     ruby_version_is "2.5" do


### PR DESCRIPTION
Adopt new specs for #any? (https://github.com/ruby/spec/commit/c76b47c32a2cdda71e183ebf7747d9267c165fc4) to the other methods.

Related issue https://github.com/ruby/spec/issues/550