### PR TITLE
 Add Set-like object interoperation specs 

### DIFF
--- a/library/set/disjoint_spec.rb
+++ b/library/set/disjoint_spec.rb
@@ -1,0 +1,23 @@
+require_relative '../../spec_helper'
+require_relative 'shared/set_like'
+require 'set'
+
+describe "Set#disjoint?" do
+  it "returns false when two Sets have at least one element in common" do
+    Set[1, 2].disjoint?(Set[2, 3]).should == false
+  end
+
+  it "returns true when two Sets have no element in common" do
+    Set[1, 2].disjoint?(Set[3, 4]).should == true
+  end
+
+  context "when comparing to a Set-like object" do
+    it "returns false when a Set has at least one element in common with a Set-like object" do
+      Set[1, 2].disjoint?(SetLike.new([2, 3])).should be_false
+    end
+
+    it "returns true when a Set has no element in common with a Set-like object" do
+      Set[1, 2].disjoint?(SetLike.new([3, 4])).should be_true
+    end
+  end
+end

--- a/library/set/equal_value_spec.rb
+++ b/library/set/equal_value_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../spec_helper'
+require_relative 'shared/set_like'
 require 'set'
 
 describe "Set#==" do
@@ -22,5 +23,11 @@ describe "Set#==" do
     set1 = Set[Set["a", "b"], Set["c", "d"], Set["e", "f"]]
     set2 = Set[Set["c", "d"], Set["a", "b"], Set["e", "f"]]
     set1.should == set2
+  end
+
+  context "when comparing to a Set-like object" do
+    it "returns true when a Set and a Set-like object contain the same elements" do
+      Set[1, 2, 3].should == SetLike.new([1, 2, 3])
+    end
   end
 end

--- a/library/set/flatten_spec.rb
+++ b/library/set/flatten_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../spec_helper'
+require_relative 'shared/set_like'
 require 'set'
 
 describe "Set#flatten" do
@@ -13,6 +14,12 @@ describe "Set#flatten" do
   it "raises an ArgumentError when self is recursive" do
     (set = Set[]) << set
     lambda { set.flatten }.should raise_error(ArgumentError)
+  end
+
+  context "when Set contains a Set-like object" do
+    it "returns a copy of self with each included Set-like object flattened" do
+      Set[SetLike.new([1])].flatten.should == Set[1]
+    end
   end
 end
 
@@ -36,5 +43,11 @@ describe "Set#flatten!" do
   it "raises an ArgumentError when self is recursive" do
     (set = Set[]) << set
     lambda { set.flatten! }.should raise_error(ArgumentError)
+  end
+
+  context "when Set contains a Set-like object" do
+    it "flattens self, including Set-like objects" do
+      Set[SetLike.new([1])].flatten!.should == Set[1]
+    end
   end
 end

--- a/library/set/intersect_spec.rb
+++ b/library/set/intersect_spec.rb
@@ -1,0 +1,23 @@
+require_relative '../../spec_helper'
+require_relative 'shared/set_like'
+require 'set'
+
+describe "Set#intersect?" do
+  it "returns true when two Sets have at least one element in common" do
+    Set[1, 2].intersect?(Set[2, 3]).should == true
+  end
+
+  it "returns false when two Sets have no element in common" do
+    Set[1, 2].intersect?(Set[3, 4]).should == false
+  end
+
+  context "when comparing to a Set-like object" do
+    it "returns true when a Set has at least one element in common with a Set-like object" do
+      Set[1, 2].intersect?(SetLike.new([2, 3])).should be_true
+    end
+
+    it "returns false when a Set has no element in common with a Set-like object" do
+      Set[1, 2].intersect?(SetLike.new([3, 4])).should be_false
+    end
+  end
+end

--- a/library/set/intersection_spec.rb
+++ b/library/set/intersection_spec.rb
@@ -1,5 +1,6 @@
 require_relative '../../spec_helper'
 require_relative 'shared/intersection'
+require_relative 'shared/set_like'
 require 'set'
 
 describe "Set#intersection" do
@@ -18,6 +19,16 @@ describe "Set#intersect?" do
   it "returns false when two Sets have no element in common" do
     Set[1, 2].intersect?(Set[3, 4]).should == false
   end
+
+  context "when comparing to a Set-like object" do
+    it "returns true when a Set has at least one element in common with a Set-like object" do
+      Set[1, 2].intersect?(SetLike.new([2, 3])).should be_true
+    end
+
+    it "returns false when a Set has no element in common with a Set-like object" do
+      Set[1, 2].intersect?(SetLike.new([3, 4])).should be_false
+    end
+  end
 end
 
 describe "Set#disjoint?" do
@@ -27,5 +38,15 @@ describe "Set#disjoint?" do
 
   it "returns true when two Sets have no element in common" do
     Set[1, 2].disjoint?(Set[3, 4]).should == true
+  end
+
+  context "when comparing to a Set-like object" do
+    it "returns false when a Set has at least one element in common with a Set-like object" do
+      Set[1, 2].disjoint?(SetLike.new([2, 3])).should be_false
+    end
+
+    it "returns true when a Set has no element in common with a Set-like object" do
+      Set[1, 2].disjoint?(SetLike.new([3, 4])).should be_true
+    end
   end
 end

--- a/library/set/intersection_spec.rb
+++ b/library/set/intersection_spec.rb
@@ -1,6 +1,5 @@
 require_relative '../../spec_helper'
 require_relative 'shared/intersection'
-require_relative 'shared/set_like'
 require 'set'
 
 describe "Set#intersection" do
@@ -9,44 +8,4 @@ end
 
 describe "Set#&" do
   it_behaves_like :set_intersection, :&
-end
-
-describe "Set#intersect?" do
-  it "returns true when two Sets have at least one element in common" do
-    Set[1, 2].intersect?(Set[2, 3]).should == true
-  end
-
-  it "returns false when two Sets have no element in common" do
-    Set[1, 2].intersect?(Set[3, 4]).should == false
-  end
-
-  context "when comparing to a Set-like object" do
-    it "returns true when a Set has at least one element in common with a Set-like object" do
-      Set[1, 2].intersect?(SetLike.new([2, 3])).should be_true
-    end
-
-    it "returns false when a Set has no element in common with a Set-like object" do
-      Set[1, 2].intersect?(SetLike.new([3, 4])).should be_false
-    end
-  end
-end
-
-describe "Set#disjoint?" do
-  it "returns false when two Sets have at least one element in common" do
-    Set[1, 2].disjoint?(Set[2, 3]).should == false
-  end
-
-  it "returns true when two Sets have no element in common" do
-    Set[1, 2].disjoint?(Set[3, 4]).should == true
-  end
-
-  context "when comparing to a Set-like object" do
-    it "returns false when a Set has at least one element in common with a Set-like object" do
-      Set[1, 2].disjoint?(SetLike.new([2, 3])).should be_false
-    end
-
-    it "returns true when a Set has no element in common with a Set-like object" do
-      Set[1, 2].disjoint?(SetLike.new([3, 4])).should be_true
-    end
-  end
 end

--- a/library/set/intersection_spec.rb
+++ b/library/set/intersection_spec.rb
@@ -9,3 +9,23 @@ end
 describe "Set#&" do
   it_behaves_like :set_intersection, :&
 end
+
+describe "Set#intersect?" do
+  it "returns true when two Sets have at least one element in common" do
+    Set[1, 2].intersect?(Set[2, 3]).should == true
+  end
+
+  it "returns false when two Sets have no element in common" do
+    Set[1, 2].intersect?(Set[3, 4]).should == false
+  end
+end
+
+describe "Set#disjoint?" do
+  it "returns false when two Sets have at least one element in common" do
+    Set[1, 2].disjoint?(Set[2, 3]).should == false
+  end
+
+  it "returns true when two Sets have no element in common" do
+    Set[1, 2].disjoint?(Set[3, 4]).should == true
+  end
+end

--- a/library/set/proper_subset_spec.rb
+++ b/library/set/proper_subset_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../spec_helper'
+require_relative 'shared/set_like'
 require 'set'
 
 describe "Set#proper_subset?" do
@@ -30,5 +31,11 @@ describe "Set#proper_subset?" do
     lambda { Set[].proper_subset?(1) }.should raise_error(ArgumentError)
     lambda { Set[].proper_subset?("test") }.should raise_error(ArgumentError)
     lambda { Set[].proper_subset?(Object.new) }.should raise_error(ArgumentError)
+  end
+
+  context "when comparing to a Set-like object" do
+    it "returns true if passed a Set-like object that self is a proper subset of" do
+      Set[1, 2, 3].proper_subset?(SetLike.new([1, 2, 3, 4])).should be_true
+    end
   end
 end

--- a/library/set/proper_superset_spec.rb
+++ b/library/set/proper_superset_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../spec_helper'
+require_relative 'shared/set_like'
 require 'set'
 
 describe "Set#proper_superset?" do
@@ -30,5 +31,11 @@ describe "Set#proper_superset?" do
     lambda { Set[].proper_superset?(1) }.should raise_error(ArgumentError)
     lambda { Set[].proper_superset?("test") }.should raise_error(ArgumentError)
     lambda { Set[].proper_superset?(Object.new) }.should raise_error(ArgumentError)
+  end
+
+  context "when comparing to a Set-like object" do
+    it "returns true if passed a Set-like object that self is a proper superset of" do
+      Set[1, 2, 3, 4].proper_superset?(SetLike.new([1, 2, 3])).should be_true
+    end
   end
 end

--- a/library/set/shared/set_like.rb
+++ b/library/set/shared/set_like.rb
@@ -1,0 +1,29 @@
+require 'set'
+
+# This class is used to test the interaction of "Set-like" objects with real Sets
+#
+# These "Set-like" objects reply to is_a?(Set) with true and thus real Set objects are able to transparently
+# interoperate with them in a duck-typing manner.
+class SetLike
+  include Enumerable
+
+  def is_a?(klass)
+    super || klass == ::Set
+  end
+
+  def initialize(entries)
+    @entries = entries
+  end
+
+  def each(&block)
+    @entries.each(&block)
+  end
+
+  def inspect
+    "#<SetLike: {#{map(&:inspect).join(", ")}}>"
+  end
+
+  def size
+    @entries.size
+  end
+end

--- a/library/set/subset_spec.rb
+++ b/library/set/subset_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../spec_helper'
+require_relative 'shared/set_like'
 require 'set'
 
 describe "Set#subset?" do
@@ -30,5 +31,11 @@ describe "Set#subset?" do
     lambda { Set[].subset?(1) }.should raise_error(ArgumentError)
     lambda { Set[].subset?("test") }.should raise_error(ArgumentError)
     lambda { Set[].subset?(Object.new) }.should raise_error(ArgumentError)
+  end
+
+  context "when comparing to a Set-like object" do
+    it "returns true if passed a Set-like object that self is a subset of" do
+      Set[1, 2, 3].subset?(SetLike.new([1, 2, 3, 4])).should be_true
+    end
   end
 end

--- a/library/set/superset_spec.rb
+++ b/library/set/superset_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../spec_helper'
+require_relative 'shared/set_like'
 require 'set'
 
 describe "Set#superset?" do
@@ -30,5 +31,11 @@ describe "Set#superset?" do
     lambda { Set[].superset?(1) }.should raise_error(ArgumentError)
     lambda { Set[].superset?("test") }.should raise_error(ArgumentError)
     lambda { Set[].superset?(Object.new) }.should raise_error(ArgumentError)
+  end
+
+  context "when comparing to a Set-like object" do
+    it "returns true if passed a Set-like object that self is a superset of" do
+      Set[1, 2, 3, 4].superset?(SetLike.new([1, 2, 3])).should be_true
+    end
   end
 end


### PR DESCRIPTION
As discussed in jruby/jruby#5227, the [persistent-💎](https://gitlab.com/ivoanjo/persistent-dmnd/) gem takes advantage of the fact that Ruby's set.rb uses `is_a?(Set)` to recognize other sets to enable `Persistent💎::Set` instances to be compared, intersected, disjointed, and flattened as if they were normal Ruby sets.

These specs cover the `is_a?(Set)` set.rb interoperation behaviors, and are broken in JRuby 9.2.0.0 by the new higher-performance `Set` implementation.

Issue jruby/jruby#5227
