### PR TITLE
Add args forwarding specs

### DIFF
--- a/language/delegation_spec.rb
+++ b/language/delegation_spec.rb
@@ -1,0 +1,39 @@
+require_relative '../spec_helper'
+require_relative 'fixtures/delegation'
+
+ruby_version_is "2.7" do
+  describe "delegation with def(...)" do
+    it "delegates rest and kwargs" do
+      a = Class.new(DelegationSpecs::Target)
+      a.class_eval(<<-RUBY)
+        def delegate(...)
+          target(...)
+        end
+      RUBY
+
+      a.new.delegate(1, b: 2).should == [[1], {b: 2}]
+    end
+
+    it "delegates block" do
+      a = Class.new(DelegationSpecs::Target)
+      a.class_eval(<<-RUBY)
+        def delegate_block(...)
+          target_block(...)
+        end
+      RUBY
+
+      a.new.delegate_block(1, b: 2) { |x| x }.should == [{b: 2}, [1]]
+    end
+
+    it "parses as open endless Range when brackets are ommitted" do
+      a = Class.new(DelegationSpecs::Target)
+      a.class_eval(<<-RUBY)
+          def delegate(...)
+            target ...
+          end
+       RUBY
+
+       a.new.delegate(1, b: 2).should == Range.new([[], {}], nil, true)
+    end
+  end
+end

--- a/language/fixtures/delegation.rb
+++ b/language/fixtures/delegation.rb
@@ -1,0 +1,11 @@
+module DelegationSpecs
+  class Target
+    def target(*args, **kwargs)
+      [args, kwargs]
+    end
+
+    def target_block(*args, **kwargs)
+      yield [kwargs, args]
+    end
+  end
+end


### PR DESCRIPTION
Related to #745. 

This is a basic args forwarding spec (extracted from [ruby-next](https://github.com/ruby-next/ruby-next/blob/master/spec/language/args_forward_spec.rb)).

I tried to add a spec for brackets-less case like this:

```ruby
it "treats arguments as Range when brackets are ommitted" do
  a = Class.new(F)
  a.class_eval(<<-RUBY)
      def delegate(...)
        target ...
      end
   RUBY

   # this passes
   a.new.delegate(1, b: 2).should == [[], {}]
end
```

But I'm not sure why the result is empty (testing in 2.7.0)? Shouldn't there be a beginless-endless range?