### PR TITLE
adds SyntaxError and warning spec for not same line heredoc

### DIFF
--- a/language/heredoc_spec.rb
+++ b/language/heredoc_spec.rb
@@ -62,7 +62,7 @@ HERE
   ruby_version_is "2.7" do
     it 'raises SyntaxError if quoted HEREDOC identifier is ending not on same line' do
       -> {
-        eval %{<<"HERE\n"raises syntax error\nHERE}
+        eval %{<<"HERE\n"\nraises syntax error\nHERE}
       }.should raise_error(SyntaxError)
     end
   end
@@ -70,7 +70,7 @@ HERE
   ruby_version_is ""..."2.7" do
     it 'prints a warning if quoted HEREDOC identifier is ending not on same line' do
       -> {
-        eval %{<<"HERE\n"it warns\nHERE}
+        eval %{<<"HERE\n"\nit warns\nHERE}
       }.should complain(/here document identifier ends with a newline/)
     end
   end

--- a/language/heredoc_spec.rb
+++ b/language/heredoc_spec.rb
@@ -59,6 +59,22 @@ HERE
     s.encoding.should == Encoding::US_ASCII
   end
 
+  ruby_version_is "2.7" do
+    it 'raises SyntaxError if identifier is ending not on same line' do
+      -> {
+        eval %{<<"HERE\n"\nHERE}
+      }.should raise_error(SyntaxError)
+    end
+  end
+
+  ruby_version_is ""..."2.7" do
+    it 'prints a warning if identifier is ending not on same line' do
+      -> {
+        eval %{<<"HERE\n"\nHERE}
+      }.should complain(/here document identifier ends with a newline/)
+    end
+  end
+
   it "allows HEREDOC with <<~'identifier', allowing to indent identifier and content" do
     require_relative 'fixtures/squiggly_heredoc'
     SquigglyHeredocSpecs.message.should == "character density, n.:\n  The number of very weird people in the office.\n"

--- a/language/heredoc_spec.rb
+++ b/language/heredoc_spec.rb
@@ -60,17 +60,17 @@ HERE
   end
 
   ruby_version_is "2.7" do
-    it 'raises SyntaxError if identifier is ending not on same line' do
+    it 'raises SyntaxError if quoted HEREDOC identifier is ending not on same line' do
       -> {
-        eval %{<<"HERE\n"\nHERE}
+        eval %{<<"HERE\n"raises syntax error\nHERE}
       }.should raise_error(SyntaxError)
     end
   end
 
   ruby_version_is ""..."2.7" do
-    it 'prints a warning if identifier is ending not on same line' do
+    it 'prints a warning if quoted HEREDOC identifier is ending not on same line' do
       -> {
-        eval %{<<"HERE\n"\nHERE}
+        eval %{<<"HERE\n"it warns\nHERE}
       }.should complain(/here document identifier ends with a newline/)
     end
   end


### PR DESCRIPTION
Sub task https://github.com/ruby/spec/issues/745

Quoted here-document identifiers must end within the same line

```ruby
<<"EOS
" # This had been warned since 2.4; Now it raises a SyntaxError
EOS
```