### PR TITLE
Add spec: Hash#fetch_values returns ordered values

### DIFF
--- a/core/hash/fetch_values_spec.rb
+++ b/core/hash/fetch_values_spec.rb
@@ -12,6 +12,10 @@ describe "Hash#fetch_values" do
       @hash.fetch_values(:a).should == [1]
       @hash.fetch_values(:a, :c).should == [1, 3]
     end
+
+    it "returns the values for keys ordered in the order of the requested keys" do
+      @hash.fetch_values(:c, :a).should == [3, 1]
+    end
   end
 
   describe "with unmatched keys" do


### PR DESCRIPTION
- `Hash#fetch_values` returns ordered values but there's no test for that
- `Hash#slice` has a similar behavior and there's already a test for that 
   - https://github.com/ruby/spec/blob/94d98ff35192a88fd3e20786fc6acb22106b3789/core/hash/slice_spec.rb#L20-L22

So it might be nice to have a test for `Hash#fetch_values`'s behavior.