### PR TITLE
Fix unclosed string literals in ruby_version_is docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,11 +136,11 @@ Here is a list of the most commonly-used guards:
 #### Version guards
 
 ```ruby
-ruby_version_is ""..."2.6 do
+ruby_version_is ""..."2.6" do
   # Specs for RUBY_VERSION < 2.6
 end
 
-ruby_version_is "2.6 do
+ruby_version_is "2.6" do
   # Specs for RUBY_VERSION >= 2.6
 end
 ```


### PR DESCRIPTION
This adds the missing `"` to close the string literals in the examples for the `ruby_version_is` guard.