### PR TITLE
[BigDecimal] to_s should be encoded as US-ASCII

### DIFF
--- a/library/bigdecimal/to_s_spec.rb
+++ b/library/bigdecimal/to_s_spec.rb
@@ -8,6 +8,11 @@ describe "BigDecimal#to_s" do
     @bigneg_str = "-3.1415926535897932384626433832795028841971693993"
     @bigdec = BigDecimal(@bigdec_str)
     @bigneg = BigDecimal(@bigneg_str)
+    @internal = Encoding.default_internal
+  end
+
+  after :each do
+    Encoding.default_internal = @internal
   end
 
   it "return type is of class String" do
@@ -78,4 +83,15 @@ describe "BigDecimal#to_s" do
     end
   end
 
+  ruby_version_is "2.8" do
+    it "returns a String in US-ASCII encoding when Encoding.default_internal is nil" do
+      Encoding.default_internal = nil
+      BigDecimal('1.23').to_s.encoding.should equal(Encoding::US_ASCII)
+    end
+
+    it "returns a String in US-ASCII encoding when Encoding.default_internal is not nil" do
+      Encoding.default_internal = Encoding::IBM437
+      BigDecimal('1.23').to_s.encoding.should equal(Encoding::US_ASCII)
+    end
+  end
 end


### PR DESCRIPTION
Ruby ticket: https://bugs.ruby-lang.org/issues/17011
BigDecimal change: https://github.com/ruby/bigdecimal/pull/160

The spec is mostly taken from `Integer` and `Float` specs.

That BigDecimal wasn't pulled in ruby/ruby yet, so I'm unsure what the process should be.