### PR TITLE
Add Method and UnboundMethod original_name specs

### DIFF
--- a/core/method/fixtures/classes.rb
+++ b/core/method/fixtures/classes.rb
@@ -26,6 +26,7 @@ module MethodSpecs
     end
 
     alias bar foo
+    alias baz bar
 
     def same_as_foo
       true

--- a/core/method/original_name_spec.rb
+++ b/core/method/original_name_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Method#original_name" do
+  it "returns the name of the method" do
+    "abc".method(:upcase).original_name.should == :upcase
+  end
+
+  it "returns the original name when aliased" do
+    obj = MethodSpecs::Methods.new
+    obj.method(:foo).original_name.should == :foo
+    obj.method(:bar).original_name.should == :foo
+    obj.method(:bar).unbind.bind(obj).original_name.should == :foo
+  end
+
+  it "returns the original name even when aliased twice" do
+    obj = MethodSpecs::Methods.new
+    obj.method(:foo).original_name.should == :foo
+    obj.method(:baz).original_name.should == :foo
+    obj.method(:baz).unbind.bind(obj).original_name.should == :foo
+  end
+end

--- a/core/unboundmethod/fixtures/classes.rb
+++ b/core/unboundmethod/fixtures/classes.rb
@@ -34,6 +34,7 @@ module UnboundMethodSpecs
     def with_block(&block); end
 
     alias bar foo
+    alias baz bar
     alias alias_1 foo
     alias alias_2 foo
 

--- a/core/unboundmethod/original_name_spec.rb
+++ b/core/unboundmethod/original_name_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "UnboundMethod#original_name" do
+  it "returns the name of the method" do
+    String.instance_method(:upcase).original_name.should == :upcase
+  end
+
+  it "returns the original name" do
+    obj = UnboundMethodSpecs::Methods.new
+    obj.method(:foo).unbind.original_name.should == :foo
+    obj.method(:bar).unbind.original_name.should == :foo
+    UnboundMethodSpecs::Methods.instance_method(:bar).original_name.should == :foo
+  end
+
+  it "returns the original name even when aliased twice" do
+    obj = UnboundMethodSpecs::Methods.new
+    obj.method(:foo).unbind.original_name.should == :foo
+    obj.method(:baz).unbind.original_name.should == :foo
+    UnboundMethodSpecs::Methods.instance_method(:baz).original_name.should == :foo
+  end
+end


### PR DESCRIPTION
`Method#original_name` and `UnboundMethod#original_name` have their
behaviour described in the Ruby documentation but do not appear in
specs. Both were misbehaving on JRuby when alias is called in chain.