### PR TITLE
Create Actions windows.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push]
+on: [push, pull_request]
 jobs:
   build:
     strategy:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,5 +1,5 @@
 name: windows
-on: [push]
+on: [push, pull_request]
 jobs:
   build:
     name: >-

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,33 @@
+name: windows
+on: [push]
+jobs:
+  build:
+    name: >-
+      build (windows, ${{ matrix.ruby }})
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ '2.4.x', '2.5.x', '2.6.x' ]
+    steps:
+      - name: git config
+        run: git config --global core.autocrlf false
+      - name: Checkout
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 10
+      - name: Load ruby, update MSYS2/MinGW
+        uses: MSP-Greg/actions-ruby@master
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          base: update
+      - name: Clone MSpec
+        run:  git clone https://github.com/ruby/mspec.git ../mspec
+      - name: Run specs
+        env:
+          CHECK_LEAKS: true
+        run: |
+          # Actions uses UTF8, causes test failures, similar to normal OS setup
+          [Console]::OutputEncoding = [System.Text.Encoding]::GetEncoding("IBM437")
+          [Console]::InputEncoding  = [System.Text.Encoding]::GetEncoding("IBM437")
+          ../mspec/bin/mspec -j

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # The Ruby Spec Suite
 
+[![Actions Build Status](https://github.com/ruby/spec/workflows/CI/badge.svg?branch=master)](https://github.com/ruby/spec/actions)
 [![Build Status](https://travis-ci.org/ruby/spec.svg)](https://travis-ci.org/ruby/spec)
 [![Build Status](https://ci.appveyor.com/api/projects/status/1gs6f399320o44b1?svg=true)](https://ci.appveyor.com/project/eregon/spec-x948i)
 [![Gitter](https://badges.gitter.im/ruby/spec.svg)](https://gitter.im/ruby/spec)


### PR DESCRIPTION
Creates an Actions yml file for Windows, tests against Ruby 2.4, 2.5, & 2.6.  Runs specs multi.

Tested running multi twice in my fork, both passed, and ruby-loco has run specs multi for a long time.

The action install current Rubies, as below. Also, updates to current MSYS2/MinGW gcc, currently 9.2.0 (Actions has gcc 7.3.0).

```
actions-ruby     default
Ruby 2.4.9        2.4.6
Ruby 2.5.7        2.5.5
Ruby 2.6.5        2.6.3
```

Ruby master has failures when run in Actions.  PR for that in the future.