### PR TITLE
[Ruby 2.5] Add specs for String#each_grapheme_cluster and String#grapheme_clusters

### DIFF
--- a/core/string/each_grapheme_cluster_spec.rb
+++ b/core/string/each_grapheme_cluster_spec.rb
@@ -1,0 +1,11 @@
+require_relative 'shared/chars'
+require_relative 'shared/grapheme_clusters'
+require_relative 'shared/each_char_without_block'
+
+ruby_version_is "2.5" do
+  describe "String#each_grapheme_cluster" do
+    it_behaves_like :string_chars, :each_grapheme_cluster
+    it_behaves_like :string_grapheme_clusters, :each_grapheme_cluster
+    it_behaves_like :string_each_char_without_block, :each_grapheme_cluster
+  end
+end

--- a/core/string/grapheme_clusters_spec.rb
+++ b/core/string/grapheme_clusters_spec.rb
@@ -1,0 +1,15 @@
+require_relative 'shared/chars'
+require_relative 'shared/grapheme_clusters'
+
+ruby_version_is "2.5" do
+  describe "String#grapheme_clusters" do
+    it_behaves_like :string_chars, :grapheme_clusters
+    it_behaves_like :string_grapheme_clusters, :grapheme_clusters
+
+    it "returns an array when no block given" do
+      string = "ab\u{1f3f3}\u{fe0f}\u{200d}\u{1f308}\u{1F43E}"
+      string.grapheme_clusters.should == ['a', 'b', "\u{1f3f3}\u{fe0f}\u{200d}\u{1f308}", "\u{1F43E}"]
+
+    end
+  end
+end

--- a/core/string/shared/grapheme_clusters.rb
+++ b/core/string/shared/grapheme_clusters.rb
@@ -1,0 +1,16 @@
+require_relative '../../../spec_helper'
+require_relative '../fixtures/classes'
+
+describe :string_grapheme_clusters, shared: true do
+  it "passes each grapheme cluster in self to the given block" do
+    a = []
+    # test string: abc[rainbow flag emoji][paw prints]
+    "ab\u{1f3f3}\u{fe0f}\u{200d}\u{1f308}\u{1F43E}".send(@method) { |c| a << c }
+    a.should == ['a', 'b', "\u{1f3f3}\u{fe0f}\u{200d}\u{1f308}", "\u{1F43E}"]
+  end
+
+  it "returns self" do
+    s = StringSpecs::MyString.new "ab\u{1f3f3}\u{fe0f}\u{200d}\u{1f308}\u{1F43E}"
+    s.send(@method) {}.should equal(s)
+  end
+end


### PR DESCRIPTION
Something for #565.  Was inspired by the specs for `#chars` and `#each_chars` for this one, and I also reused the shared specs for those as they behave mostly the same.  Suggestions welcome! 😄 