### PR TITLE
rb_class_inherited_p returns Ruby's true/false/nil

### DIFF
--- a/optional/capi/ext/object_spec.c
+++ b/optional/capi/ext/object_spec.c
@@ -348,9 +348,9 @@ static VALUE object_spec_rb_class_inherited_p(VALUE self, VALUE mod, VALUE arg) 
 static VALUE speced_allocator(VALUE klass) {
   VALUE flags = 0;
   VALUE instance;
-  if (rb_class_inherited_p(klass, rb_cString)) {
+  if (RTEST(rb_class_inherited_p(klass, rb_cString))) {
     flags = T_STRING;
-  } else if (rb_class_inherited_p(klass, rb_cArray)) {
+  } else if (RTEST(rb_class_inherited_p(klass, rb_cArray))) {
     flags = T_ARRAY;
   } else {
     flags = T_OBJECT;


### PR DESCRIPTION
From: https://github.com/ruby/ruby/blob/6b86549df8f6d48eeab3c7b48b3fd9ee02f744ba/object.c#L1828-L1846

> Returns <code>nil</code> if there's no relationship between the two.