### PR TITLE
Fix failures with LC_ALL=C

### DIFF
--- a/core/env/each_pair_spec.rb
+++ b/core/env/each_pair_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../spec_helper'
+require_relative 'spec_helper'
 require_relative 'shared/each'
 
 describe "ENV.each_pair" do

--- a/core/env/each_spec.rb
+++ b/core/env/each_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../spec_helper'
+require_relative 'spec_helper'
 require_relative 'shared/each'
 
 describe "ENV.each" do

--- a/core/env/each_value_spec.rb
+++ b/core/env/each_value_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../spec_helper'
+require_relative 'spec_helper'
 require_relative '../enumerable/shared/enumeratorized'
 
 describe "ENV.each_value" do
@@ -26,7 +26,7 @@ describe "ENV.each_value" do
 
   it "uses the locale encoding" do
     ENV.each_value do |value|
-      value.encoding.should == Encoding.find('locale')
+      value.should.be_locale_env
     end
   end
 

--- a/core/env/shared/each.rb
+++ b/core/env/shared/each.rb
@@ -35,8 +35,6 @@ describe :env_each, shared: true do
       @internal = Encoding.default_internal
 
       Encoding.default_external = Encoding::BINARY
-
-      @locale_encoding = Encoding.find "locale"
     end
 
     after :each do
@@ -48,8 +46,8 @@ describe :env_each, shared: true do
       Encoding.default_internal = nil
 
       ENV.send(@method) do |key, value|
-        key.encoding.should equal(@locale_encoding)
-        value.encoding.should equal(@locale_encoding)
+        key.should.be_locale_env
+        value.should.be_locale_env
       end
     end
 

--- a/core/env/shared/to_hash.rb
+++ b/core/env/shared/to_hash.rb
@@ -15,11 +15,11 @@ describe :env_to_hash, shared: true do
   end
 
   it "uses the locale encoding for keys" do
-    ENV.send(@method).keys.all? {|k| k.encoding == Encoding.find('locale') }.should be_true
+    ENV.send(@method).keys.each {|k| k.should.be_locale_env }
   end
 
   it "uses the locale encoding for values" do
-    ENV.send(@method).values.all? {|v| v.encoding == Encoding.find('locale') }.should be_true
+    ENV.send(@method).values.each {|k| k.should.be_locale_env }
   end
 
   it "duplicates the ENV when converting to a Hash" do

--- a/core/env/spec_helper.rb
+++ b/core/env/spec_helper.rb
@@ -1,0 +1,28 @@
+require_relative '../../spec_helper'
+
+class BeLocaleEnvEncodingString
+  def initialize(name = 'locale')
+    encoding = Encoding.find(name)
+    @encodings = (encoding = Encoding::US_ASCII) ?
+                   [encoding, Encoding::ASCII_8BIT] : [encoding]
+  end
+
+  def matches?(actual)
+    @actual = actual = actual.encoding
+    @encodings.include?(actual)
+  end
+
+  def failure_message
+    ["Expected #{@actual} to be #{@encodings.join(' or ')}"]
+  end
+
+  def negative_failure_message
+    ["Expected #{@actual} not to be #{@encodings.join(' or ')}"]
+  end
+end
+
+class String
+  def be_locale_env(expected = 'locale')
+    BeLocaleEnvEncodingString.new(expected)
+  end
+end

--- a/core/env/spec_helper.rb
+++ b/core/env/spec_helper.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
 
-class BeLocaleEnvEncodingString
+locale_env_matcher = Class.new do
   def initialize(name = 'locale')
     encoding = Encoding.find(name)
     @encodings = (encoding = Encoding::US_ASCII) ?
@@ -21,8 +21,6 @@ class BeLocaleEnvEncodingString
   end
 end
 
-class String
-  def be_locale_env(expected = 'locale')
-    BeLocaleEnvEncodingString.new(expected)
-  end
+String.__send__(:define_method, :be_locale_env) do |expected = 'locale'|
+  locale_env_matcher.new(expected)
 end

--- a/core/env/to_a_spec.rb
+++ b/core/env/to_a_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../spec_helper'
+require_relative 'spec_helper'
 
 describe "ENV.to_a" do
 
@@ -11,8 +11,8 @@ describe "ENV.to_a" do
 
   it "returns the entries in the locale encoding" do
     ENV.to_a.each do |key, value|
-      key.encoding.should == Encoding.find('locale')
-      value.encoding.should == Encoding.find('locale')
+      key.should.be_locale_env
+      value.should.be_locale_env
     end
   end
 end

--- a/core/env/to_h_spec.rb
+++ b/core/env/to_h_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../spec_helper'
+require_relative 'spec_helper'
 require_relative 'shared/to_hash'
 
 describe "ENV.to_h" do

--- a/core/env/to_hash_spec.rb
+++ b/core/env/to_hash_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../spec_helper'
+require_relative 'spec_helper'
 require_relative 'shared/to_hash'
 
 describe "ENV.to_hash" do

--- a/core/env/values_spec.rb
+++ b/core/env/values_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../spec_helper'
+require_relative 'spec_helper'
 
 describe "ENV.values" do
 
@@ -8,7 +8,7 @@ describe "ENV.values" do
 
   it "uses the locale encoding" do
     ENV.values.each do |value|
-      value.encoding.should == Encoding.find('locale')
+      value.should.be_locale_env
     end
   end
 end


### PR DESCRIPTION
When the locale is `C`, environment variables which cannot represent in US-ASCII have ASCII-8BIT encoding.