### PR TITLE
Update the Tempfile.open spec to confirm the options argument is passed to File.open.

### DIFF
--- a/library/tempfile/open_spec.rb
+++ b/library/tempfile/open_spec.rb
@@ -43,7 +43,7 @@ describe "Tempfile.open" do
   end
 
   it "passes the third argument (options) to open" do
-    Tempfile.open("specs", "/tmp", encoding: "IBM037:IBM037", binmode: true) do |tempfile|
+    Tempfile.open("specs", Dir.tmpdir, encoding: "IBM037:IBM037", binmode: true) do |tempfile|
       @tempfile = tempfile
       tempfile.external_encoding.should == Encoding.find("IBM037")
       tempfile.binmode?.should be_true

--- a/library/tempfile/open_spec.rb
+++ b/library/tempfile/open_spec.rb
@@ -41,6 +41,14 @@ describe "Tempfile.open" do
     Tempfile.open(["specs", ".tt"]) { |tempfile| @tempfile = tempfile }
     @tempfile.path.should =~ /specs.*\.tt$/
   end
+
+  it "passes the third argument (options) to open" do
+    Tempfile.open("specs", "/tmp", encoding: "IBM037:IBM037", binmode: true) do |tempfile|
+      @tempfile = tempfile
+      tempfile.external_encoding.should == Encoding.find("IBM037")
+      tempfile.binmode?.should be_true
+    end
+  end
 end
 
 describe "Tempfile.open when passed a block" do


### PR DESCRIPTION
This spec is in response to jruby/jruby#5456