### PR TITLE
Increase buffer size that must be larger than the pipe capacity

### DIFF
--- a/core/io/syswrite_spec.rb
+++ b/core/io/syswrite_spec.rb
@@ -55,7 +55,7 @@ describe "IO#syswrite on a pipe" do
     r, w = IO.pipe
     begin
       w.nonblock = true
-      larger_than_pipe_capacity = 100 * 1024
+      larger_than_pipe_capacity = 2 * 1024 * 1024
       written = w.syswrite("a"*larger_than_pipe_capacity)
       written.should > 0
       written.should < larger_than_pipe_capacity


### PR DESCRIPTION
#626 
The default pipe capacity is 1048576 bytes on Linux ppc64le.