### PR TITLE
add spec for Range#=== to behave like Range#cover? in Ruby 2.7

### DIFF
--- a/core/range/case_compare_spec.rb
+++ b/core/range/case_compare_spec.rb
@@ -25,4 +25,9 @@ describe "Range#===" do
       (range === RangeSpecs::WithoutSucc.new(2)).should == true
     end
   end
+
+  ruby_version_is "2.7" do
+    it_behaves_like :range_cover_and_include, :===
+    it_behaves_like :range_cover, :===
+  end
 end

--- a/core/range/cover_spec.rb
+++ b/core/range/cover_spec.rb
@@ -6,4 +6,5 @@ require_relative 'shared/cover'
 describe "Range#cover?" do
   it_behaves_like :range_cover_and_include, :cover?
   it_behaves_like :range_cover, :cover?
+  it_behaves_like :range_cover_subrange, :cover?
 end

--- a/core/range/shared/cover.rb
+++ b/core/range/shared/cover.rb
@@ -90,7 +90,9 @@ describe :range_cover, shared: true do
       end
     end
   end
+end
 
+describe :range_cover_subrange, shared: true do
   ruby_version_is "2.6" do
     context "range argument" do
       it "accepts range argument" do


### PR DESCRIPTION
Hello again 👋

From https://github.com/ruby/spec/issues/745 :

> * [ ] Range#=== now uses Range#cover? for String arguments, too (in Ruby 2.6, it was
changed from Range#include? for all types except strings). Bug #15449

To _cover_ that (pun intended), I basically just added this to `Range#===` specs

```ruby
it_behaves_like :range_cover_and_include, :cover?
it_behaves_like :range_cover, :cover?
```

Do you think this is sufficient? 🙈 