### PR TITLE
Add spec for splatting empty Array/Hash

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,9 @@ Lint/LiteralAsCondition:
 Lint/UnneededRequireStatement:
   Enabled: false
 
+Lint/UnneededSplatExpansion:
+  Enabled: false
+
 Lint/UnifiedInteger:
   Enabled: false
 
@@ -52,7 +55,6 @@ Lint/UselessAssignment:
 Lint/UselessComparison:
   Enabled: false
 
-# The cop registers too many false positives to `.should == something`
 Lint/Void:
   Enabled: false
 
@@ -65,10 +67,31 @@ Lint/EmptyWhen:
     - language/case_spec.rb
     - optional/capi/spec_helper.rb
 
+Lint/FormatParameterMismatch:
+  Exclude:
+    - 'core/kernel/shared/sprintf.rb'
+    - 'core/string/modulo_spec.rb'
+
 Lint/NestedMethodDefinition:
   Exclude:
     - language/def_spec.rb
     - language/fixtures/def.rb
+
+Lint/UnreachableCode:
+  Exclude:
+    - 'core/enumerator/lazy/fixtures/classes.rb'
+    - 'core/kernel/catch_spec.rb'
+    - 'core/kernel/throw_spec.rb'
+    - 'language/break_spec.rb'
+    - 'language/fixtures/break.rb'
+    - 'language/fixtures/break_lambda_toplevel.rb'
+    - 'language/fixtures/break_lambda_toplevel_block.rb'
+    - 'language/fixtures/break_lambda_toplevel_method.rb'
+    - 'language/fixtures/return.rb'
+    - 'language/next_spec.rb'
+    - 'language/return_spec.rb'
+    - 'optional/capi/kernel_spec.rb'
+    - 'shared/kernel/raise.rb'
 
 Lint/UriRegexp:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -32,12 +32,6 @@ Lint/FloatOutOfRange:
   Exclude:
     - 'core/string/modulo_spec.rb'
 
-# Offense count: 107
-Lint/FormatParameterMismatch:
-  Exclude:
-    - 'core/kernel/shared/sprintf.rb'
-    - 'core/string/modulo_spec.rb'
-
 # Offense count: 29
 Lint/HandleExceptions:
   Enabled: false
@@ -147,42 +141,6 @@ Lint/UnderscorePrefixedVariableName:
     - 'core/io/pipe_spec.rb'
     - 'core/io/popen_spec.rb'
     - 'language/block_spec.rb'
-
-# Offense count: 90
-# Cop supports --auto-correct.
-Lint/UnneededSplatExpansion:
-  Exclude:
-    - 'core/array/element_reference_spec.rb'
-    - 'core/enumerable/fixtures/classes.rb'
-    - 'core/enumerable/max_by_spec.rb'
-    - 'core/enumerable/min_by_spec.rb'
-    - 'core/enumerable/minmax_by_spec.rb'
-    - 'core/enumerator/lazy/fixtures/classes.rb'
-    - 'core/file/basename_spec.rb'
-    - 'core/kernel/p_spec.rb'
-    - 'language/array_spec.rb'
-    - 'language/break_spec.rb'
-    - 'language/case_spec.rb'
-    - 'language/next_spec.rb'
-    - 'language/send_spec.rb'
-    - 'language/variables_spec.rb'
-
-# Offense count: 54
-Lint/UnreachableCode:
-  Exclude:
-    - 'core/enumerator/lazy/fixtures/classes.rb'
-    - 'core/kernel/catch_spec.rb'
-    - 'core/kernel/throw_spec.rb'
-    - 'language/break_spec.rb'
-    - 'language/fixtures/break.rb'
-    - 'language/fixtures/break_lambda_toplevel.rb'
-    - 'language/fixtures/break_lambda_toplevel_block.rb'
-    - 'language/fixtures/break_lambda_toplevel_method.rb'
-    - 'language/fixtures/return.rb'
-    - 'language/next_spec.rb'
-    - 'language/return_spec.rb'
-    - 'optional/capi/kernel_spec.rb'
-    - 'shared/kernel/raise.rb'
 
 # Offense count: 7
 # Configuration parameters: ContextCreatingMethods, MethodCreatingMethods.

--- a/language/method_spec.rb
+++ b/language/method_spec.rb
@@ -512,6 +512,15 @@ describe "A method" do
     end
 
     evaluate <<-ruby do
+        def m() end
+      ruby
+
+      m().should be_nil
+      m(*[]).should be_nil
+      m(**{}).should be_nil
+    end
+
+    evaluate <<-ruby do
         def m(*) end
       ruby
 
@@ -527,6 +536,8 @@ describe "A method" do
       m().should == []
       m(1).should == [1]
       m(1, 2, 3).should == [1, 2, 3]
+      m(*[]).should == []
+      m(**{}).should == []
     end
 
     evaluate <<-ruby do
@@ -561,6 +572,8 @@ describe "A method" do
 
       m().should == {}
       m(a: 1, b: 2).should == { a: 1, b: 2 }
+      m(*[]).should == {}
+      m(**{}).should == {}
       lambda { m(2) }.should raise_error(ArgumentError)
     end
 


### PR DESCRIPTION
Hi,

Today I found a bug in Opal (opal/opal#1872). It would be nice if there is a spec that covers the case.