### PR TITLE
Specs for File.open('x'), exception: false, KeyError constructor options.

### DIFF
--- a/core/exception/key_error_spec.rb
+++ b/core/exception/key_error_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../spec_helper'
+
+describe "KeyError" do
+  ruby_version_is "2.6" do
+    it "accepts :receiver and :key options" do
+      receiver = mock("receiver")
+      key = mock("key")
+
+      error = KeyError.new(receiver: receiver, key: key)
+
+      error.receiver.should == receiver
+      error.key.should == key
+    end
+  end
+end

--- a/core/file/open_spec.rb
+++ b/core/file/open_spec.rb
@@ -638,6 +638,29 @@ describe "File.open" do
     end
   end
 
+  ruby_version_is "2.6" do
+    context "'x' flag" do
+      before do
+        @file = tmp("x-flag")
+        rm_r @file
+      end
+
+      it "does nothing if the file doesn't exist" do
+        File.open(@file, "wx") { |f| f.write("content") }
+        File.read(@file).should == "content"
+      end
+
+      it "throws a Errno::EEXIST error if the file exists" do
+        touch @file
+        lambda { File.open(@file, "wx") }.should raise_error(Errno::EEXIST)
+      end
+
+      it "can't be used with 'r' and 'a' flags" do
+        lambda { File.open(@file, "rx") }.should raise_error(ArgumentError, 'invalid access mode rx')
+        lambda { File.open(@file, "ax") }.should raise_error(ArgumentError, 'invalid access mode ax')
+      end
+    end
+  end
 end
 
 describe "File.open when passed a file descriptor" do

--- a/core/kernel/Complex_spec.rb
+++ b/core/kernel/Complex_spec.rb
@@ -138,4 +138,50 @@ describe "Kernel.Complex()" do
       lambda { Complex(nil, 0) }.should raise_error(TypeError, "can't convert nil into Complex")
     end
   end
+
+  ruby_version_is "2.6" do
+    describe "when passed exception: false" do
+      describe "and [Numeric]" do
+        it "returns a complex number" do
+          Complex("123", exception: false).should == Complex(123)
+        end
+      end
+
+      describe "and [non-Numeric]" do
+        it "swallows an error" do
+          Complex(:sym, exception: false).should == nil
+        end
+      end
+
+      describe "and [non-Numeric, Numeric] argument" do
+        it "throws a TypeError" do
+          lambda { Complex(:sym, 0, exception: false) }.should raise_error(TypeError, "not a real")
+        end
+      end
+
+      describe "and [anything, non-Numeric] argument" do
+        it "swallows an error" do
+          Complex("a",  :sym, exception: false).should == nil
+          Complex(:sym, :sym, exception: false).should == nil
+          Complex(0,    :sym, exception: false).should == nil
+        end
+      end
+
+      describe "and non-numeric String arguments" do
+        it "swallows an error" do
+          Complex("a", "b", exception: false).should == nil
+          Complex("a", 0, exception: false).should == nil
+          Complex(0, "b", exception: false).should == nil
+        end
+      end
+
+      describe "and nil arguments" do
+        it "still throws a TypeError" do
+          lambda { Complex(nil, exception: false) }.should raise_error(TypeError, "can't convert nil into Complex")
+          lambda { Complex(0, nil, exception: false) }.should raise_error(TypeError, "can't convert nil into Complex")
+          lambda { Complex(nil, 0, exception: false) }.should raise_error(TypeError, "can't convert nil into Complex")
+        end
+      end
+    end
+  end
 end

--- a/core/kernel/Float_spec.rb
+++ b/core/kernel/Float_spec.rb
@@ -299,6 +299,31 @@ describe :kernel_float, shared: true do
     c = Complex(2, 3)
     lambda { @object.send(:Float, c) }.should raise_error(RangeError)
   end
+
+  ruby_version_is "2.6" do
+    describe "when passed exception: false" do
+      describe "and valid input" do
+        it "returns a Float number" do
+          @object.send(:Float, 1, exception: false).should == 1.0
+          @object.send(:Float, "1", exception: false).should == 1.0
+          @object.send(:Float, "1.23", exception: false).should == 1.23
+        end
+      end
+
+      describe "and invalid input" do
+        it "swallows an error" do
+          @object.send(:Float, "abc", exception: false).should == nil
+          @object.send(:Float, :sym, exception: false).should == nil
+        end
+      end
+
+      describe "and nil" do
+        it "swallows it" do
+          @object.send(:Float, nil, exception: false).should == nil
+        end
+      end
+    end
+  end
 end
 
 describe "Kernel.Float" do

--- a/core/kernel/Integer_spec.rb
+++ b/core/kernel/Integer_spec.rb
@@ -142,6 +142,18 @@ describe :kernel_integer, shared: true do
           Integer(nil, exception: false).should == nil
         end
       end
+
+      describe "and passed a String that contains numbers" do
+        it "normally parses it and returns an Integer" do
+          Integer("42", exception: false).should == 42
+        end
+      end
+
+      describe "and passed a String that can't be converted to an Integer" do
+        it "swallows an error" do
+          Integer("abc", exception: false).should == nil
+        end
+      end
     end
   end
 end

--- a/core/kernel/Integer_spec.rb
+++ b/core/kernel/Integer_spec.rb
@@ -99,6 +99,51 @@ describe :kernel_integer, shared: true do
   it "raises a FloatDomainError when passed Infinity" do
     lambda { Integer(infinity_value) }.should raise_error(FloatDomainError)
   end
+
+  ruby_version_is "2.6" do
+    describe "when passed exception: false" do
+      describe "and to_i returns a value that is not an Integer" do
+        it "swallows an error" do
+          obj = mock("object")
+          obj.should_receive(:to_i).and_return("1")
+          Integer(obj, exception: false).should == nil
+        end
+      end
+
+      describe "and no to_int or to_i methods exist" do
+        it "swallows an error" do
+          obj = mock("object")
+          Integer(obj, exception: false).should == nil
+        end
+      end
+
+      describe "and to_int returns nil and no to_i exists" do
+        it "swallows an error" do
+          obj = mock("object")
+          obj.should_receive(:to_i).and_return(nil)
+          Integer(obj, exception: false).should == nil
+        end
+      end
+
+      describe "and passed NaN" do
+        it "raises a TypeError" do
+          lambda { Integer(nan_value, exception: false) }.should raise_error(FloatDomainError)
+        end
+      end
+
+      describe "and passed Infinity" do
+        it "raises a TypeError" do
+          lambda { Integer(infinity_value, exception: false) }.should raise_error(FloatDomainError)
+        end
+      end
+
+      describe "and passed nil" do
+        it "swallows an error" do
+          Integer(nil, exception: false).should == nil
+        end
+      end
+    end
+  end
 end
 
 describe "Integer() given a String", shared: true do
@@ -187,6 +232,34 @@ describe "Integer() given a String", shared: true do
 
   it "raises an ArgumentError for an empty String" do
     lambda { Integer("") }.should raise_error(ArgumentError)
+  end
+
+  ruby_version_is "2.6" do
+    describe "when passed exception: false" do
+      describe "and multiple leading -s" do
+        it "swallows an error" do
+          Integer("---1", exception: false).should == nil
+        end
+      end
+
+      describe "and multiple trailing -s" do
+        it "swallows an error" do
+          Integer("1---", exception: false).should == nil
+        end
+      end
+
+      describe "and an argument that contains a period" do
+        it "swallows an error" do
+          Integer("0.0", exception: false).should == nil
+        end
+      end
+
+      describe "and an empty string" do
+        it "swallows an error" do
+          Integer("", exception: false).should == nil
+        end
+      end
+    end
   end
 
   it "parses the value as 0 if the string consists of a single zero character" do
@@ -506,6 +579,24 @@ describe "Integer() given a String and base", shared: true do
 
     it "raises an ArgumentError if a base is given for a non-String value" do
       lambda { Integer(98, 15) }.should raise_error(ArgumentError)
+    end
+  end
+
+  ruby_version_is "2.6" do
+    describe "when passed exception: false" do
+      describe "and valid argument" do
+        it "returns an Integer number" do
+          Integer("100", 10, exception: false).should == 100
+          Integer("100", 2, exception: false).should == 4
+        end
+      end
+
+      describe "and invalid argument" do
+        it "swallows an error" do
+          Integer("999", 2, exception: false).should == nil
+          Integer("abc", 10, exception: false).should == nil
+        end
+      end
     end
   end
 end

--- a/shared/rational/Rational.rb
+++ b/shared/rational/Rational.rb
@@ -100,4 +100,44 @@ describe :kernel_Rational, shared: true do
       lambda { Rational(1, :sym) }.should raise_error(TypeError)
     end
   end
+
+  ruby_version_is "2.6" do
+    describe "when passed exception: false" do
+      describe "and [non-Numeric]" do
+        it "swallows an error" do
+          Rational(:sym, exception: false).should == nil
+          Rational("abc", exception: false).should == nil
+        end
+      end
+
+      describe "and [non-Numeric, Numeric]" do
+        it "swallows an error" do
+          Rational(:sym, 1, exception: false).should == nil
+          Rational("abc", 1, exception: false).should == nil
+        end
+      end
+
+      describe "and [anything, non-Numeric]" do
+        it "swallows an error" do
+          Rational(:sym, :sym, exception: false).should == nil
+          Rational("abc", :sym, exception: false).should == nil
+        end
+      end
+
+      describe "and non-Numeric String arguments" do
+        it "swallows an error" do
+          Rational("a", "b", exception: false).should == nil
+          Rational("a", 0, exception: false).should == nil
+          Rational(0, "b", exception: false).should == nil
+        end
+      end
+
+      describe "and nil arguments" do
+        it "raises a TypeError" do
+          lambda { Rational(nil, exception: false) }.should raise_error(TypeError, "can't convert nil into Rational")
+          lambda { Rational(nil, nil, exception: false) }.should raise_error(TypeError, "can't convert nil into Rational")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
+ File.open with 'x' flag.
+ `Kernel#Complex` with exception: false.
+ `Kernel#Float` with exception: false.
+ `Kernel#Integer` with exception: false.
+ `Kernel#Rational` with exception: false.
+ new `:receiver` and `:key` options for `KeyError`.