### PR TITLE
Add spec to test that MatchData#regexp returns the same Regexp object used to match

### DIFF
--- a/core/matchdata/regexp_spec.rb
+++ b/core/matchdata/regexp_spec.rb
@@ -11,6 +11,12 @@ describe "MatchData#regexp" do
     m.regexp.should == /hay/
   end
 
+  it "returns the same Regexp used to match" do
+    r = /hay/
+    m = 'haystack'.match(r)
+    m.regexp.object_id.should == r.object_id
+  end
+
   it "returns a Regexp for the result of gsub(String)" do
     'he[[o'.gsub('[', ']')
     $~.regexp.should == /\[/


### PR DESCRIPTION
Found this during a refactor of the Artichoke `Regexp` implementation.