### PR TITLE
Include some basic tests for Regexp to test POSIX bracket expressions for unicode 8.0 / 9.0

### DIFF
--- a/language/regexp_spec.rb
+++ b/language/regexp_spec.rb
@@ -167,4 +167,31 @@ describe "Literal Regexps" do
       pattern.to_s.should == ref
     end
   end
+
+  ruby_version_is '2.4' do
+    it "support handling unicode 9.0 characters with POSIX bracket expressions" do
+      char_lowercase = "\u{104D8}" # OSAGE SMALL LETTER A
+      /[[:lower:]]/.match(char_lowercase).to_s.should == char_lowercase
+      char_uppercase = "\u{104B0}" # OSAGE CAPITAL LETTER A
+      /[[:upper:]]/.match(char_uppercase).to_s.should == char_uppercase
+    end
+  end
+
+  ruby_version_is ""..."2.4" do
+    it "does not support handling unicode 9.0 characters with POSIX bracket expressions" do
+      char_lowercase = "\u{104D8}" # OSAGE SMALL LETTER A
+      /[[:lower:]]/.match(char_lowercase).to_s.should == nil
+
+      char_uppercase = "\u{104B0}" # OSAGE CAPITAL LETTER A
+      /[[:upper:]]/.match(char_lowercase).to_s.should == nil
+    end
+
+    it "supports handling unicode 8.0 characters with POSIX bracket expressions" do
+      char_lowercase = "\u{A7B5}" # LATIN SMALL LETTER BETA
+      /[[:lower:]]/.match(char_lowercase).to_s.should == char_lowercase
+
+      char_uppercase = "\u{A7B4}" # LATIN CAPTIAL LETTER BETA
+      /[[:upper:]]/.match(char_uppercase).to_s.should == char_uppercase
+    end
+  end
 end

--- a/language/regexp_spec.rb
+++ b/language/regexp_spec.rb
@@ -180,10 +180,10 @@ describe "Literal Regexps" do
   ruby_version_is ""..."2.4" do
     it "does not support handling unicode 9.0 characters with POSIX bracket expressions" do
       char_lowercase = "\u{104D8}" # OSAGE SMALL LETTER A
-      /[[:lower:]]/.match(char_lowercase).to_s.should.empty?
+      /[[:lower:]]/.match(char_lowercase).to_s.should == ""
 
       char_uppercase = "\u{104B0}" # OSAGE CAPITAL LETTER A
-      /[[:upper:]]/.match(char_lowercase).to_s.should.empty?
+      /[[:upper:]]/.match(char_lowercase).to_s.should == ""
     end
 
     it "supports handling unicode 8.0 characters with POSIX bracket expressions" do

--- a/language/regexp_spec.rb
+++ b/language/regexp_spec.rb
@@ -190,7 +190,7 @@ describe "Literal Regexps" do
       char_lowercase = "\u{A7B5}" # LATIN SMALL LETTER BETA
       /[[:lower:]]/.match(char_lowercase).to_s.should == char_lowercase
 
-      char_uppercase = "\u{A7B4}" # LATIN CAPTIAL LETTER BETA
+      char_uppercase = "\u{A7B4}" # LATIN CAPITAL LETTER BETA
       /[[:upper:]]/.match(char_uppercase).to_s.should == char_uppercase
     end
   end

--- a/language/regexp_spec.rb
+++ b/language/regexp_spec.rb
@@ -180,10 +180,10 @@ describe "Literal Regexps" do
   ruby_version_is ""..."2.4" do
     it "does not support handling unicode 9.0 characters with POSIX bracket expressions" do
       char_lowercase = "\u{104D8}" # OSAGE SMALL LETTER A
-      /[[:lower:]]/.match(char_lowercase).to_s.should == ""
+      /[[:lower:]]/.match(char_lowercase).should == nil
 
       char_uppercase = "\u{104B0}" # OSAGE CAPITAL LETTER A
-      /[[:upper:]]/.match(char_lowercase).to_s.should == ""
+      /[[:upper:]]/.match(char_lowercase).should == nil
     end
 
     it "supports handling unicode 8.0 characters with POSIX bracket expressions" do

--- a/language/regexp_spec.rb
+++ b/language/regexp_spec.rb
@@ -180,10 +180,10 @@ describe "Literal Regexps" do
   ruby_version_is ""..."2.4" do
     it "does not support handling unicode 9.0 characters with POSIX bracket expressions" do
       char_lowercase = "\u{104D8}" # OSAGE SMALL LETTER A
-      /[[:lower:]]/.match(char_lowercase).to_s.should == nil
+      /[[:lower:]]/.match(char_lowercase).to_s.should.empty?
 
       char_uppercase = "\u{104B0}" # OSAGE CAPITAL LETTER A
-      /[[:upper:]]/.match(char_lowercase).to_s.should == nil
+      /[[:upper:]]/.match(char_lowercase).to_s.should.empty?
     end
 
     it "supports handling unicode 8.0 characters with POSIX bracket expressions" do


### PR DESCRIPTION
I included some basic tests for the POSIX bracket expressions functionality in the Regexp class. The tests will check (depend on the ruby verion) about compatibility of unicode 9.0.