### PR TITLE
adds spec for yield in singleton class

### DIFF
--- a/language/singleton_class_spec.rb
+++ b/language/singleton_class_spec.rb
@@ -157,6 +157,23 @@ describe "A constant on a singleton class" do
   end
 end
 
+describe "Defining yield in singleton class" do
+  ruby_version_is "2.7"..."3.0" do
+    it 'emits a deprecation warning' do
+      code = <<~RUBY
+          def m
+            class << Object.new
+              yield
+            end
+          end
+          m { :ok }
+        RUBY
+
+      ruby_exe(code, args: "2>&1").should =~ /warning: `yield' in class syntax will not be supported from Ruby 3.0/
+    end
+  end
+end
+
 describe "Defining instance methods on a singleton class" do
   before :each do
     @k = ClassSpecs::K.new

--- a/language/singleton_class_spec.rb
+++ b/language/singleton_class_spec.rb
@@ -169,7 +169,7 @@ describe "Defining yield in singleton class" do
           m { :ok }
         RUBY
 
-      ruby_exe(code, args: "2>&1").should =~ /warning: `yield' in class syntax will not be supported from Ruby 3.0/
+      -> { eval(code) }.should complain(/warning: `yield' in class syntax will not be supported from Ruby 3.0/)
     end
   end
 end


### PR DESCRIPTION
Solving #745 

> yield in singleton class syntax is warned and will be deprecated later. Feature #15575.

```ruby
def foo
  class << Object.new
    yield #=> warning: `yield' in class syntax will not be supported from Ruby 3.0. [Feature #15575](https://bugs.ruby-lang.org/issues/15575)
  end
end
foo { p :ok }
```

I was trying different approaches to catch the warning. `evaluates` block does not fit there because warning emits on parsing stage. 
Maybe it will be better to using `eval` here?