### PR TITLE
thread: don't assume the underlying acceptable priority range

### DIFF
--- a/core/thread/priority_spec.rb
+++ b/core/thread/priority_spec.rb
@@ -49,11 +49,11 @@ describe "Thread#priority=" do
       value.should == 3
     end
 
-    it "clamps the priority to -3..3" do
-      @thread.priority = 42
-      @thread.priority.should == 3
-      @thread.priority = -42
-      @thread.priority.should == -3
+    it "clamps priority to the acceptable underlying range" do
+      @thread.priority = 255
+      @thread.priority.should < 255
+      @thread.priority = -255
+      @thread.priority.should > -255
     end
   end
 


### PR DESCRIPTION
This change is needed by https://github.com/ruby/ruby/pull/2093

Basically, the range of acceptable thread priorities should not be assumed by the spec,
only that invalid priorities are clamped to the acceptable range. The only thing the changed
spec assumes is that 255 and -255 are outside this range.