### PR TITLE
Travis trunk fix & rubocop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,16 @@ sudo: false
 language: ruby
 install:
   - git clone https://github.com/ruby/mspec.git ../mspec
+before_install:
+  # fix Travis trunk build as of 2018-01-05
+  - |
+    rv="$(ruby -e 'STDOUT.write RUBY_VERSION')";
+    if [ "$rv" = "2.7.0" ]; then
+      lib="$(ruby -e 'STDOUT.write RbConfig::CONFIG["sitelibdir"]')";
+      echo "Processing 2.7.0 - $lib";
+      rm -rf $lib/rubygems;
+      rm -f  $lib/rubygems.rb $lib/ubygems.rb;
+    fi
 script:
   - ../mspec/bin/mspec $MSPEC_OPTS
 matrix:

--- a/core/nil/match_spec.rb
+++ b/core/nil/match_spec.rb
@@ -17,4 +17,3 @@ ruby_version_is "2.6" do
     end
   end
 end
-


### PR DESCRIPTION
For some reason Travis thinks RubyGems 2.7.7 should be installed in trunk...

Fixed simple rubocop error to get Travis to pass...