### PR TITLE
Add missing require for StringIO

### DIFF
--- a/core/enumerator/new_spec.rb
+++ b/core/enumerator/new_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../spec_helper'
+require 'stringio'
 
 describe "Enumerator.new" do
   it "creates a new custom enumerator with the given object, iterator and arguments" do

--- a/core/enumerator/produce_spec.rb
+++ b/core/enumerator/produce_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../spec_helper'
+require 'stringio'
 
 ruby_version_is "2.7" do
   describe "Enumerator.produce" do


### PR DESCRIPTION
This raised `NameError: uninitialized constant StringIO` in parallel spec runs like here: https://ci.appveyor.com/project/larskanis/rubyinstaller2-hbuor/build/job/igy0qvplokejuy2b