### PR TITLE
Add specs for eval with refinements

### DIFF
--- a/core/kernel/eval_spec.rb
+++ b/core/kernel/eval_spec.rb
@@ -373,4 +373,44 @@ CODE
       EvalSpecs.send :remove_const, :Vπstring_not_frozen
     end
   end
+
+  it "activates refinements from the eval scope" do
+    refinery = Module.new do
+      refine EvalSpecs::A do
+        def foo
+          "bar"
+        end
+      end
+    end
+
+    result = nil
+
+    Module.new do
+      using refinery
+
+      result = eval "EvalSpecs::A.new.foo"
+    end
+
+    result.should == "bar"
+  end
+
+  it "activates refinements from the binding" do
+    refinery = Module.new do
+      refine EvalSpecs::A do
+        def foo
+          "bar"
+        end
+      end
+    end
+
+    b = nil
+    m = Module.new do
+      using refinery
+      b = binding
+    end
+
+    result = eval "EvalSpecs::A.new.foo", b
+
+    result.should == "bar"
+  end
 end

--- a/core/module/shared/class_eval.rb
+++ b/core/module/shared/class_eval.rb
@@ -112,4 +112,48 @@ describe :module_class_eval, shared: true do
     a.attribute.should == "A"
     b.attribute.should == "B"
   end
+
+  it "activates refinements from the eval scope" do
+    refinery = Module.new do
+      refine ModuleSpecs::NamedClass do
+        def foo
+          "bar"
+        end
+      end
+    end
+
+    mid = @method
+    result = nil
+
+    Class.new do
+      using refinery
+
+      result = send(mid, "ModuleSpecs::NamedClass.new.foo")
+    end
+
+    result.should == "bar"
+  end
+
+  it "activates refinements from the eval scope with block" do
+    refinery = Module.new do
+      refine ModuleSpecs::NamedClass do
+        def foo
+          "bar"
+        end
+      end
+    end
+
+    mid = @method
+    result = nil
+
+    Class.new do
+      using refinery
+
+      result = send(mid) do
+        ModuleSpecs::NamedClass.new.foo
+      end
+    end
+
+    result.should == "bar"
+  end
 end


### PR DESCRIPTION
Based on this JRuby ticket: https://github.com/jruby/jruby/issues/6017

Added examples for `Kernel#eval` and `Module#{module_eval,class_eval}`.