### PR TITLE
Enumerable#any?, one? and all? with multiple yield

### DIFF
--- a/core/enumerable/all_spec.rb
+++ b/core/enumerable/all_spec.rb
@@ -53,6 +53,9 @@ describe "Enumerable#all?" do
 
       EnumerableSpecs::Numerous.new('a','b','c').all?.should == true
       EnumerableSpecs::Numerous.new(0, "x", true).all?.should == true
+      EnumerableSpecs::Numerous.new([]).all?.should == true
+      EnumerableSpecs::Numerous.new([false]).all?.should == true
+      EnumerableSpecs::Numerous.new([nil]).all?.should == true
     end
 
     it "returns false if there are false or nil elements" do
@@ -65,12 +68,6 @@ describe "Enumerable#all?" do
       EnumerableSpecs::Numerous.new(1, nil, 2).all?.should == false
       EnumerableSpecs::Numerous.new(0, "x", false, true).all?.should == false
       @enum2.all?.should == false
-    end
-
-    it "gathers whole arrays as elements when each yields multiple" do
-      # This spec doesn't spec what it says it does
-      multi = EnumerableSpecs::YieldsMultiWithFalse.new
-      multi.all?.should be_true
     end
   end
 

--- a/core/enumerable/none_spec.rb
+++ b/core/enumerable/none_spec.rb
@@ -46,14 +46,10 @@ describe "Enumerable#none?" do
     end
 
     it "returns false if at least one of the elements in self are true" do
-      e = EnumerableSpecs::Numerous.new(false, nil, true, false)
-      e.none?.should be_false
-    end
-
-    it "gathers whole arrays as elements when each yields multiple" do
-      # This spec doesn't spec what it says it does
-      multi = EnumerableSpecs::YieldsMultiWithFalse.new
-      multi.none?.should be_false
+      EnumerableSpecs::Numerous.new(false, nil, true).none?.should be_false
+      EnumerableSpecs::Numerous.new([]).none?.should be_false
+      EnumerableSpecs::Numerous.new([false]).none?.should be_false
+      EnumerableSpecs::Numerous.new([nil]).none?.should be_false
     end
   end
 

--- a/core/enumerable/one_spec.rb
+++ b/core/enumerable/one_spec.rb
@@ -42,19 +42,19 @@ describe "Enumerable#one?" do
   describe "with no block" do
     it "returns true if only one element evaluates to true" do
       [false, nil, true].one?.should be_true
+      [false, nil, []].one?.should be_true
+      [false, nil, [false]].one?.should be_true
+      [false, nil, [nil]].one?.should be_true
     end
 
     it "returns false if two elements evaluate to true" do
       [false, :value, nil, true].one?.should be_false
+      [false, [], nil, [false]].one?.should be_false
+      [false, [], nil, [nil]].one?.should be_false
     end
 
     it "returns false if all elements evaluate to false" do
-      [false, nil, false].one?.should be_false
-    end
-
-    it "gathers whole arrays as elements when each yields multiple" do
-      multi = EnumerableSpecs::YieldsMultiWithSingleTrue.new
-      multi.one?.should be_false
+      [false, nil].one?.should be_false
     end
   end
 
@@ -75,21 +75,6 @@ describe "Enumerable#one?" do
       lambda {
         @enum.one? { raise "from block" }
       }.should raise_error(RuntimeError)
-    end
-
-    it "gathers initial args as elements when each yields multiple" do
-      # This spec doesn't spec what it says it does
-      multi = EnumerableSpecs::YieldsMulti.new
-      yielded = []
-      multi.one? { |e| yielded << e; false }.should == false
-      yielded.should == [1, 3, 6]
-    end
-
-    it "yields multiple arguments when each yields multiple" do
-      multi = EnumerableSpecs::YieldsMulti.new
-      yielded = []
-      multi.one? { |*args| yielded << args; false }.should == false
-      yielded.should == [[1, 2], [3, 4, 5], [6, 7, 8, 9]]
     end
   end
 


### PR DESCRIPTION
Assuming the original intent for [these tests](https://github.com/ruby/spec/commit/13c5170c7dc79064dd0a2e7a7503bc2a3c6fb152) was to test the behavior of `#all?`, `#none?`, and `#one?` with array elements, these changes fix https://github.com/ruby/spec/issues/554.