### PR TITLE
[Ruby 2.6] Add specs for Random.bytes

### DIFF
--- a/core/random/bytes_spec.rb
+++ b/core/random/bytes_spec.rb
@@ -1,18 +1,9 @@
 # -*- encoding: binary -*-
 require_relative '../../spec_helper'
+require_relative 'shared/bytes'
 
 describe "Random#bytes" do
-  it "returns a String" do
-    Random.new.bytes(1).should be_an_instance_of(String)
-  end
-
-  it "returns a String of the length given as argument" do
-    Random.new.bytes(15).length.should == 15
-  end
-
-  it "returns an ASCII-8BIT String" do
-    Random.new.bytes(15).encoding.should == Encoding::ASCII_8BIT
-  end
+  it_behaves_like :random_bytes, :bytes, Random.new
 
   it "returns the same output for a given seed" do
     Random.new(33).bytes(2).should == Random.new(33).bytes(2)
@@ -32,8 +23,10 @@ describe "Random#bytes" do
     rnd.bytes(1000) # skip some
     rnd.bytes(2).should == "\x17\x12"
   end
+end
 
-  it "returns a random binary String" do
-    Random.new.bytes(12).should_not == Random.new.bytes(12)
+ruby_version_is "2.6" do
+  describe "Random.bytes" do
+    it_behaves_like :random_bytes, :bytes, Random
   end
 end

--- a/core/random/shared/bytes.rb
+++ b/core/random/shared/bytes.rb
@@ -1,0 +1,17 @@
+describe :random_bytes, shared: true do
+  it "returns a String" do
+    @object.bytes(1).should be_an_instance_of(String)
+  end
+
+  it "returns a String of the length given as argument" do
+    @object.bytes(15).length.should == 15
+  end
+
+  it "returns an ASCII-8BIT String" do
+    @object.bytes(15).encoding.should == Encoding::ASCII_8BIT
+  end
+
+  it "returns a random binary String" do
+    @object.bytes(12).should_not == @object.bytes(12)
+  end
+end


### PR DESCRIPTION
This PR adds a spec for [feature 4938](https://bugs.ruby-lang.org/issues/4780) where `Random.bytes` was added for convenience.

I moved the specs from `Random#bytes` where no seed is required to a shared spec and use them for both `Random#bytes` and `Random.bytes`.