### PR TITLE
Use the same stdout object reference as used in the test block

### DIFF
--- a/core/io/puts_spec.rb
+++ b/core/io/puts_spec.rb
@@ -25,7 +25,7 @@ describe "IO#puts" do
   end
 
   it "writes just a newline when given just a newline" do
-    -> { $stdout.puts "\n" }.should output_to_fd("\n", STDOUT)
+    -> { $stdout.puts "\n" }.should output_to_fd("\n", $stdout)
   end
 
   it "writes empty string with a newline when given nil as an arg" do


### PR DESCRIPTION
This allows for the object referred to by $stdout to be replaced without breaking the test