### PR TITLE
Add TravisCI to run specs on Ruby 2.7

### DIFF
--- a/.mspec.constants
+++ b/.mspec.constants
@@ -55,6 +55,7 @@ DefSpecsLambdaVisibility
 DefineMethodByProcClass
 DefineMethodSpecClass
 DefineSingletonMethodSpecClass
+Delegator
 DescArray
 DescObjectTest
 Digest
@@ -161,6 +162,7 @@ SecondClass
 SecureRandom
 Set
 Shellwords
+SimpleDelegator
 SingleForwardable
 Singleton
 Socket
@@ -188,6 +190,7 @@ TimeoutError
 UDPSocket
 UNIXServer
 UNIXSocket
+URI
 UnaryMinusTest
 UnicodeNormalize
 UnloadableDumpableDir

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: ruby
+install:
+  - git clone --depth 1 https://github.com/ruby/mspec.git ../mspec
+script:
+  - CHECK_LEAKS=true ../mspec/bin/mspec
+rvm: 2.7.0
+branches:
+  only:
+    - master
+    - /^try/
+notifications:
+  email:
+    on_success: change
+    on_failure: change


### PR DESCRIPTION
* Until we figure out a way to run Ruby 2.7 in GitHub Actions.

cc @andrykonchin 