### PR TITLE
Be more flexible in the message for Errno::EPIPE

### DIFF
--- a/core/io/shared/write.rb
+++ b/core/io/shared/write.rb
@@ -87,7 +87,7 @@ describe :io_write, shared: true do
 
     it "raises Errno::EPIPE if the read end is closed" do
       @r.close
-      -> { @w.send(@method, "foo") }.should raise_error(Errno::EPIPE, "Broken pipe")
+      -> { @w.send(@method, "foo") }.should raise_error(Errno::EPIPE, /Broken pipe/)
     end
   end
 end


### PR DESCRIPTION
https://github.com/jruby/jruby/commit/6598331f4f45bb12cbcc05635c2926cc5646832b#diff-7d23c1ab694a49b5cfdc07104c3f0877

just a sync with jruby