### PR TITLE
[Ruby 2.7] Add new specs. Language/Core

### DIFF
--- a/core/array/intersection_spec.rb
+++ b/core/array/intersection_spec.rb
@@ -1,87 +1,21 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative 'shared/intersection'
 
 describe "Array#&" do
-  it "creates an array with elements common to both arrays (intersection)" do
-    ([] & []).should == []
-    ([1, 2] & []).should == []
-    ([] & [1, 2]).should == []
-    ([ 1, 3, 5 ] & [ 1, 2, 3 ]).should == [1, 3]
-  end
+  it_behaves_like :array_intersection, :&
+end
 
-  it "creates an array with no duplicates" do
-    ([ 1, 1, 3, 5 ] & [ 1, 2, 3 ]).uniq!.should == nil
-  end
+ruby_version_is "2.7" do
+  describe "Array#intersection" do
+    it_behaves_like :array_intersection, :intersection
 
-  it "creates an array with elements in order they are first encountered" do
-    ([ 1, 2, 3, 2, 5 ] & [ 5, 2, 3, 4 ]).should == [2, 3, 5]
-  end
-
-  it "does not modify the original Array" do
-    a = [1, 1, 3, 5]
-    (a & [1, 2, 3]).should == [1, 3]
-    a.should == [1, 1, 3, 5]
-  end
-
-  it "properly handles recursive arrays" do
-    empty = ArraySpecs.empty_recursive_array
-    (empty & empty).should == empty
-
-    (ArraySpecs.recursive_array & []).should == []
-    ([] & ArraySpecs.recursive_array).should == []
-
-    (ArraySpecs.recursive_array & ArraySpecs.recursive_array).should == [1, 'two', 3.0, ArraySpecs.recursive_array]
-  end
-
-  it "tries to convert the passed argument to an Array using #to_ary" do
-    obj = mock('[1,2,3]')
-    obj.should_receive(:to_ary).and_return([1, 2, 3])
-    ([1, 2] & obj).should == ([1, 2])
-  end
-
-  it "determines equivalence between elements in the sense of eql?" do
-    not_supported_on :opal do
-      ([5.0, 4.0] & [5, 4]).should == []
+    it "accepts multiple arguments" do
+      [1, 2, 3, 4].intersection([1, 2, 3], [2, 3, 4]).should == [2, 3]
     end
 
-    str = "x"
-    ([str] & [str.dup]).should == [str]
-
-    obj1 = mock('1')
-    obj2 = mock('2')
-    obj1.stub!(:hash).and_return(0)
-    obj2.stub!(:hash).and_return(0)
-    obj1.should_receive(:eql?).at_least(1).and_return(true)
-    obj2.stub!(:eql?).and_return(true)
-
-    ([obj1] & [obj2]).should == [obj1]
-    ([obj1, obj1, obj2, obj2] & [obj2]).should == [obj1]
-
-    obj1 = mock('3')
-    obj2 = mock('4')
-    obj1.stub!(:hash).and_return(0)
-    obj2.stub!(:hash).and_return(0)
-    obj1.should_receive(:eql?).at_least(1).and_return(false)
-
-    ([obj1] & [obj2]).should == []
-    ([obj1, obj1, obj2, obj2] & [obj2]).should == [obj2]
-  end
-
-  it "does return subclass instances for Array subclasses" do
-    (ArraySpecs::MyArray[1, 2, 3] & []).should be_an_instance_of(Array)
-    (ArraySpecs::MyArray[1, 2, 3] & ArraySpecs::MyArray[1, 2, 3]).should be_an_instance_of(Array)
-    ([] & ArraySpecs::MyArray[1, 2, 3]).should be_an_instance_of(Array)
-  end
-
-  it "does not call to_ary on array subclasses" do
-    ([5, 6] & ArraySpecs::ToAryArray[1, 2, 5, 6]).should == [5, 6]
-  end
-
-  it "properly handles an identical item even when its #eql? isn't reflexive" do
-    x = mock('x')
-    x.stub!(:hash).and_return(42)
-    x.stub!(:eql?).and_return(false) # Stubbed for clarity and latitude in implementation; not actually sent by MRI.
-
-    ([x] & [x]).should == [x]
+    it "preserves elements order from original array" do
+      [1, 2, 3, 4].intersection([3, 2, 1]).should == [1, 2, 3]
+    end
   end
 end

--- a/core/array/shared/intersection.rb
+++ b/core/array/shared/intersection.rb
@@ -1,0 +1,84 @@
+describe :array_intersection, shared: true do
+  it "creates an array with elements common to both arrays (intersection)" do
+    [].send(@method, []).should == []
+    [1, 2].send(@method, []).should == []
+    [].send(@method, [1, 2]).should == []
+    [ 1, 3, 5 ].send(@method, [ 1, 2, 3 ]).should == [1, 3]
+  end
+
+  it "creates an array with no duplicates" do
+    [ 1, 1, 3, 5 ].send(@method, [ 1, 2, 3 ]).uniq!.should == nil
+  end
+
+  it "creates an array with elements in order they are first encountered" do
+    [ 1, 2, 3, 2, 5 ].send(@method, [ 5, 2, 3, 4 ]).should == [2, 3, 5]
+  end
+
+  it "does not modify the original Array" do
+    a = [1, 1, 3, 5]
+    a.send(@method, [1, 2, 3]).should == [1, 3]
+    a.should == [1, 1, 3, 5]
+  end
+
+  it "properly handles recursive arrays" do
+    empty = ArraySpecs.empty_recursive_array
+    empty.send(@method, empty).should == empty
+
+    ArraySpecs.recursive_array.send(@method, []).should == []
+    [].send(@method, ArraySpecs.recursive_array).should == []
+
+    ArraySpecs.recursive_array.send(@method, ArraySpecs.recursive_array).should == [1, 'two', 3.0, ArraySpecs.recursive_array]
+  end
+
+  it "tries to convert the passed argument to an Array using #to_ary" do
+    obj = mock('[1,2,3]')
+    obj.should_receive(:to_ary).and_return([1, 2, 3])
+    [1, 2].send(@method, obj).should == ([1, 2])
+  end
+
+  it "determines equivalence between elements in the sense of eql?" do
+    not_supported_on :opal do
+      [5.0, 4.0].send(@method, [5, 4]).should == []
+    end
+
+    str = "x"
+    [str].send(@method, [str.dup]).should == [str]
+
+    obj1 = mock('1')
+    obj2 = mock('2')
+    obj1.stub!(:hash).and_return(0)
+    obj2.stub!(:hash).and_return(0)
+    obj1.should_receive(:eql?).at_least(1).and_return(true)
+    obj2.stub!(:eql?).and_return(true)
+
+    [obj1].send(@method, [obj2]).should == [obj1]
+    [obj1, obj1, obj2, obj2].send(@method, [obj2]).should == [obj1]
+
+    obj1 = mock('3')
+    obj2 = mock('4')
+    obj1.stub!(:hash).and_return(0)
+    obj2.stub!(:hash).and_return(0)
+    obj1.should_receive(:eql?).at_least(1).and_return(false)
+
+    [obj1].send(@method, [obj2]).should == []
+    [obj1, obj1, obj2, obj2].send(@method, [obj2]).should == [obj2]
+  end
+
+  it "does return subclass instances for Array subclasses" do
+    ArraySpecs::MyArray[1, 2, 3].send(@method, []).should be_an_instance_of(Array)
+    ArraySpecs::MyArray[1, 2, 3].send(@method, ArraySpecs::MyArray[1, 2, 3]).should be_an_instance_of(Array)
+    [].send(@method, ArraySpecs::MyArray[1, 2, 3]).should be_an_instance_of(Array)
+  end
+
+  it "does not call to_ary on array subclasses" do
+    [5, 6].send(@method, ArraySpecs::ToAryArray[1, 2, 5, 6]).should == [5, 6]
+  end
+
+  it "properly handles an identical item even when its #eql? isn't reflexive" do
+    x = mock('x')
+    x.stub!(:hash).and_return(42)
+    x.stub!(:eql?).and_return(false) # Stubbed for clarity and latitude in implementation; not actually sent by MRI.
+
+    [x].send(@method, [x]).should == [x]
+  end
+end

--- a/core/array/shared/join.rb
+++ b/core/array/shared/join.rb
@@ -113,6 +113,20 @@ describe :array_join_with_default_separator, shared: true do
 
     -> { ary_utf8_bad_binary.send(@method) }.should raise_error(EncodingError)
   end
+
+  ruby_version_is "2.7" do
+    context "when $, is not nil" do
+      before do
+        suppress_warning do
+          $, = '*'
+        end
+      end
+
+      it "warns" do
+        -> { [].join }.should complain(/warning: \$, is set to non-nil value/)
+      end
+    end
+  end
 end
 
 describe :array_join_with_string_separator, shared: true do

--- a/core/complex/comparision_spec.rb
+++ b/core/complex/comparision_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../spec_helper'
 
 describe "Complex#<=>" do
-  ruby_version_is '2.7' do
+  ruby_version_is "2.7" do
     it "returns nil if either self or argument has imaginary part" do
       (Complex(5, 1) <=> Complex(2)).should be_nil
       (Complex(1) <=> Complex(2, 1)).should be_nil

--- a/core/enumerator/lazy/eager_spec.rb
+++ b/core/enumerator/lazy/eager_spec.rb
@@ -1,0 +1,29 @@
+require_relative '../../../spec_helper'
+
+ruby_version_is "2.7" do
+  describe "Enumerator::Lazy#eager" do
+    it "returns a non-lazy Enumerator converted from the lazy enumerator" do
+      enum = [1, 2, 3].lazy
+
+      enum.class.should == Enumerator::Lazy
+      enum.eager.class.should == Enumerator
+    end
+
+    it "does not enumerate an enumerator" do
+      ScratchPad.record []
+
+      sequence = [1, 2, 3]
+      enum_lazy = Enumerator::Lazy.new(sequence) do |yielder, value|
+        yielder << value
+        ScratchPad << value
+      end
+
+      ScratchPad.recorded.should == []
+      enum = enum_lazy.eager
+      ScratchPad.recorded.should == []
+
+      enum.map { |i| i }.should == [1, 2, 3]
+      ScratchPad.recorded.should == [1, 2, 3]
+    end
+  end
+end

--- a/core/enumerator/new_spec.rb
+++ b/core/enumerator/new_spec.rb
@@ -38,4 +38,43 @@ describe "Enumerator.new" do
     end
     enum.to_a.should == [:bar]
   end
+
+  context "when passed a block" do
+    it "defines iteration with block, yielder argument and calling << method" do
+      enum = Enumerator.new do |yielder|
+        a = 1
+
+        loop do
+          yielder << a
+          a = a + 1
+        end
+      end
+
+      enum.take(3).should == [1, 2, 3]
+    end
+
+    it "defines iteration with block, yielder argument and calling yield method" do
+      enum = Enumerator.new do |yielder|
+        a = 1
+
+        loop do
+          yielder.yield(a)
+          a = a + 1
+        end
+      end
+
+      enum.take(3).should == [1, 2, 3]
+    end
+
+    ruby_version_is "2.7" do
+      it "defines iteration with block, yielder argument and treating it as a proc" do
+        enum = Enumerator.new do |yielder|
+          io = StringIO.new("a\nb\nc")
+          io.each_line(&yielder)
+        end
+
+        enum.to_a.should == ["a\n", "b\n", "c"]
+      end
+    end
+  end
 end

--- a/core/enumerator/produce_spec.rb
+++ b/core/enumerator/produce_spec.rb
@@ -1,0 +1,36 @@
+require_relative '../../spec_helper'
+
+ruby_version_is "2.7" do
+  describe "Enumerator.produce" do
+    it "creates an infinite enumerator" do
+      enum = Enumerator.produce(0) { |prev| prev + 1 }
+      enum.take(5).should == [0, 1, 2, 3, 4]
+    end
+
+    it "terminates iteration when block raises StopIteration exception" do
+      enum = Enumerator.produce(0) do | prev|
+        raise StopIteration if prev >= 2
+        prev + 1
+      end
+
+      enum.to_a.should == [0, 1, 2]
+    end
+
+    context "when initial value skipped" do
+      it "uses nil instead" do
+        ScratchPad.record []
+        enum = Enumerator.produce { |prev| ScratchPad << prev; (prev || 0) + 1 }
+
+        enum.take(3).should == [1, 2, 3]
+        ScratchPad.recorded.should == [nil, 1, 2]
+      end
+
+      it "starts enumerable from result of first block call" do
+        io = StringIO.new("a\nb\nc\nd")
+        lines = Enumerator.produce { io.gets }.take_while { |s| s }
+
+        lines.should == ["a\n", "b\n", "c\n", "d"]
+      end
+    end
+  end
+end

--- a/core/enumerator/yielder/to_proc_spec.rb
+++ b/core/enumerator/yielder/to_proc_spec.rb
@@ -1,0 +1,18 @@
+require_relative '../../../spec_helper'
+
+ruby_version_is "2.7" do
+  describe "Enumerator::Yielder#to_proc" do
+    it "returns a Proc object that takes an argument and yields it to the block" do
+      ScratchPad.record []
+      y = Enumerator::Yielder.new { |*args| ScratchPad << args; "foobar" }
+
+      callable = y.to_proc
+      callable.class.should == Proc
+
+      result = callable.call(1, 2)
+      ScratchPad.recorded.should == [[1, 2]]
+
+      result.should == "foobar"
+    end
+  end
+end

--- a/core/string/split_spec.rb
+++ b/core/string/split_spec.rb
@@ -84,6 +84,24 @@ describe "String#split with String" do
         $; = old_fs
       end
     end
+
+    ruby_version_is "2.7" do
+      context "when $; is not nil" do
+        before do
+          suppress_warning do
+            @old_value, $; = $;, 'foobar'
+          end
+        end
+
+        after do
+          $; = @old_value
+        end
+
+        it "warns" do
+          -> { "".split }.should complain(/warning: \$; is set to non-nil value/)
+        end
+      end
+    end
   end
 
   it "ignores leading and continuous whitespace when string is a single space" do

--- a/core/time/inspect_spec.rb
+++ b/core/time/inspect_spec.rb
@@ -3,4 +3,19 @@ require_relative 'shared/inspect'
 
 describe "Time#inspect" do
   it_behaves_like :inspect, :inspect
+
+  ruby_version_is "2.7" do
+    it "preserves milliseconds" do
+      t = Time.utc(2007, 11, 1, 15, 25, 0, 123456)
+      t.inspect.should == "2007-11-01 15:25:00.123456 UTC"
+    end
+
+    it "formats nanoseconds as a Rational" do
+      t = Time.utc(2007, 11, 1, 15, 25, 0, 123456.789)
+      t.nsec.should == 123456789
+      t.strftime("%N").should == "123456789"
+
+      t.inspect.should == "2007-11-01 15:25:00 8483885939586761/68719476736000000 UTC"
+    end
+  end
 end

--- a/language/comment_spec.rb
+++ b/language/comment_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../spec_helper'
+
+describe "The comment" do
+  ruby_version_is "2.7" do
+    it "can be placed between fluent dot now" do
+      code = <<~CODE
+        10
+          # some comment
+          .to_s
+        CODE
+
+      eval(code).should == '10'
+    end
+  end
+end

--- a/language/predefined_spec.rb
+++ b/language/predefined_spec.rb
@@ -633,6 +633,12 @@ describe "Predefined global $," do
   it "raises TypeError if assigned a non-String" do
     -> { $, = Object.new }.should raise_error(TypeError)
   end
+
+  ruby_version_is "2.7" do
+    it "warns if assigned non-nil" do
+      -> { $, = "_" }.should complain(/warning: `\$,' is deprecated/)
+    end
+  end
 end
 
 describe "Predefined global $." do

--- a/language/predefined_spec.rb
+++ b/language/predefined_spec.rb
@@ -662,6 +662,18 @@ describe "Predefined global $." do
   end
 end
 
+describe "Predefined global $;" do
+  after :each do
+    $; = nil
+  end
+
+  ruby_version_is "2.7" do
+    it "warns if assigned non-nil" do
+      -> { $; = "_" }.should complain(/warning: `\$;' is deprecated/)
+    end
+  end
+end
+
 describe "Predefined global $_" do
   it "is set to the last line read by e.g. StringIO#gets" do
     stdin = StringIO.new("foo\nbar\n", "r")

--- a/language/rescue_spec.rb
+++ b/language/rescue_spec.rb
@@ -481,5 +481,15 @@ describe "The rescue keyword" do
         a = raise(Exception) rescue 1
       }.should raise_error(Exception)
     end
+
+    ruby_version_is "2.7" do
+      it "rescues with multiple assignment" do
+
+        a, b = raise rescue [1, 2]
+
+        a.should == 1
+        b.should == 2
+      end
+    end
   end
 end


### PR DESCRIPTION
### Language

- Setting $; to a non-nil value is warned now. [Feature #14240]
- Setting $, to a non-nil value is warned now. [Feature #14240]
- Modifier rescue now operates the same for multiple assignment as single assignment. [Bug #8279]

### Core

- Added Array#intersection. [Feature #16155]
- Added Enumerator.produce to generate an Enumerator from any custom
data transformation. [Feature #14781]
- Added Enumerator::Lazy#eager that generates a non-lazy enumerator
from a lazy enumerator. [Feature #15901]
- Added Enumerator::Yielder#to_proc so that a Yielder object can be directly passed to another method as a block argument. [Feature #15618]
- Integer#[] now supports range operations. Feature #8842
- Time#inspect is separated from Time#to_s and it shows
the time's sub second. Feature #15958