### PR TITLE
partially backported from ruby core

### DIFF
--- a/core/data/constants_spec.rb
+++ b/core/data/constants_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
 
-ruby_version_is ""..."3.0" do
+ruby_version_is ""..."2.7" do
   describe "Data" do
     it "is a subclass of Object" do
       suppress_warning do

--- a/core/env/index_spec.rb
+++ b/core/env/index_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../spec_helper'
 require_relative 'shared/key'
 
-ruby_version_is ""..."3.0" do
+ruby_version_is ""..."2.7" do
   describe "ENV.index" do
     it_behaves_like :env_key, :index
 

--- a/core/integer/constants_spec.rb
+++ b/core/integer/constants_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
 
-ruby_version_is ""..."3.0" do
+ruby_version_is ""..."2.7" do
   describe "Fixnum" do
     it "is unified into Integer" do
       suppress_warning do

--- a/core/kernel/match_spec.rb
+++ b/core/kernel/match_spec.rb
@@ -14,7 +14,7 @@ describe "Kernel#=~" do
     end
   end
 
-  ruby_version_is "2.6"..."3.0" do
+  ruby_version_is "2.6"..."2.7" do
     it "is deprecated" do
       -> do
         Object.new =~ /regexp/

--- a/core/kernel/proc_spec.rb
+++ b/core/kernel/proc_spec.rb
@@ -40,19 +40,11 @@ describe "Kernel#proc" do
     proc
   end
 
-  ruby_version_is ""..."2.7" do
+  ruby_version_is ""..."3.0" do
     it "uses the implicit block from an enclosing method" do
       prc = some_method { "hello" }
 
       prc.call.should == "hello"
-    end
-  end
-
-  ruby_version_is "2.7"..."3.0" do
-    it "can be created when called with no block" do
-      -> {
-        some_method { "hello" }
-      }.should complain(/Capturing the given block using Kernel#proc is deprecated/)
     end
   end
 

--- a/core/proc/new_spec.rb
+++ b/core/proc/new_spec.rb
@@ -180,7 +180,7 @@ describe "Proc.new without a block" do
     -> { ProcSpecs.new_proc_subclass_in_method }.should raise_error(ArgumentError)
   end
 
-  ruby_version_is ""..."2.7" do
+  ruby_version_is ""..."3.0" do
     it "uses the implicit block from an enclosing method" do
       def some_method
         Proc.new
@@ -200,27 +200,6 @@ describe "Proc.new without a block" do
       prc = some_method { "hello" }
 
       prc.call.should == "hello"
-    end
-  end
-
-  ruby_version_is "2.7"..."3.0" do
-    it "can be created if invoked from within a method with a block" do
-      -> { ProcSpecs.new_proc_in_method { "hello" } }.should complain(/Capturing the given block using Proc.new is deprecated/)
-    end
-
-    it "can be created if invoked on a subclass from within a method with a block" do
-      -> { ProcSpecs.new_proc_subclass_in_method { "hello" } }.should complain(/Capturing the given block using Proc.new is deprecated/)
-    end
-
-
-    it "can be create when called with no block" do
-      def some_method
-        Proc.new
-      end
-
-      -> {
-        some_method { "hello" }
-      }.should complain(/Capturing the given block using Proc.new is deprecated/)
     end
   end
 

--- a/language/predefined_spec.rb
+++ b/language/predefined_spec.rb
@@ -653,12 +653,6 @@ describe "Predefined global $," do
   it "raises TypeError if assigned a non-String" do
     -> { $, = Object.new }.should raise_error(TypeError)
   end
-
-  ruby_version_is "2.7"..."3.0" do
-    it "warns if assigned non-nil" do
-      -> { $, = "_" }.should complain(/warning: `\$,' is deprecated/)
-    end
-  end
 end
 
 describe "Predefined global $." do
@@ -685,18 +679,6 @@ describe "Predefined global $." do
     obj.should_receive(:to_int).and_return('abc')
 
     -> { $. = obj }.should raise_error(TypeError)
-  end
-end
-
-describe "Predefined global $;" do
-  after :each do
-    $; = nil
-  end
-
-  ruby_version_is "2.7"..."3.0" do
-    it "warns if assigned non-nil" do
-      -> { $; = "_" }.should complain(/warning: `\$;' is deprecated/)
-    end
   end
 end
 


### PR DESCRIPTION
Partially backported the changesets below from ruby core to suppress error in RubyCI.org.

https://github.com/ruby/ruby/commit/996af2ce086249e904b2ce95ab2fcd1de7d757be
https://github.com/ruby/ruby/commit/df3f52a6331f1a47af9933b77311a8650727d8d1

ruby 2.7 now doesn't show deprecated warnings by default.
(cf. https://bugs.ruby-lang.org/issues/16345 and https://bugs.ruby-lang.org/issues/17000)