### PR TITLE
Improve tz related specs for Time#floor/ceil

### DIFF
--- a/core/time/ceil_spec.rb
+++ b/core/time/ceil_spec.rb
@@ -36,10 +36,11 @@ ruby_version_is "2.7" do
     it "copies own timezone to the returning value" do
       @time.zone.should == @time.ceil.zone
 
-      with_timezone "JST-9" do
-        time = Time.at 0, 1
-        time.zone.should == time.ceil.zone
+      time = with_timezone "JST-9" do
+        Time.at 0, 1
       end
+
+      time.zone.should == time.ceil.zone
     end
   end
 end

--- a/core/time/floor_spec.rb
+++ b/core/time/floor_spec.rb
@@ -28,10 +28,11 @@ ruby_version_is "2.7" do
     it "copies own timezone to the returning value" do
       @time.zone.should == @time.floor.zone
 
-      with_timezone "JST-9" do
-        time = Time.at 0, 1
-        time.zone.should == time.floor.zone
+      time = with_timezone "JST-9" do
+        Time.at 0, 1
       end
+
+      time.zone.should == time.floor.zone
     end
   end
 end


### PR DESCRIPTION
Running `#ceil/#floor` within the block would take into account `ENV['TZ']` variable and could produce false positives (e.g., when underlying implementation uses something similar to `Time.new` or `Time.at`).