### PR TITLE
add warning test when access or set $SAFE

### DIFF
--- a/language/safe_spec.rb
+++ b/language/safe_spec.rb
@@ -135,4 +135,18 @@ describe "The $SAFE variable" do
       }.call
     end
   end
+
+  ruby_version_is "2.7" do
+    it "warn when access" do
+      -> {
+        $SAFE
+      }.should complain(/\$SAFE will become a normal global variable in Ruby 3.0/)
+    end
+
+    it "warn when set" do
+      -> {
+        $SAFE = 1
+      }.should complain(/\$SAFE will become a normal global variable in Ruby 3.0/)
+    end
+  end
 end

--- a/language/safe_spec.rb
+++ b/language/safe_spec.rb
@@ -136,7 +136,7 @@ describe "The $SAFE variable" do
     end
   end
 
-  ruby_version_is "2.7" do
+  ruby_version_is "2.7"..."3.0" do
     it "warn when access" do
       -> {
         $SAFE


### PR DESCRIPTION
Hi, here is a PR for solving #745, add spec of warning when access or set $SAFE.

> * [ ]  Access and setting of `$SAFE` is now always warned. `$SAFE`
>   will become a normal global variable in Ruby 3.0. [Feature #16131](https://bugs.ruby-lang.org/issues/16131)