### PR TITLE
MinGW fixes - adds examples that pass on newer MinGW builds

### DIFF
--- a/core/array/pack/l_spec.rb
+++ b/core/array/pack/l_spec.rb
@@ -29,7 +29,7 @@ describe "Array#pack with format 'L'" do
     it_behaves_like :array_pack_32bit_be, 'L>'
   end
 
-  guard -> { platform_is wordsize: 32 or platform_is :mingw32 } do
+  platform_is wordsize: 32 do
     describe "with modifier '<' and '_'" do
       it_behaves_like :array_pack_32bit_le, 'L<_'
       it_behaves_like :array_pack_32bit_le, 'L_<'
@@ -51,7 +51,7 @@ describe "Array#pack with format 'L'" do
     end
   end
 
-  guard -> { platform_is wordsize: 64 and platform_is_not :mingw32 } do
+  platform_is wordsize: 64 do
     describe "with modifier '<' and '_'" do
       it_behaves_like :array_pack_64bit_le, 'L<_'
       it_behaves_like :array_pack_64bit_le, 'L_<'
@@ -83,7 +83,7 @@ describe "Array#pack with format 'l'" do
     it_behaves_like :array_pack_32bit_be, 'l>'
   end
 
-  guard -> { platform_is wordsize: 32 or platform_is :mingw32 } do
+  platform_is wordsize: 32 do
     describe "with modifier '<' and '_'" do
       it_behaves_like :array_pack_32bit_le, 'l<_'
       it_behaves_like :array_pack_32bit_le, 'l_<'
@@ -105,7 +105,7 @@ describe "Array#pack with format 'l'" do
     end
   end
 
-  guard -> { platform_is wordsize: 64 and platform_is_not :mingw32 } do
+  platform_is wordsize: 64 do
     describe "with modifier '<' and '_'" do
       it_behaves_like :array_pack_64bit_le, 'l<_'
       it_behaves_like :array_pack_64bit_le, 'l_<'
@@ -137,7 +137,7 @@ little_endian do
     it_behaves_like :array_pack_32bit_le, 'l'
   end
 
-  guard -> { platform_is wordsize: 32 or platform_is :mingw32 } do
+  platform_is wordsize: 32 do
     describe "Array#pack with format 'L' with modifier '_'" do
       it_behaves_like :array_pack_32bit_le, 'L_'
     end
@@ -155,7 +155,7 @@ little_endian do
     end
   end
 
-  guard -> { platform_is wordsize: 64 and platform_is_not :mingw32 } do
+  platform_is wordsize: 64 do
     describe "Array#pack with format 'L' with modifier '_'" do
       it_behaves_like :array_pack_64bit_le, 'L_'
     end
@@ -183,7 +183,7 @@ big_endian do
     it_behaves_like :array_pack_32bit_be, 'l'
   end
 
-  guard -> { platform_is wordsize: 32 or platform_is :mingw32 } do
+  platform_is wordsize: 32 do
     describe "Array#pack with format 'L' with modifier '_'" do
       it_behaves_like :array_pack_32bit_be, 'L_'
     end
@@ -201,7 +201,7 @@ big_endian do
     end
   end
 
-  guard -> { platform_is wordsize: 64 and platform_is_not :mingw32 } do
+  platform_is wordsize: 64 do
     describe "Array#pack with format 'L' with modifier '_'" do
       it_behaves_like :array_pack_64bit_be, 'L_'
     end

--- a/core/file/atime_spec.rb
+++ b/core/file/atime_spec.rb
@@ -15,7 +15,7 @@ describe "File.atime" do
     File.atime(@file).should be_kind_of(Time)
   end
 
-  platform_is :linux do
+  guard -> { platform_is :linux or (platform_is :windows and ruby_version_is '2.5') } do
     ## NOTE also that some Linux systems disable atime (e.g. via mount params) for better filesystem speed.
     it "returns the last access time for the named file with microseconds" do
       supports_subseconds = Integer(`stat -c%x '#{__FILE__}'`[/\.(\d+)/, 1], 10)

--- a/core/file/ctime_spec.rb
+++ b/core/file/ctime_spec.rb
@@ -14,7 +14,7 @@ describe "File.ctime" do
     File.ctime(@file).should be_kind_of(Time)
   end
 
-  platform_is :linux do
+  guard -> { platform_is :linux or (platform_is :windows and ruby_version_is '2.5') } do
     it "returns the change time for the named file (the time at which directory information about the file was changed, not the file itself) with microseconds." do
       supports_subseconds = Integer(`stat -c%z '#{__FILE__}'`[/\.(\d+)/, 1], 10)
       if supports_subseconds != 0

--- a/core/file/mtime_spec.rb
+++ b/core/file/mtime_spec.rb
@@ -15,7 +15,7 @@ describe "File.mtime" do
     File.mtime(@filename).should be_close(@mtime, 2.0)
   end
 
-  platform_is :linux do
+  guard -> { platform_is :linux or (platform_is :windows and ruby_version_is '2.5') } do
     it "returns the modification Time of the file with microseconds" do
       supports_subseconds = Integer(`stat -c%y '#{__FILE__}'`[/\.(\d+)/, 1], 10)
       if supports_subseconds != 0

--- a/core/file/utime_spec.rb
+++ b/core/file/utime_spec.rb
@@ -1,6 +1,11 @@
 require_relative '../../spec_helper'
 
 describe "File.utime" do
+
+  before :all do
+    @time_is_float = /mswin|mingw/ =~ RUBY_PLATFORM && RUBY_VERSION >= '2.5'
+  end
+
   before :each do
     @atime = Time.now
     @mtime = Time.now
@@ -16,18 +21,33 @@ describe "File.utime" do
 
   it "sets the access and modification time of each file" do
     File.utime(@atime, @mtime, @file1, @file2)
-    File.atime(@file1).to_i.should be_close(@atime.to_i, 2)
-    File.mtime(@file1).to_i.should be_close(@mtime.to_i, 2)
-    File.atime(@file2).to_i.should be_close(@atime.to_i, 2)
-    File.mtime(@file2).to_i.should be_close(@mtime.to_i, 2)
+    if @time_is_float
+      File.atime(@file1).should be_close(@atime, 0.0001)
+      File.mtime(@file1).should be_close(@mtime, 0.0001)
+      File.atime(@file2).should be_close(@atime, 0.0001)
+      File.mtime(@file2).should be_close(@mtime, 0.0001)
+    else
+      File.atime(@file1).to_i.should be_close(@atime.to_i, 2)
+      File.mtime(@file1).to_i.should be_close(@mtime.to_i, 2)
+      File.atime(@file2).to_i.should be_close(@atime.to_i, 2)
+      File.mtime(@file2).to_i.should be_close(@mtime.to_i, 2)
+    end
   end
 
   it "uses the current times if two nil values are passed" do
+    tn = Time.now
     File.utime(nil, nil, @file1, @file2)
-    File.atime(@file1).to_i.should be_close(Time.now.to_i, 2)
-    File.mtime(@file1).to_i.should be_close(Time.now.to_i, 2)
-    File.atime(@file2).to_i.should be_close(Time.now.to_i, 2)
-    File.mtime(@file2).to_i.should be_close(Time.now.to_i, 2)
+    if @time_is_float
+      File.atime(@file1).should be_close(tn, 0.050)
+      File.mtime(@file1).should be_close(tn, 0.050)
+      File.atime(@file2).should be_close(tn, 0.050)
+      File.mtime(@file2).should be_close(tn, 0.050)
+    else
+      File.atime(@file1).to_i.should be_close(Time.now.to_i, 2)
+      File.mtime(@file1).to_i.should be_close(Time.now.to_i, 2)
+      File.atime(@file2).to_i.should be_close(Time.now.to_i, 2)
+      File.mtime(@file2).to_i.should be_close(Time.now.to_i, 2)
+    end
   end
 
   it "accepts an object that has a #to_path method" do
@@ -35,11 +55,19 @@ describe "File.utime" do
   end
 
   it "accepts numeric atime and mtime arguments" do
-    File.utime(@atime.to_i, @mtime.to_i, @file1, @file2)
-    File.atime(@file1).to_i.should be_close(@atime.to_i, 2)
-    File.mtime(@file1).to_i.should be_close(@mtime.to_i, 2)
-    File.atime(@file2).to_i.should be_close(@atime.to_i, 2)
-    File.mtime(@file2).to_i.should be_close(@mtime.to_i, 2)
+    if @time_is_float
+      File.utime(@atime.to_f, @mtime.to_f, @file1, @file2)
+      File.atime(@file1).should be_close(@atime, 0.0001)
+      File.mtime(@file1).should be_close(@mtime, 0.0001)
+      File.atime(@file2).should be_close(@atime, 0.0001)
+      File.mtime(@file2).should be_close(@mtime, 0.0001)
+    else
+      File.utime(@atime.to_i, @mtime.to_i, @file1, @file2)
+      File.atime(@file1).to_i.should be_close(@atime.to_i, 2)
+      File.mtime(@file1).to_i.should be_close(@mtime.to_i, 2)
+      File.atime(@file2).to_i.should be_close(@atime.to_i, 2)
+      File.mtime(@file2).to_i.should be_close(@mtime.to_i, 2)
+    end
   end
 
   platform_is :linux do

--- a/core/float/round_spec.rb
+++ b/core/float/round_spec.rb
@@ -10,11 +10,9 @@ describe "Float#round" do
     0.0.round.should == 0
   end
 
-  platform_is_not :mingw32 do
-    it "returns the nearest Integer for Float near the limit" do
-      0.49999999999999994.round.should == 0
-      -0.49999999999999994.round.should == 0
-    end
+  it "returns the nearest Integer for Float near the limit" do
+    0.49999999999999994.round.should == 0
+    -0.49999999999999994.round.should == 0
   end
 
   it "raises FloatDomainError for exceptional values" do

--- a/core/string/unpack/l_spec.rb
+++ b/core/string/unpack/l_spec.rb
@@ -14,7 +14,7 @@ describe "String#unpack with format 'L'" do
     it_behaves_like :string_unpack_32bit_be_unsigned, 'L>'
   end
 
-  guard -> { platform_is wordsize: 32 or platform_is :mingw32 } do
+  platform_is wordsize: 32 do
     describe "with modifier '<' and '_'" do
       it_behaves_like :string_unpack_32bit_le, 'L<_'
       it_behaves_like :string_unpack_32bit_le, 'L_<'
@@ -44,7 +44,7 @@ describe "String#unpack with format 'L'" do
     end
   end
 
-  guard -> { platform_is wordsize: 64 and platform_is_not :mingw32 } do
+  platform_is wordsize: 64 do
     describe "with modifier '<' and '_'" do
       it_behaves_like :string_unpack_64bit_le, 'L<_'
       it_behaves_like :string_unpack_64bit_le, 'L_<'
@@ -86,7 +86,7 @@ describe "String#unpack with format 'l'" do
     it_behaves_like :string_unpack_32bit_be_signed, 'l>'
   end
 
-  guard -> { platform_is wordsize: 32 or platform_is :mingw32 } do
+  platform_is wordsize: 32 do
     describe "with modifier '<' and '_'" do
       it_behaves_like :string_unpack_32bit_le, 'l<_'
       it_behaves_like :string_unpack_32bit_le, 'l_<'
@@ -116,7 +116,7 @@ describe "String#unpack with format 'l'" do
     end
   end
 
-  guard -> { platform_is wordsize: 64 and platform_is_not :mingw32 } do
+  platform_is wordsize: 64 do
     describe "with modifier '<' and '_'" do
       it_behaves_like :string_unpack_64bit_le, 'l<_'
       it_behaves_like :string_unpack_64bit_le, 'l_<'
@@ -160,7 +160,7 @@ little_endian do
     it_behaves_like :string_unpack_32bit_le_signed, 'l'
   end
 
-  guard -> { platform_is wordsize: 32 or platform_is :mingw32 } do
+  platform_is wordsize: 32 do
     describe "String#unpack with format 'L' with modifier '_'" do
       it_behaves_like :string_unpack_32bit_le, 'L_'
       it_behaves_like :string_unpack_32bit_le_unsigned, 'L_'
@@ -182,7 +182,7 @@ little_endian do
     end
   end
 
-  guard -> { platform_is wordsize: 64 and platform_is_not :mingw32 } do
+  platform_is wordsize: 64 do
     describe "String#unpack with format 'L' with modifier '_'" do
       it_behaves_like :string_unpack_64bit_le, 'L_'
       it_behaves_like :string_unpack_64bit_le_unsigned, 'L_'
@@ -218,7 +218,7 @@ big_endian do
     it_behaves_like :string_unpack_32bit_be_signed, 'l'
   end
 
-  guard -> { platform_is wordsize: 32 or platform_is :mingw32 } do
+  platform_is wordsize: 32 do
     describe "String#unpack with format 'L' with modifier '_'" do
       it_behaves_like :string_unpack_32bit_be, 'L_'
       it_behaves_like :string_unpack_32bit_be_unsigned, 'L_'
@@ -240,7 +240,7 @@ big_endian do
     end
   end
 
-  guard -> { platform_is wordsize: 64 and platform_is_not :mingw32 } do
+  platform_is wordsize: 64 do
     describe "String#unpack with format 'L' with modifier '_'" do
       it_behaves_like :string_unpack_64bit_be, 'L_'
       it_behaves_like :string_unpack_64bit_be_unsigned, 'L_'

--- a/optional/capi/time_spec.rb
+++ b/optional/capi/time_spec.rb
@@ -165,7 +165,7 @@ describe "CApiTimeSpecs" do
       usec.should == 500000
     end
 
-    platform_is_not :mingw32 do
+    guard -> { platform_is_not :mingw or ruby_version_is '2.5' } do
       it "creates a timeval for a negative Fixnum" do
         sec, usec = @s.rb_time_timeval(-1232141421)
         sec.should be_kind_of(Integer)
@@ -224,7 +224,7 @@ describe "CApiTimeSpecs" do
       nsec.should == 500000000
     end
 
-    platform_is_not :mingw32 do
+    guard -> { platform_is_not :mingw or ruby_version_is '2.5' } do
       it "creates a timespec for a negative Fixnum" do
         sec, nsec = @s.rb_time_timespec(-1232141421)
         sec.should be_kind_of(Integer)


### PR DESCRIPTION
Based on fixes used in ruby-loco, some used since last year

typo  rime => time