### PR TITLE
Use ST2FIX

### DIFF
--- a/optional/capi/ext/string_spec.c
+++ b/optional/capi/ext/string_spec.c
@@ -366,11 +366,7 @@ static VALUE string_spec_SafeStringValue(VALUE self, VALUE str) {
 static VALUE string_spec_rb_str_hash(VALUE self, VALUE str) {
   st_index_t val = rb_str_hash(str);
 
-#if SIZEOF_LONG == SIZEOF_VOIDP || SIZEOF_LONG_LONG == SIZEOF_VOIDP
-  return LONG2FIX((long)val);
-#else
-#error unsupported platform
-#endif
+  return ST2FIX(val);
 }
 
 static VALUE string_spec_rb_str_update(VALUE self, VALUE str, VALUE beg, VALUE end, VALUE replacement) {


### PR DESCRIPTION
Merge from ruby/ruby@9e6e39c3512f "Split ruby.h"

Now `INT2FIX` and `LONG2FIX` have a stricter assertion, that the argument must be `FIXABLE`.