### PR TITLE
[Ruby 2.6] TracePoint#enable accepts new keywords target: and target_line:

### DIFF
--- a/core/tracepoint/enable_spec.rb
+++ b/core/tracepoint/enable_spec.rb
@@ -99,4 +99,284 @@ describe 'TracePoint#enable' do
       trace.enabled?.should be_false
     end
   end
+
+  ruby_version_is "2.6" do
+    describe 'target: option' do
+      before :each do
+        ScratchPad.record []
+      end
+
+      it 'enables trace point for specific location' do
+        trace = TracePoint.new(:call) do |tp|
+          ScratchPad << tp.method_id
+        end
+
+        obj = Object.new
+        def obj.foo; end
+        def obj.bar; end
+
+        trace.enable(target: obj.method(:foo)) do
+          obj.foo
+          obj.bar
+        end
+
+        ScratchPad.recorded.should == [:foo]
+      end
+
+      it 'traces all the events triggered in specified location' do
+        trace = TracePoint.new(:line, :call, :return, :b_call, :b_return) do |tp|
+          ScratchPad << tp.event
+        end
+
+        obj = Object.new
+        def obj.foo
+          bar
+          -> {}.call
+        end
+        def obj.bar; end
+
+        trace.enable(target: obj.method(:foo)) do
+          obj.foo
+        end
+
+        ScratchPad.recorded.uniq.sort.should == [:call, :return, :b_call, :b_return, :line].sort
+      end
+
+      it 'does not trace events in nested locations' do
+        trace = TracePoint.new(:call) do |tp|
+          ScratchPad << tp.method_id
+        end
+
+        obj = Object.new
+        def obj.foo
+          bar
+        end
+        def obj.bar
+          baz
+        end
+        def obj.baz
+        end
+
+        trace.enable(target: obj.method(:foo)) do
+          obj.foo
+        end
+
+        ScratchPad.recorded.should == [:foo]
+      end
+
+      describe 'option value' do
+        it 'excepts Method' do
+          trace = TracePoint.new(:call) do |tp|
+            ScratchPad << tp.method_id
+          end
+
+          obj = Object.new
+          def obj.foo; end
+
+          trace.enable(target: obj.method(:foo)) do
+            obj.foo
+          end
+
+          ScratchPad.recorded.should == [:foo]
+        end
+
+        it 'excepts UnboundMethod' do
+          trace = TracePoint.new(:call) do |tp|
+            ScratchPad << tp.method_id
+          end
+
+          klass = Class.new do
+            def foo; end
+          end
+
+          unbound_method = klass.instance_method(:foo)
+          trace.enable(target: unbound_method) do
+            klass.new.foo
+          end
+
+          ScratchPad.recorded.should == [:foo]
+        end
+
+        it 'excepts Proc' do
+          trace = TracePoint.new(:b_call) do |tp|
+            ScratchPad << tp.lineno
+          end
+
+          block = proc {}
+          _, lineno = block.source_location
+
+          trace.enable(target: block) do
+            block.call
+          end
+
+          ScratchPad.recorded.should == [lineno]
+          lineno.should be_kind_of(Integer)
+        end
+
+        it 'excepts RubyVM::InstructionSequence' do
+          trace = TracePoint.new(:call) do |tp|
+            ScratchPad << tp.method_id
+          end
+
+          obj = Object.new
+          def obj.foo; end
+
+          iseq = RubyVM::InstructionSequence.of(obj.method(:foo))
+          trace.enable(target: iseq) do
+            obj.foo
+          end
+
+          ScratchPad.recorded.should == [:foo]
+        end
+      end
+
+      it "raises ArgumentError when passed object isn't consisted of InstructionSequence (iseq)" do
+        trace = TracePoint.new(:call) do |tp|
+          ScratchPad << tp.method_id
+        end
+
+        core_method = 'foo bar'.method(:bytes)
+        RubyVM::InstructionSequence.of(core_method).should == nil
+
+        lambda {
+          trace.enable(target: core_method) do
+          end
+        }.should raise_error(ArgumentError, /specified target is not supported/)
+      end
+
+      it "raises ArgumentError if target object cannot trigger specified event" do
+        trace = TracePoint.new(:call) do |tp|
+          ScratchPad << tp.method_id
+        end
+
+        block = proc {}
+
+        lambda {
+          trace.enable(target: block) do
+            block.call # triggers :b_call and :b_return events
+          end
+        }.should raise_error(ArgumentError, /can not enable any hooks/)
+      end
+
+      it "raises ArgumentError if passed not Method/UnboundMethod/Proc/RubyVM::InstructionSequence" do
+        trace = TracePoint.new(:call) do |tp|
+        end
+
+        lambda {
+          trace.enable(target: Object.new) do
+          end
+        }.should raise_error(ArgumentError, /specified target is not supported/)
+      end
+
+      context "nested enabling and disabling" do
+        it "raises ArgumentError if trace point already enabled with target is re-enabled with target" do
+          trace = TracePoint.new(:b_call) do
+          end
+
+          lambda {
+            trace.enable(target: -> {}) do
+              trace.enable(target: -> {}) do
+              end
+            end
+          }.should raise_error(ArgumentError, /can't nest-enable a targetting TracePoint/)
+        end
+
+        it "raises ArgumentError if trace point already enabled without target is re-enabled with target" do
+          trace = TracePoint.new(:b_call) do
+          end
+
+          lambda {
+            trace.enable do
+              trace.enable(target: -> {}) do
+              end
+            end
+          }.should raise_error(ArgumentError, /can't nest-enable a targetting TracePoint/)
+        end
+
+        it "raises ArgumentError if trace point already enabled with target is re-enabled without target" do
+          trace = TracePoint.new(:b_call) do
+          end
+
+          lambda {
+            trace.enable(target: -> {}) do
+              trace.enable do
+              end
+            end
+          }.should raise_error(ArgumentError, /can't nest-enable a targetting TracePoint/)
+        end
+
+        it "raises ArgumentError if trace point already enabled with target is disabled with block" do
+          trace = TracePoint.new(:b_call) do
+          end
+
+          lambda {
+            trace.enable(target: -> {}) do
+              trace.disable do
+              end
+            end
+          }.should raise_error(ArgumentError, /can't disable a targetting TracePoint in a block/)
+        end
+
+        it "traces events when trace point with target is enabled in another trace point enabled without target" do
+          trace_outer = TracePoint.new(:b_call) do |tp|
+            ScratchPad << :outer
+          end
+
+          trace_inner = TracePoint.new(:b_call) do |tp|
+            ScratchPad << :inner
+          end
+
+          target = -> {}
+
+          trace_outer.enable do
+            trace_inner.enable(target: target) do
+              target.call
+            end
+          end
+
+          ScratchPad.recorded.should == [:outer, :outer, :outer, :inner]
+        end
+
+        it "traces events when trace point with target is enabled in another trace point enabled with target" do
+          trace_outer = TracePoint.new(:b_call) do |tp|
+            ScratchPad << :outer
+          end
+
+          trace_inner = TracePoint.new(:b_call) do |tp|
+            ScratchPad << :inner
+          end
+
+          target = -> {}
+
+          trace_outer.enable(target: target) do
+            trace_inner.enable(target: target) do
+              target.call
+            end
+          end
+
+          ScratchPad.recorded.should == [:inner, :outer]
+        end
+
+        it "traces events when trace point without target is enabled in another trace point enabled with target" do
+          trace_outer = TracePoint.new(:b_call) do |tp|
+            ScratchPad << :outer
+          end
+
+          trace_inner = TracePoint.new(:b_call) do |tp|
+            ScratchPad << :inner
+          end
+
+          target = -> {}
+
+          trace_outer.enable(target: target) do
+            trace_inner.enable do
+              target.call
+            end
+          end
+
+          ScratchPad.recorded.should == [:inner, :inner, :outer]
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Issue https://github.com/ruby/spec/issues/640