### PR TITLE
Add tests for exotic rescued error capturing

### DIFF
--- a/language/fixtures/rescue.rb
+++ b/language/fixtures/rescue.rb
@@ -1,5 +1,15 @@
 module RescueSpecs
-  class ClassVariableCaptor
+  class Captor
+    attr_accessor :captured_error
+
+    def self.should_capture_exception
+      captor = new
+      captor.capture('some text').should == :caught # Ensure rescue body still runs
+      captor.captured_error.message.should == 'some text'
+    end
+  end
+
+  class ClassVariableCaptor < Captor
     def capture(msg)
       raise msg
     rescue => @@captured_error
@@ -11,7 +21,7 @@ module RescueSpecs
     end
   end
 
-  class ConstantCaptor
+  class ConstantCaptor < Captor
     # Using lambda gets around the dynamic constant assignment warning
     CAPTURE = -> msg {
       begin
@@ -30,7 +40,7 @@ module RescueSpecs
     end
   end
 
-  class GlobalVariableCaptor
+  class GlobalVariableCaptor < Captor
     def capture(msg)
       raise msg
     rescue => $captured_error
@@ -44,9 +54,7 @@ module RescueSpecs
     end
   end
 
-  class InstanceVariableCaptor
-    attr_reader :captured_error
-
+  class InstanceVariableCaptor < Captor
     def capture(msg)
       raise msg
     rescue => @captured_error
@@ -54,9 +62,7 @@ module RescueSpecs
     end
   end
 
-  class LocalVariableCaptor
-    attr_reader :captured_error
-
+  class LocalVariableCaptor < Captor
     def capture(msg)
       raise msg
     rescue => captured_error
@@ -65,9 +71,7 @@ module RescueSpecs
     end
   end
 
-  class SafeNavigationSetterCaptor
-    attr_accessor :captured_error
-
+  class SafeNavigationSetterCaptor < Captor
     def capture(msg)
       raise msg
     rescue => self&.captured_error
@@ -75,9 +79,7 @@ module RescueSpecs
     end
   end
 
-  class SetterCaptor
-    attr_accessor :captured_error
-
+  class SetterCaptor < Captor
     def capture(msg)
       raise msg
     rescue => self.captured_error
@@ -85,7 +87,7 @@ module RescueSpecs
     end
   end
 
-  class SquareBracketsCaptor
+  class SquareBracketsCaptor < Captor
     def capture(msg)
       @hash = {}
 

--- a/language/rescue_spec.rb
+++ b/language/rescue_spec.rb
@@ -23,11 +23,22 @@ describe "The rescue keyword" do
     end.should == :caught
   end
 
-  it "can capture the raised exception in a local variable" do
-    begin
-      raise SpecificExampleException, "some text"
-    rescue SpecificExampleException => e
-      e.message.should == "some text"
+  {
+    # Standard use case
+    'can capture the raised exception in a local variable'                    => RescueSpecs::LocalVariableCaptor,
+    # Exotic use cases
+    'can capture the raised exception in a class variable'                    => RescueSpecs::ClassVariableCaptor,
+    'can capture the raised exception in a constant'                          => RescueSpecs::ConstantCaptor,
+    'can capture the raised exception in a global variable'                   => RescueSpecs::GlobalVariableCaptor,
+    'can capture the raised exception in an instance variable'                => RescueSpecs::InstanceVariableCaptor,
+    'can capture the raised exception using a safely navigated setter method' => RescueSpecs::SafeNavigationSetterCaptor,
+    'can capture the raised exception using a setter method'                  => RescueSpecs::SetterCaptor,
+    'can capture the raised exception using a square brackets setter'         => RescueSpecs::SquareBracketsCaptor,
+  }.each do |description, klass|
+    it description do
+      captor = klass.new
+      captor.capture('some text').should == :caught # Ensure rescue body still runs
+      captor.captured_error.message.should == 'some text'
     end
   end
 

--- a/language/rescue_spec.rb
+++ b/language/rescue_spec.rb
@@ -23,22 +23,37 @@ describe "The rescue keyword" do
     end.should == :caught
   end
 
-  {
-    # Standard use case
-    'can capture the raised exception in a local variable'                    => RescueSpecs::LocalVariableCaptor,
-    # Exotic use cases
-    'can capture the raised exception in a class variable'                    => RescueSpecs::ClassVariableCaptor,
-    'can capture the raised exception in a constant'                          => RescueSpecs::ConstantCaptor,
-    'can capture the raised exception in a global variable'                   => RescueSpecs::GlobalVariableCaptor,
-    'can capture the raised exception in an instance variable'                => RescueSpecs::InstanceVariableCaptor,
-    'can capture the raised exception using a safely navigated setter method' => RescueSpecs::SafeNavigationSetterCaptor,
-    'can capture the raised exception using a setter method'                  => RescueSpecs::SetterCaptor,
-    'can capture the raised exception using a square brackets setter'         => RescueSpecs::SquareBracketsCaptor,
-  }.each do |description, klass|
-    it description do
-      captor = klass.new
-      captor.capture('some text').should == :caught # Ensure rescue body still runs
-      captor.captured_error.message.should == 'some text'
+  describe 'can capture the raised exception' do
+    it 'in a local variable' do
+      RescueSpecs::LocalVariableCaptor.should_capture_exception
+    end
+
+    it 'in a class variable' do
+      RescueSpecs::ClassVariableCaptor.should_capture_exception
+    end
+
+    it 'in a constant' do
+      RescueSpecs::ConstantCaptor.should_capture_exception
+    end
+
+    it 'in a global variable' do
+      RescueSpecs::GlobalVariableCaptor.should_capture_exception
+    end
+
+    it 'in an instance variable' do
+      RescueSpecs::InstanceVariableCaptor.should_capture_exception
+    end
+
+    it 'using a safely navigated setter method' do
+      RescueSpecs::SafeNavigationSetterCaptor.should_capture_exception
+    end
+
+    it 'using a setter method' do
+      RescueSpecs::SetterCaptor.should_capture_exception
+    end
+
+    it 'using a square brackets setter' do
+      RescueSpecs::SquareBracketsCaptor.should_capture_exception
     end
   end
 


### PR DESCRIPTION
The idiomatic way to capture exceptions is to assign to a local variable

```ruby
rescue => local_variable
```

However, other kinds of LVALUEs also work

```ruby
rescue => $global_variable
rescue => @@class_variable
rescue => @instance_variable
rescue => Constant
rescue => receiver&.setter_method
rescue => receiver.setter_method
rescue => receiver[:key]
```

This adds specs documenting their usage.

----
Closes #773 
cc. @chrisseaton 