### PR TITLE
Add a spec for String#scan with multi-byte characters

### DIFF
--- a/core/string/scan_spec.rb
+++ b/core/string/scan_spec.rb
@@ -84,6 +84,11 @@ describe "String#scan" do
     a = "hello".taint.scan(/./)
     a.each { |m| m.tainted?.should be_true }
   end
+
+  # jruby/jruby#5513
+  it "does not raise any errors when passed a multi-byte string" do
+    "あああaaaあああ".scan("あああ").should == ["あああ", "あああ"]
+  end
 end
 
 describe "String#scan with pattern and block" do


### PR DESCRIPTION
This spec is for jruby/jruby#5513.

JRuby 9.x.x.x raises an error when `String#scan` is called with multi-byte string. I reported this problem, and the problem has been fixed on master. This spec is a regression test for the issue.

I've confirmed the spec raises an error with JRuby 9.2.5.0, and it passed with JRuby HEAD.



```bash
# WIth JRuby HEAD
$ /home/pocke/ghq/github.com/jruby/jruby/bin/jruby /home/pocke/ghq/github.com/ruby/mspec/bin/mspec-run core/string/scan_spec.rb
jruby 9.2.6.0-SNAPSHOT (2.5.3) 2018-12-13 73d3de5 OpenJDK 64-Bit Server VM 25.192-b26 on 1.8.0_192-b26 +jit [linux-x86_64]
........................

Finished in 0.076482 seconds

1 file, 24 examples, 87 expectations, 0 failures, 0 errors, 0 tagged




# With JRuby 9.2.5.0
$ ruby /home/pocke/ghq/github.com/ruby/mspec/bin/mspec-run core/string/scan_spec.rb
jruby 9.2.5.0 (2.5.0) 2018-12-06 6d5a228 OpenJDK 64-Bit Server VM 25.192-b26 on 1.8.0_192-b26 +jit [linux-x86_64]
............E...........

1)
String#scan does not raise any errors when passed a multi-byte string ERROR
Java::JavaLang::ArrayIndexOutOfBoundsException: -1342547898
org.jruby.util.StringSupport.rb_memsearch_qs_utf8(StringSupport.java:2503)
org.jruby.util.StringSupport.memsearch(StringSupport.java:2048)
org.jruby.RubyString.strseqIndex(RubyString.java:3275)
org.jruby.RubyString.patternSearch(RubyString.java:4402)
org.jruby.RubyString.scanOnce(RubyString.java:4362)
org.jruby.RubyString.scan(RubyString.java:4330)
org.jruby.RubyString$INVOKER$i$1$0$scan.call(RubyString$INVOKER$i$1$0$scan.gen)
org.jruby.internal.runtime.methods.JavaMethod$JavaMethodOneOrNBlock.call(JavaMethod.java:399)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:346)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:172)
org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:317)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
org.jruby.ir.interpreter.Interpreter.INTERPRET_BLOCK(Interpreter.java:128)
org.jruby.runtime.MixedModeIRBlockBody.commonYieldPath(MixedModeIRBlockBody.java:151)
org.jruby.runtime.IRBlockBody.doYield(IRBlockBody.java:194)
org.jruby.runtime.BlockBody.yield(BlockBody.java:125)
org.jruby.runtime.Block.yieldNonArray(Block.java:169)
org.jruby.RubyBasicObject.yieldUnder(RubyBasicObject.java:1799)
org.jruby.RubyBasicObject.specificEval(RubyBasicObject.java:1818)
org.jruby.RubyBasicObject.instance_eval(RubyBasicObject.java:2594)
org.jruby.RubyBasicObject$INVOKER$i$instance_eval.call(RubyBasicObject$INVOKER$i$instance_eval.gen)
org.jruby.internal.runtime.methods.JavaMethod$JavaMethodZeroOrOneOrTwoOrThreeBlock.call(JavaMethod.java:609)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:82)
org.jruby.ir.instructions.CallBase.interpret(CallBase.java:547)
org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:362)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:86)
org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:171)
org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:158)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:180)
org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:339)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
org.jruby.ir.interpreter.Interpreter.INTERPRET_BLOCK(Interpreter.java:128)
org.jruby.runtime.MixedModeIRBlockBody.commonYieldPath(MixedModeIRBlockBody.java:151)
org.jruby.runtime.IRBlockBody.doYield(IRBlockBody.java:187)
org.jruby.runtime.BlockBody.yield(BlockBody.java:116)
org.jruby.runtime.Block.yield(Block.java:165)
org.jruby.RubyArray.all_p(RubyArray.java:4441)
org.jruby.RubyEnumerable.all_p(RubyEnumerable.java:1738)
org.jruby.RubyEnumerable$INVOKER$s$0$1$all_p.call(RubyEnumerable$INVOKER$s$0$1$all_p.gen)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:82)
org.jruby.runtime.callsite.CachingCallSite.callIter(CachingCallSite.java:91)
org.jruby.ir.instructions.CallBase.interpret(CallBase.java:544)
org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:362)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:92)
org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:204)
org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:191)
org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:207)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:201)
org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:326)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
org.jruby.ir.interpreter.Interpreter.INTERPRET_BLOCK(Interpreter.java:128)
org.jruby.runtime.MixedModeIRBlockBody.commonYieldPath(MixedModeIRBlockBody.java:151)
org.jruby.runtime.IRBlockBody.yieldSpecific(IRBlockBody.java:89)
org.jruby.runtime.Block.yieldSpecific(Block.java:134)
org.jruby.ir.runtime.IRRuntimeHelpers.yieldSpecific(IRRuntimeHelpers.java:468)
org.jruby.ir.instructions.YieldInstr.interpret(YieldInstr.java:76)
org.jruby.ir.interpreter.StartupInterpreterEngine.processOtherOp(StartupInterpreterEngine.java:178)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:104)
org.jruby.ir.interpreter.Interpreter.INTERPRET_BLOCK(Interpreter.java:128)
org.jruby.runtime.MixedModeIRBlockBody.commonYieldPath(MixedModeIRBlockBody.java:151)
org.jruby.runtime.IRBlockBody.yieldSpecific(IRBlockBody.java:89)
org.jruby.runtime.Block.yieldSpecific(Block.java:134)
org.jruby.RubyFixnum.times(RubyFixnum.java:278)
org.jruby.RubyInteger$INVOKER$i$0$0$times.call(RubyInteger$INVOKER$i$0$0$times.gen)
org.jruby.internal.runtime.methods.JavaMethod$JavaMethodZeroBlock.call(JavaMethod.java:537)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:82)
org.jruby.runtime.callsite.CachingCallSite.callIter(CachingCallSite.java:91)
org.jruby.ir.instructions.CallBase.interpret(CallBase.java:544)
org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:362)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:105)
org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:92)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:82)
org.jruby.runtime.callsite.CachingCallSite.callIter(CachingCallSite.java:91)
org.jruby.ir.instructions.CallBase.interpret(CallBase.java:544)
org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:362)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
org.jruby.ir.interpreter.Interpreter.INTERPRET_BLOCK(Interpreter.java:128)
org.jruby.runtime.MixedModeIRBlockBody.commonYieldPath(MixedModeIRBlockBody.java:151)
org.jruby.runtime.IRBlockBody.doYield(IRBlockBody.java:187)
org.jruby.runtime.BlockBody.yield(BlockBody.java:116)
org.jruby.runtime.Block.yield(Block.java:165)
org.jruby.RubyArray.each(RubyArray.java:1792)
org.jruby.RubyArray$INVOKER$i$0$0$each.call(RubyArray$INVOKER$i$0$0$each.gen)
org.jruby.internal.runtime.methods.JavaMethod$JavaMethodZeroBlock.call(JavaMethod.java:537)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:303)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:84)
org.jruby.runtime.callsite.CachingCallSite.callIter(CachingCallSite.java:91)
org.jruby.ir.instructions.CallBase.interpret(CallBase.java:544)
org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:362)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:80)
org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:138)
org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:125)
org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:191)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:325)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:141)
org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:346)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:105)
org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:92)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:303)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:84)
org.jruby.ir.instructions.CallBase.interpret(CallBase.java:547)
org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:362)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:86)
org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:171)
org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:158)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:357)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:182)
org.jruby.runtime.callsite.CachingCallSite.callIter(CachingCallSite.java:189)
org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:338)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
org.jruby.ir.interpreter.Interpreter.INTERPRET_ROOT(Interpreter.java:108)
org.jruby.ir.interpreter.Interpreter.execute(Interpreter.java:95)
org.jruby.ir.interpreter.Interpreter.execute(Interpreter.java:34)
org.jruby.ir.IRTranslator.execute(IRTranslator.java:42)
org.jruby.Ruby.runInterpreter(Ruby.java:861)
org.jruby.Ruby.loadFile(Ruby.java:2953)
org.jruby.runtime.load.LibrarySearcher$ResourceLibrary.load(LibrarySearcher.java:251)
org.jruby.runtime.load.LibrarySearcher$FoundLibrary.load(LibrarySearcher.java:34)
org.jruby.runtime.load.LoadService.load(LoadService.java:346)
org.jruby.RubyKernel.loadCommon(RubyKernel.java:1037)
org.jruby.RubyKernel.load(RubyKernel.java:1007)
org.jruby.RubyKernel$INVOKER$s$load.call(RubyKernel$INVOKER$s$load.gen)
org.jruby.internal.runtime.methods.JavaMethod$JavaMethodOneOrNBlock.call(JavaMethod.java:399)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:346)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:172)
org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:317)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
org.jruby.ir.interpreter.Interpreter.INTERPRET_BLOCK(Interpreter.java:128)
org.jruby.runtime.MixedModeIRBlockBody.commonYieldPath(MixedModeIRBlockBody.java:151)
org.jruby.runtime.IRBlockBody.doYield(IRBlockBody.java:194)
org.jruby.runtime.BlockBody.yield(BlockBody.java:125)
org.jruby.runtime.Block.yieldNonArray(Block.java:169)
org.jruby.RubyBasicObject.yieldUnder(RubyBasicObject.java:1799)
org.jruby.RubyBasicObject.specificEval(RubyBasicObject.java:1818)
org.jruby.RubyBasicObject.instance_eval(RubyBasicObject.java:2594)
org.jruby.RubyBasicObject$INVOKER$i$instance_eval.call(RubyBasicObject$INVOKER$i$instance_eval.gen)
org.jruby.internal.runtime.methods.JavaMethod$JavaMethodZeroOrOneOrTwoOrThreeBlock.call(JavaMethod.java:609)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:303)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:84)
org.jruby.ir.instructions.CallBase.interpret(CallBase.java:547)
org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:362)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:86)
org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:171)
org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:158)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:357)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:182)
org.jruby.runtime.callsite.CachingCallSite.callIter(CachingCallSite.java:189)
org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:338)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
org.jruby.ir.interpreter.Interpreter.INTERPRET_BLOCK(Interpreter.java:128)
org.jruby.runtime.MixedModeIRBlockBody.commonYieldPath(MixedModeIRBlockBody.java:151)
org.jruby.runtime.IRBlockBody.doYield(IRBlockBody.java:187)
org.jruby.runtime.BlockBody.yield(BlockBody.java:116)
org.jruby.runtime.Block.yield(Block.java:165)
org.jruby.RubyArray.each(RubyArray.java:1792)
org.jruby.RubyArray$INVOKER$i$0$0$each.call(RubyArray$INVOKER$i$0$0$each.gen)
org.jruby.internal.runtime.methods.JavaMethod$JavaMethodZeroBlock.call(JavaMethod.java:537)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:303)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:84)
org.jruby.ir.instructions.CallBase.interpret(CallBase.java:547)
org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:362)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:105)
org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:92)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:303)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:84)
org.jruby.runtime.callsite.CachingCallSite.callIter(CachingCallSite.java:91)
org.jruby.ir.instructions.CallBase.interpret(CallBase.java:544)
org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:362)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:80)
org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:138)
org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:125)
org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:191)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:325)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:141)
org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:346)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:80)
org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:138)
org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:125)
org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:191)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:325)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:141)
org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:346)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:80)
org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:138)
org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:125)
org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:191)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:325)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:141)
org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:346)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:80)
org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:138)
org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:125)
org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:191)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:325)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:141)
java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:627)
org.jruby.ir.Compiler$1.load(Compiler.java:94)
org.jruby.Ruby.runScript(Ruby.java:849)
org.jruby.Ruby.runNormally(Ruby.java:772)
org.jruby.Ruby.runNormally(Ruby.java:790)
org.jruby.Ruby.runFromMain(Ruby.java:602)
org.jruby.Main.doRunFromMain(Main.java:415)
org.jruby.Main.internalRun(Main.java:307)
org.jruby.Main.run(Main.java:234)
org.jruby.Main.main(Main.java:206)

Finished in 0.063866 seconds

1 file, 24 examples, 86 expectations, 0 failures, 1 error, 0 tagged
```