### PR TITLE
[Ruby 2.6] Time.new and Time#getlocal accept a timezone object

### DIFF
--- a/core/time/at_spec.rb
+++ b/core/time/at_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
 
 describe "Time.at" do
   describe "passed Numeric" do
@@ -195,6 +196,58 @@ describe "Time.at" do
         Time.at(0, 123456.500, :microsecond).nsec.should == 123456500
         Time.at(0, 123456.500, :usec).nsec.should == 123456500
         Time.at(0, 123.500, :millisecond).nsec.should == 123500000
+      end
+    end
+  end
+
+  ruby_version_is "2.6" do
+    describe ":in keyword argument" do
+      before do
+        @epoch_time = Time.now.to_i
+      end
+
+      it "could be UTC offset as a String in '+HH:MM or '-HH:MM' format" do
+        time = Time.at(@epoch_time, in: "+05:00")
+
+        time.utc_offset.should == 5*60*60
+        time.zone.should == nil
+        time.to_i.should == @epoch_time
+
+        time = Time.at(@epoch_time, in: "-09:00")
+
+        time.utc_offset.should == -9*60*60
+        time.zone.should == nil
+        time.to_i.should == @epoch_time
+      end
+
+      it "could be UTC offset as a number of seconds" do
+        time = Time.at(@epoch_time, in: 5*60*60)
+
+        time.utc_offset.should == 5*60*60
+        time.zone.should == nil
+        time.to_i.should == @epoch_time
+
+        time = Time.at(@epoch_time, in: -9*60*60)
+
+        time.utc_offset.should == -9*60*60
+        time.zone.should == nil
+        time.to_i.should == @epoch_time
+      end
+
+      it "could be a timezone object" do
+        zone = TimeSpecs::TimezoneWithName.new(name: "Asia/Colombo", offset: (5*3600+30*60))
+        time = Time.at(@epoch_time, in: zone)
+
+        time.utc_offset.should == 5*3600+30*60
+        time.zone.should == zone
+        time.to_i.should == @epoch_time
+
+        zone = TimeSpecs::TimezoneWithName.new(name: "PST", offset: (-9*60*60))
+        time = Time.at(@epoch_time, in: zone)
+
+        time.utc_offset.should == -9*60*60
+        time.zone.should == zone
+        time.to_i.should == @epoch_time
       end
     end
   end

--- a/core/time/fixtures/classes.rb
+++ b/core/time/fixtures/classes.rb
@@ -9,18 +9,77 @@ module TimeSpecs
     end
   end
 
-  Timezone = Struct.new(:name, :abbr, :offset)
   class Timezone
-    def utc_offset(t = nil)
-      offset
+    def initialize(options)
+      @offset = options[:offset]
     end
 
     def local_to_utc(t)
-      t - utc_offset(t)
+      t - @offset
     end
 
     def utc_to_local(t)
-      t + utc_offset(t)
+      t + @offset
+    end
+  end
+
+  class TimezoneMethodCallRecorder < Timezone
+    def initialize(options, &blk)
+      super(options)
+      @blk = blk
+    end
+
+    def local_to_utc(t)
+      @blk.call(t)
+      super
+    end
+
+    def utc_to_local(t)
+      @blk.call(t)
+      super
+    end
+  end
+
+  class TimeLikeArgumentRecorder
+    def self.result
+      arguments = []
+
+      zone = TimeSpecs::TimezoneMethodCallRecorder.new(offset: 0) do |obj|
+        arguments << obj
+      end
+
+      # ensure timezone's methods are called at least once
+      Time.new(2000, 1, 1, 12, 0, 0, zone)
+
+      return arguments[0]
+    end
+  end
+
+  class TimezoneWithAbbr < Timezone
+    def initialize(options)
+      super
+      @abbr = options[:abbr]
+    end
+
+    def abbr(time)
+      @abbr
+    end
+  end
+
+  class TimezoneWithName < Timezone
+    def initialize(options)
+      super
+      @name = options[:name]
+    end
+
+    def name
+      @name
+    end
+  end
+
+  class TimeWithFindTimezone < Time
+    def self.find_timezone(name)
+      TimezoneWithName.new(name: name.to_s, offset: -10*60*60)
     end
   end
 end

--- a/core/time/getlocal_spec.rb
+++ b/core/time/getlocal_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
 
 describe "Time#getlocal" do
   it "returns a new time which is the local representation of time" do
@@ -99,15 +100,69 @@ describe "Time#getlocal" do
   ruby_version_is "2.6" do
     describe "with a timezone argument" do
       it "returns a Time in the timezone" do
-        zone = mock('timezone')
-        zone.should_receive(:utc_to_local).and_return(Time.utc(2000, 1, 1, 17, 30, 0))
-        t = Time.utc(2000, 1, 1, 12, 0, 0)
-        tv = t.to_i
-        t = t.getlocal(zone)
-        t.to_a[0, 6].should == [0, 30, 17, 1, 1, 2000]
-        t.utc_offset.should == 19800
-        t.to_i.should == tv
-        t.zone.should == zone
+        zone = TimeSpecs::Timezone.new(offset: (5*3600+30*60))
+        time = Time.utc(2000, 1, 1, 12, 0, 0).getlocal(zone)
+
+        time.zone.should == zone
+        time.utc_offset.should == 5*3600+30*60
+      end
+
+      it "accepts timezone argument that must have #local_to_utc and #utc_to_local methods" do
+        zone = Object.new
+        def zone.utc_to_local(time)
+          time
+        end
+        def zone.local_to_utc(time)
+          time
+        end
+
+        lambda {
+          Time.utc(2000, 1, 1, 12, 0, 0).getlocal(zone).should be_kind_of(Time)
+        }.should_not raise_error
+      end
+
+      it "raises TypeError if timezone does not implement #utc_to_local method" do
+        zone = Object.new
+        def zone.local_to_utc(time)
+          time
+        end
+
+        lambda {
+          Time.utc(2000, 1, 1, 12, 0, 0).getlocal(zone)
+        }.should raise_error(TypeError, /can't convert \w+ into an exact number/)
+      end
+
+      it "does not raise exception if timezone does not implement #local_to_utc method" do
+        zone = Object.new
+        def zone.utc_to_local(time)
+          time
+        end
+
+        lambda {
+          Time.utc(2000, 1, 1, 12, 0, 0).getlocal(zone).should be_kind_of(Time)
+        }.should_not raise_error
+      end
+
+      context "subject's class implements .find_timezone method" do
+        it "calls .find_timezone to build a time object if passed zone name as a timezone argument" do
+          time = TimeSpecs::TimeWithFindTimezone.utc(2000, 1, 1, 12, 0, 0).getlocal("Asia/Colombo")
+          time.zone.should be_kind_of TimeSpecs::TimezoneWithName
+          time.zone.name.should == "Asia/Colombo"
+
+          time = TimeSpecs::TimeWithFindTimezone.utc(2000, 1, 1, 12, 0, 0).getlocal("some invalid zone name")
+          time.zone.should be_kind_of TimeSpecs::TimezoneWithName
+          time.zone.name.should == "some invalid zone name"
+        end
+
+        it "does not call .find_timezone if passed any not string/numeric/timezone timezone argument" do
+          [Object.new, [], {}, :"some zone"].each do |zone|
+            time = TimeSpecs::TimeWithFindTimezone.utc(2000, 1, 1, 12, 0, 0)
+
+            lambda {
+              time.getlocal(zone)
+            }.should raise_error(TypeError, /can't convert \w+ into an exact number/)
+          end
+        end
       end
     end
   end

--- a/core/time/minus_spec.rb
+++ b/core/time/minus_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
 
 describe "Time#-" do
   it "decrements the time by the specified amount" do
@@ -87,6 +88,25 @@ describe "Time#-" do
 
   it "returns a time with the same fixed offset as self" do
     (Time.new(2012, 1, 1, 0, 0, 0, 3600) - 10).utc_offset.should == 3600
+  end
+
+  it "preserves time zone" do
+    time_with_zone = Time.now.utc
+    time_with_zone.zone.should == (time_with_zone - 60*60).zone
+
+    time_with_zone = Time.now
+    time_with_zone.zone.should == (time_with_zone - 60*60).zone
+  end
+
+  ruby_version_is "2.6" do
+    context "zone is a timezone object" do
+      it "preserves time zone" do
+        zone = TimeSpecs::Timezone.new(offset: (5*3600+30*60))
+        time = Time.new(2012, 1, 1, 12, 0, 0, zone) - 60*60
+
+        time.zone.should == zone
+      end
+    end
   end
 
   it "does not return a subclass instance" do

--- a/core/time/new_spec.rb
+++ b/core/time/new_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
 require_relative 'shared/now'
 require_relative 'shared/local'
 require_relative 'shared/time_params'
@@ -116,12 +117,211 @@ end
 
 ruby_version_is "2.6" do
   describe "Time.new with a timezone argument" do
-    it "returns a Time correspoinding to UTC time returned by local_to_utc" do
-      zone = TimeSpecs::Timezone.new("Asia/Colombo", "MMT", (5*3600+30*60))
-      t = Time.new(2000, 1, 1, 12, 0, 0, zone)
-      t.to_a[0, 6].should == [0, 0, 12, 1, 1, 2000]
-      t.utc_offset.should == 19800
-      t.zone.should == zone
+    it "returns a Time in the timezone" do
+      zone = TimeSpecs::Timezone.new(offset: (5*3600+30*60))
+      time = Time.new(2000, 1, 1, 12, 0, 0, zone)
+
+      time.zone.should == zone
+      time.utc_offset.should == 5*3600+30*60
+    end
+
+    it "accepts timezone argument that must have #local_to_utc and #utc_to_local methods" do
+      zone = Object.new
+      def zone.utc_to_local(time)
+        time
+      end
+      def zone.local_to_utc(time)
+        time
+      end
+
+      lambda {
+        Time.new(2000, 1, 1, 12, 0, 0, zone).should be_kind_of(Time)
+      }.should_not raise_error
+    end
+
+    it "raises TypeError if timezone does not implement #local_to_utc method" do
+      zone = Object.new
+      def zone.utc_to_local(time)
+        time
+      end
+
+      lambda {
+        Time.new(2000, 1, 1, 12, 0, 0, zone)
+      }.should raise_error(TypeError, /can't convert \w+ into an exact number/)
+    end
+
+    it "does not raise exception if timezone does not implement #utc_to_local method" do
+      zone = Object.new
+      def zone.local_to_utc(time)
+        time
+      end
+
+      lambda {
+        Time.new(2000, 1, 1, 12, 0, 0, zone).should be_kind_of(Time)
+      }.should_not raise_error
+    end
+
+    # The result also should be a Time or Time-like object (not necessary to be the same class)
+    # The zone of the result is just ignored
+    describe "returned value by #utc_to_local and #local_to_utc methods" do
+      it "could be Time instance" do
+        zone = Object.new
+        def zone.local_to_utc(t)
+          Time.utc(t.year, t.mon, t.day, t.hour - 1, t.min, t.sec)
+        end
+
+        lambda {
+          Time.new(2000, 1, 1, 12, 0, 0, zone).should be_kind_of(Time)
+          Time.new(2000, 1, 1, 12, 0, 0, zone).utc_offset.should == 60*60
+        }.should_not raise_error
+      end
+
+      it "could be Time subclass instance" do
+        zone = Object.new
+        def zone.local_to_utc(t)
+          Class.new(Time).utc(t.year, t.mon, t.day, t.hour - 1, t.min, t.sec)
+        end
+
+        lambda {
+          Time.new(2000, 1, 1, 12, 0, 0, zone).should be_kind_of(Time)
+          Time.new(2000, 1, 1, 12, 0, 0, zone).utc_offset.should == 60*60
+        }.should_not raise_error
+      end
+
+      it "could be any object with #to_i method" do
+        zone = Object.new
+        def zone.local_to_utc(time)
+          Struct.new(:to_i).new(time.to_i - 60*60)
+        end
+
+        lambda {
+          Time.new(2000, 1, 1, 12, 0, 0, zone).should be_kind_of(Time)
+          Time.new(2000, 1, 1, 12, 0, 0, zone).utc_offset.should == 60*60
+        }.should_not raise_error
+      end
+
+      it "could have any #zone and #utc_offset because they are ignored" do
+        zone = Object.new
+        def zone.local_to_utc(time)
+          Struct.new(:to_i, :zone, :utc_offset).new(time.to_i, 'America/New_York', -5*60*60)
+        end
+        Time.new(2000, 1, 1, 12, 0, 0, zone).utc_offset.should == 0
+
+        zone = Object.new
+        def zone.local_to_utc(time)
+          Struct.new(:to_i, :zone, :utc_offset).new(time.to_i, 'Asia/Tokyo', 9*60*60)
+        end
+        Time.new(2000, 1, 1, 12, 0, 0, zone).utc_offset.should == 0
+      end
+
+      it "leads to raising Argument error if difference between argument and result is too large" do
+        zone = Object.new
+        def zone.local_to_utc(t)
+          Time.utc(t.year, t.mon, t.day + 1, t.hour, t.min, t.sec)
+        end
+
+        lambda {
+          Time.new(2000, 1, 1, 12, 0, 0, zone)
+        }.should raise_error(ArgumentError, "utc_offset out of range")
+      end
+    end
+
+    # https://github.com/ruby/ruby/blob/v2_6_0/time.c#L5330
+    #
+    # Time-like argument to these methods is similar to a Time object in UTC without sub-second;
+    # it has attribute readers for the parts, e.g. year, month, and so on, and epoch time readers, to_i
+    #
+    # The sub-second attributes are fixed as 0, and utc_offset, zone, isdst, and their aliases are same as a Time object in UTC
+    describe "Time-like argument of #utc_to_local and #local_to_utc methods" do
+      before do
+        @obj = TimeSpecs::TimeLikeArgumentRecorder.result
+        @obj.should_not == nil
+      end
+
+      it "implements subset of Time methods" do
+        [
+          :year, :mon, :month, :mday, :hour, :min, :sec,
+          :tv_sec, :tv_usec, :usec, :tv_nsec, :nsec, :subsec,
+          :to_i, :to_f, :to_r, :+, :-,
+          :isdst, :dst?, :zone, :gmtoff, :gmt_offset, :utc_offset, :utc?, :gmt?,
+          :to_s, :inspect, :to_a, :to_time,
+        ].each do |name|
+          @obj.respond_to?(name).should == true
+        end
+      end
+
+      it "has attribute values the same as a Time object in UTC" do
+        @obj.usec.should == 0
+        @obj.nsec.should == 0
+        @obj.subsec.should == 0
+        @obj.tv_usec.should == 0
+        @obj.tv_nsec.should == 0
+
+        @obj.utc_offset.should == 0
+        @obj.zone.should == "UTC"
+        @obj.isdst.should == Time.new.utc.isdst
+      end
+    end
+
+    context "#name method" do
+      it "uses the optional #name method for marshaling" do
+        zone = TimeSpecs::TimezoneWithName.new(name: "Asia/Colombo", offset: (5*3600+30*60))
+        time = Time.new(2000, 1, 1, 12, 0, 0, zone)
+        time_loaded = Marshal.load(Marshal.dump(time))
+
+        time_loaded.zone.should == "Asia/Colombo"
+        time_loaded.utc_offset.should == 5*3600+30*60
+      end
+
+      it "cannot marshal Time if #name method isn't implemented" do
+        zone = TimeSpecs::Timezone.new(offset: (5*3600+30*60))
+        time = Time.new(2000, 1, 1, 12, 0, 0, zone)
+
+        lambda {
+          Marshal.dump(time)
+        }.should raise_error(NoMethodError, /undefined method `name' for/)
+      end
+    end
+
+    it "the #abbr method is used by '%Z' in #strftime" do
+      zone = TimeSpecs::TimezoneWithAbbr.new(abbr: "MMT", offset: (5*3600+30*60))
+      time = Time.new(2000, 1, 1, 12, 0, 0, zone)
+
+      time.strftime("%Z").should == "MMT"
+    end
+
+    # At loading marshaled data, a timezone name will be converted to a timezone object
+    # by find_timezone class method, if the method is defined.
+    # Similary, that class method will be called when a timezone argument does not have
+    # the necessary methods mentioned above.
+    context "subject's class implements .find_timezone method" do
+      it "calls .find_timezone to build a time object at loading marshaled data" do
+        zone = TimeSpecs::TimezoneWithName.new(name: "Asia/Colombo", offset: (5*3600+30*60))
+        time = TimeSpecs::TimeWithFindTimezone.new(2000, 1, 1, 12, 0, 0, zone)
+        time_loaded = Marshal.load(Marshal.dump(time))
+
+        time_loaded.zone.should be_kind_of TimeSpecs::TimezoneWithName
+        time_loaded.zone.name.should == "Asia/Colombo"
+        time_loaded.utc_offset.should == 5*3600+30*60
+      end
+
+      it "calls .find_timezone to build a time object if passed zone name as a timezone argument" do
+        time = TimeSpecs::TimeWithFindTimezone.new(2000, 1, 1, 12, 0, 0, "Asia/Colombo")
+        time.zone.should be_kind_of TimeSpecs::TimezoneWithName
+        time.zone.name.should == "Asia/Colombo"
+
+        time = TimeSpecs::TimeWithFindTimezone.new(2000, 1, 1, 12, 0, 0, "some invalid zone name")
+        time.zone.should be_kind_of TimeSpecs::TimezoneWithName
+        time.zone.name.should == "some invalid zone name"
+      end
+
+      it "does not call .find_timezone if passed any not string/numeric/timezone timezone argument" do
+        [Object.new, [], {}, :"some zone"].each do |zone|
+          lambda {
+            TimeSpecs::TimeWithFindTimezone.new(2000, 1, 1, 12, 0, 0, zone)
+          }.should raise_error(TypeError, /can't convert \w+ into an exact number/)
+        end
+      end
     end
   end
 end

--- a/core/time/plus_spec.rb
+++ b/core/time/plus_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
 
 describe "Time#+" do
   it "increments the time by the specified amount" do
@@ -47,16 +48,22 @@ describe "Time#+" do
     (Time.new(2012, 1, 1, 0, 0, 0, 3600) + 10).utc_offset.should == 3600
   end
 
+  it "preserves time zone" do
+    time_with_zone = Time.now.utc
+    time_with_zone.zone.should == (time_with_zone + 60*60).zone
+
+    time_with_zone = Time.now
+    time_with_zone.zone.should == (time_with_zone + 60*60).zone
+  end
+
   ruby_version_is "2.6" do
-    it "returns a time with the same timezone as self" do
-      zone = mock("timezone")
-      zone.should_receive(:local_to_utc).and_return(Time.utc(2012, 1, 1, 6, 30, 0))
-      zone.should_receive(:utc_to_local).and_return(Time.utc(2012, 1, 1, 12, 0, 10))
-      t = Time.new(2012, 1, 1, 12, 0, 0, zone) + 10
-      t.zone.should == zone
-      t.utc_offset.should == 19800
-      t.to_a[0, 6].should == [10, 0, 12, 1, 1, 2012]
-      t.should == Time.utc(2012, 1, 1, 6, 30, 10)
+    context "zone is a timezone object" do
+      it "preserves time zone" do
+        zone = TimeSpecs::Timezone.new(offset: (5*3600+30*60))
+        time = Time.new(2012, 1, 1, 12, 0, 0, zone) + 60*60
+
+        time.zone.should == zone
+      end
     end
   end
 

--- a/core/time/succ_spec.rb
+++ b/core/time/succ_spec.rb
@@ -1,19 +1,39 @@
 require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
 
 describe "Time#succ" do
   it "returns a new time one second later than time" do
-    -> {
+    suppress_warning {
       @result = Time.at(100).succ
-    }.should complain(/Time#succ is obsolete/)
+    }
+
     @result.should == Time.at(101)
   end
 
   it "returns a new instance" do
-    t1 = Time.at(100)
-    t2 = nil
-    -> {
-      t2 = t1.succ
+    time = Time.at(100)
+
+    suppress_warning {
+      @result = time.succ
+    }
+
+    @result.should_not equal time
+  end
+
+  it "is obsolete" do
+    lambda {
+      Time.at(100).succ
     }.should complain(/Time#succ is obsolete/)
-    t1.should_not equal t2
+  end
+
+  ruby_version_is "2.6" do
+    context "zone is a timezone object" do
+      it "preserves time zone" do
+        zone = TimeSpecs::Timezone.new(offset: (5*3600+30*60))
+        time = Time.new(2012, 1, 1, 12, 0, 0, zone) - 60*60
+
+        time.zone.should == zone
+      end
+    end
   end
 end


### PR DESCRIPTION
Time.new and Time#getlocal accept a timezone object as well as a UTC offset string. Time#+, Time#-, and Time#succ also preserve the timezone.

Feature #14850

Issue https://github.com/ruby/spec/issues/640