### PR TITLE
adds spec for non-symbol keyword argument

### DIFF
--- a/language/method_spec.rb
+++ b/language/method_spec.rb
@@ -600,6 +600,15 @@ describe "A method" do
       -> { m(2) }.should raise_error(ArgumentError)
     end
 
+    ruby_version_is "2.7" do
+      evaluate <<-ruby do
+        def m(**k); k end;
+        ruby
+
+        m("a" => 1).should == { "a" => 1 }
+      end
+    end
+
     evaluate <<-ruby do
         def m(&b) b end
       ruby


### PR DESCRIPTION
Solving #745

> Non-symbols are allowed as keyword argument keys if the method accepts
arbitrary keywords. Feature #14183

> Non-Symbol keys in a keyword arguments hash were prohibited in 2.6.0,
but are now allowed again. Bug #15658
