### PR TITLE
Hash#slice should ignore overridden Hash#[]

### DIFF
--- a/core/hash/slice_spec.rb
+++ b/core/hash/slice_spec.rb
@@ -32,5 +32,21 @@ ruby_version_is "2.5" do
       r.should == {foo: 42}
       r.class.should == Hash
     end
+
+    it "uses the regular hash #[] method, even on subclasses that override it" do
+      ScratchPad.record []
+      klass = Class.new(Hash) do
+        def [](value)
+          ScratchPad << :used_subclassed_operator
+          super
+        end
+      end
+
+      h = klass.new
+      h[:foo] = 42
+      h.slice(:foo)
+
+      ScratchPad.recorded.should == []
+    end
   end
 end


### PR DESCRIPTION
Probably for performance reason, Hash.slice doesn't use overridden [] operator.