### PR TITLE
adds spec for an empty keyword splat to a method that does not accept…

### DIFF
--- a/language/method_spec.rb
+++ b/language/method_spec.rb
@@ -1688,6 +1688,22 @@ describe "A method" do
     end
   end
 
+  ruby_version_is '2.7'...'3.0' do
+    context 'when passing an empty keyword splat to a method that does not accept keywords' do
+      evaluate <<-ruby do
+          def m(a); a; end
+        ruby
+        h = {}
+
+        -> do
+          suppress_warning do
+            m(**h).should == {}
+          end
+        end.should_not raise_error
+      end
+    end
+  end
+
   ruby_version_is ''...'3.0' do
     context "assigns keyword arguments from a passed Hash without modifying it" do
       evaluate <<-ruby do
@@ -1706,6 +1722,18 @@ describe "A method" do
   end
 
   ruby_version_is '3.0' do
+    context 'when passing an empty keyword splat to a method that does not accept keywords' do
+      evaluate <<-ruby do
+          def m(a); a; end
+        ruby
+        h = {}
+
+        -> do
+          m(**h).should == {}
+        end.should raise_error(ArgumentError)
+      end
+    end
+
     context "raises ArgumentError if passing hash as keyword arguments" do
       evaluate <<-ruby do
           def m(a: nil); a; end

--- a/language/method_spec.rb
+++ b/language/method_spec.rb
@@ -1688,6 +1688,18 @@ describe "A method" do
     end
   end
 
+  ruby_version_is '2.7' do
+    context 'when passing an empty keyword splat to a method that does not accept keywords' do
+      evaluate <<-ruby do
+          def m(*a); a; end
+        ruby
+
+        h = {}
+        m(**h).should == []
+      end
+    end
+  end
+
   ruby_version_is '2.7'...'3.0' do
     context 'when passing an empty keyword splat to a method that does not accept keywords' do
       evaluate <<-ruby do
@@ -1696,10 +1708,8 @@ describe "A method" do
         h = {}
 
         -> do
-          suppress_warning do
-            m(**h).should == {}
-          end
-        end.should_not raise_error
+          m(**h).should == {}
+        end.should complain(/warning: Passing the keyword argument as the last hash parameter is deprecated/)
       end
     end
   end


### PR DESCRIPTION
… keywords

Closing #745 

>    Passing an empty keyword splat to a method that does not accept keywords
    no longer passes an empty hash, unless the empty hash is necessary for
    a required parameter, in which case a warning will be emitted. Remove
    the double splat to continue passing a positional hash. Feature #14183

```ruby
h = {}; def foo(*a) a end; foo(**h) # []
h = {}; def foo(a) a end; foo(**h)  # {} and warning
h = {}; def foo(*a) a end; foo(h)   # [{}]
h = {}; def foo(a) a end; foo(h)    # {}
```