### PR TITLE
add spec for Array#minmax

### DIFF
--- a/core/array/minmax_spec.rb
+++ b/core/array/minmax_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../../spec_helper'
+require_relative '../../shared/enumerable/minmax'
+
+describe "Array#minmax" do
+  before :each do
+    @enum = [6, 4, 5, 10, 8]
+    @empty_enum = []
+    @incomparable_enum = [BasicObject.new, BasicObject.new]
+    @incompatible_enum = [11, "22"]
+    @strs = ["333", "2", "60", "55555", "1010", "111"]
+  end
+
+  it_behaves_like :enumerable_minmax, :minmax
+end

--- a/core/enumerable/minmax_spec.rb
+++ b/core/enumerable/minmax_spec.rb
@@ -1,41 +1,17 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative '../../shared/enumerable/minmax'
 
 describe "Enumerable#minmax" do
   before :each do
     @enum = EnumerableSpecs::Numerous.new(6, 4, 5, 10, 8)
-
+    @empty_enum = EnumerableSpecs::Empty.new
+    @incomparable_enum = EnumerableSpecs::Numerous.new(BasicObject.new, BasicObject.new)
+    @incompatible_enum = EnumerableSpecs::Numerous.new(11,"22")
     @strs = EnumerableSpecs::Numerous.new("333", "2", "60", "55555", "1010", "111")
   end
 
-  it "min should return the minimum element" do
-    @enum.minmax.should == [4, 10]
-    @strs.minmax.should == ["1010", "60" ]
-  end
-
-  it "returns [nil, nil] for an empty Enumerable" do
-    EnumerableSpecs::Empty.new.minmax.should == [nil, nil]
-  end
-
-  it "raises an ArgumentError when elements are incomparable" do
-    -> do
-      EnumerableSpecs::Numerous.new(11,"22").minmax
-    end.should raise_error(ArgumentError)
-    -> do
-      EnumerableSpecs::Numerous.new(11,12,22,33).minmax{|a, b| nil}
-    end.should raise_error(ArgumentError)
-  end
-
-  it "raises a NoMethodError for elements without #<=>" do
-    -> do
-      EnumerableSpecs::Numerous.new(BasicObject.new, BasicObject.new).minmax
-    end.should raise_error(NoMethodError)
-  end
-
-  it "returns the minimum when using a block rule" do
-    @enum.minmax {|a,b| b <=> a }.should == [10, 4]
-    @strs.minmax {|a,b| a.length <=> b.length }.should == ["2", "55555"]
-  end
+  it_behaves_like :enumerable_minmax, :minmax
 
   it "gathers whole arrays as elements when each yields multiple" do
     multi = EnumerableSpecs::YieldsMulti.new

--- a/shared/enumerable/minmax.rb
+++ b/shared/enumerable/minmax.rb
@@ -1,0 +1,24 @@
+describe :enumerable_minmax, shared: true do
+  it "min should return the minimum element" do
+    @enum.minmax.should == [4, 10]
+    @strs.minmax.should == ["1010", "60"]
+  end
+
+  it "returns the minimum when using a block rule" do
+    @enum.minmax {|a,b| b <=> a }.should == [10, 4]
+    @strs.minmax {|a,b| a.length <=> b.length }.should == ["2", "55555"]
+  end
+
+  it "returns [nil, nil] for an empty Enumerable" do
+    @empty_enum.minmax.should == [nil, nil]
+  end
+
+  it "raises a NoMethodError for elements without #<=>" do
+    -> { @incomparable_enum.minmax }.should raise_error(NoMethodError)
+  end
+
+  it "raises an ArgumentError when elements are incompatible" do
+    -> { @incompatible_enum.minmax }.should raise_error(ArgumentError)
+    -> { @enum.minmax{ |a, b| nil } }.should raise_error(ArgumentError)
+  end
+end


### PR DESCRIPTION
Hello 👋

Here's a PR for `Array#minmax`:

> * [ ] Added Array#minmax, with a faster implementation than Enumerable#minmax. Bug #15929

After quick [pre-discussion](https://github.com/ruby/spec/issues/745#issuecomment-705658217) I thought to try a different approach.

Instead of copying the file `core/enumerable/minmax_spec.rb` for Arrays, I moved the existing specs to `shared/enumerable/minmax.rb` and use `it_behaves_like` in `Enumerable` and `Array`, but with different instance variables.

I am unsure if this is a good/proper solution, what do you think?