### PR TITLE
Document behavior of String#to_f with a trailing decimal

### DIFF
--- a/core/string/to_f_spec.rb
+++ b/core/string/to_f_spec.rb
@@ -12,6 +12,7 @@ describe "String#to_f" do
 
    ".5".to_f.should == 0.5
    ".5e1".to_f.should == 5.0
+   "5.".to_f.should == 5.0
    "5e".to_f.should == 5.0
    "5E".to_f.should == 5.0
   end


### PR DESCRIPTION
There's already a spec for "5e" with no exponent, but it seemed good to document this case too because I ran into a corresponding issue with BigDecimal: https://github.com/ruby/bigdecimal/pull/132

(feel free to ignore if this seems redundant)