### PR TITLE
Add a spec for String#-@ re-use when called on an already frozen string

### DIFF
--- a/core/string/uminus_spec.rb
+++ b/core/string/uminus_spec.rb
@@ -69,4 +69,11 @@ describe 'String#-@' do
       (-dynamic).should equal(-"this string is frozen".freeze)
     end
   end
+
+  ruby_version_is "3.0" do
+    it "interns the provided string if it is frozen" do
+      dynamic = %w(this string is unique and frozen).join(' ').freeze
+      (-dynamic).should equal(dynamic)
+    end
+  end
 end


### PR DESCRIPTION
Since ~~2.6~~ 2.8, if you try to dedup a frozen string, and that string no yet exist in the fstring table, MRI will directly intern that object and return `self`. 

Very often when you are deduplicating strings, you are trying to be efficient in both memory retention and memory allocation.
So I frequently rely on this behavior. 

While implementing a jruby extension (in msgpack-ruby and json) I noticed it would always duplicate the provided string, even when it was eligible for interning.

cc @eregon maybe I can pick your interest on this?