### PR TITLE
Use a StringScanner in strscan_concat_fixnum

### DIFF
--- a/library/stringscanner/shared/concat.rb
+++ b/library/stringscanner/shared/concat.rb
@@ -25,6 +25,6 @@ describe :strscan_concat_fixnum, shared: true do
     x = mock('x')
     x.should_not_receive(:to_int)
 
-    lambda { "".send(@method, x) }.should raise_error(TypeError)
+    lambda { StringScanner.new("").send(@method, x) }.should raise_error(TypeError)
   end
 end


### PR DESCRIPTION
`strscan_concat_fixnum` sends `:concat` to an empty `String` with a `Fixnum` argument and expects a `TypeError`.

This is incorrect because `Fixnum` is a valid argument to `String#concat`. It is only `StringScanner` that disallows it.