### PR TITLE
Test `class Class < superclass` syntax aswell

### DIFF
--- a/core/class/new_spec.rb
+++ b/core/class/new_spec.rb
@@ -96,11 +96,12 @@ describe "Class.new" do
 
   it "raises a TypeError when given a non-Class" do
     error_msg = /superclass must be a Class/
-    -> { Class.new("")         }.should raise_error(TypeError, error_msg)
-    -> { Class.new(1)          }.should raise_error(TypeError, error_msg)
-    -> { Class.new(:symbol)    }.should raise_error(TypeError, error_msg)
-    -> { Class.new(mock('o'))  }.should raise_error(TypeError, error_msg)
-    -> { Class.new(Module.new) }.should raise_error(TypeError, error_msg)
+    -> { Class.new("")              }.should raise_error(TypeError, error_msg)
+    -> { Class.new(1)               }.should raise_error(TypeError, error_msg)
+    -> { Class.new(:symbol)         }.should raise_error(TypeError, error_msg)
+    -> { Class.new(mock('o'))       }.should raise_error(TypeError, error_msg)
+    -> { Class.new(Module.new)      }.should raise_error(TypeError, error_msg)
+    -> { Class.new(BasicObject.new) }.should raise_error(TypeError, error_msg)
   end
 end
 

--- a/language/class_spec.rb
+++ b/language/class_spec.rb
@@ -285,6 +285,16 @@ describe "A class definition extending an object (sclass)" do
     }.should raise_error(TypeError)
   end
 
+  it "raises a TypeError when trying to extend non-Class" do
+    error_msg = /superclass must be a Class/
+    -> { class TestClass < "";              end }.should raise_error(TypeError, error_msg)
+    -> { class TestClass < 1;               end }.should raise_error(TypeError, error_msg)
+    -> { class TestClass < :symbol;         end }.should raise_error(TypeError, error_msg)
+    -> { class TestClass < mock('o');       end }.should raise_error(TypeError, error_msg)
+    -> { class TestClass < Module.new;      end }.should raise_error(TypeError, error_msg)
+    -> { class TestClass < BasicObject.new; end }.should raise_error(TypeError, error_msg)
+  end
+
   ruby_version_is ""..."3.0" do
     it "allows accessing the block of the original scope" do
       suppress_warning do


### PR DESCRIPTION
I found this bug that in Opal
```ruby
class TestClass < BasicObject.new
end
```

Doesn't raise error but fails internally with `can't convert undefined to object`
While this works correctly and raises expected error (so these tests were passing)
```ruby
Class.new(BasicObject.new)
```

This means we need to test both syntaxes even if they should be same thing, in Opal they both have completely separate code-paths.
