### PR TITLE
add ruby 2.7...3.0 specs for Object#{taint,untaint,trust,untrust}

### DIFF
--- a/core/kernel/taint_spec.rb
+++ b/core/kernel/taint_spec.rb
@@ -44,4 +44,20 @@ describe "Kernel#taint" do
       end
     end
   end
+
+  ruby_version_is "2.7"..."3.0" do
+    it "is a no-op" do
+      o = Object.new
+      o.taint
+      o.should_not.tainted?
+    end
+
+    it "warns in verbose mode" do
+      -> {
+        $VERBOSE = true
+        obj = mock("tainted")
+        obj.taint
+      }.should complain(/Object#taint is deprecated and will be removed in Ruby 3.2/)
+    end
+  end
 end

--- a/core/kernel/taint_spec.rb
+++ b/core/kernel/taint_spec.rb
@@ -54,10 +54,9 @@ describe "Kernel#taint" do
 
     it "warns in verbose mode" do
       -> {
-        $VERBOSE = true
         obj = mock("tainted")
         obj.taint
-      }.should complain(/Object#taint is deprecated and will be removed in Ruby 3.2/)
+      }.should complain(/Object#taint is deprecated and will be removed in Ruby 3.2/, verbose: true)
     end
   end
 end

--- a/core/kernel/tainted_spec.rb
+++ b/core/kernel/tainted_spec.rb
@@ -23,10 +23,9 @@ describe "Kernel#tainted?" do
 
     it "warns in verbose mode" do
       -> {
-        $VERBOSE = true
         o = mock('o')
         o.tainted?
-      }.should complain(/Object#tainted\? is deprecated and will be removed in Ruby 3.2/)
+      }.should complain(/Object#tainted\? is deprecated and will be removed in Ruby 3.2/, verbose: true)
     end
   end
 end

--- a/core/kernel/tainted_spec.rb
+++ b/core/kernel/tainted_spec.rb
@@ -11,4 +11,22 @@ describe "Kernel#tainted?" do
       p.should.tainted?
     end
   end
+
+  ruby_version_is "2.7"..."3.0" do
+    it "is a no-op" do
+      o = mock('o')
+      p = mock('p')
+      p.taint
+      o.should_not.tainted?
+      p.should_not.tainted?
+    end
+
+    it "warns in verbose mode" do
+      -> {
+        $VERBOSE = true
+        o = mock('o')
+        o.tainted?
+      }.should complain(/Object#tainted\? is deprecated and will be removed in Ruby 3.2/)
+    end
+  end
 end

--- a/core/kernel/trust_spec.rb
+++ b/core/kernel/trust_spec.rb
@@ -28,16 +28,16 @@ describe "Kernel#trust" do
   ruby_version_is "2.7"..."3.0" do
     it "is a no-op" do
       o = Object.new.untrust
+      o.should_not.untrusted?
       o.trust
       o.should_not.untrusted?
     end
 
     it "warns in verbose mode" do
       -> {
-        $VERBOSE = true
         o = Object.new.untrust
         o.trust
-      }.should complain(/Object#trust is deprecated and will be removed in Ruby 3.2/)
+      }.should complain(/Object#trust is deprecated and will be removed in Ruby 3.2/, verbose: true)
     end
   end
 end

--- a/core/kernel/trust_spec.rb
+++ b/core/kernel/trust_spec.rb
@@ -24,4 +24,20 @@ describe "Kernel#trust" do
       o.trust.should equal(o)
     end
   end
+
+  ruby_version_is "2.7"..."3.0" do
+    it "is a no-op" do
+      o = Object.new.untrust
+      o.trust
+      o.should_not.untrusted?
+    end
+
+    it "warns in verbose mode" do
+      -> {
+        $VERBOSE = true
+        o = Object.new.untrust
+        o.trust
+      }.should complain(/Object#trust is deprecated and will be removed in Ruby 3.2/)
+    end
+  end
 end

--- a/core/kernel/untaint_spec.rb
+++ b/core/kernel/untaint_spec.rb
@@ -24,4 +24,20 @@ describe "Kernel#untaint" do
       o.untaint.should equal(o)
     end
   end
+
+  ruby_version_is "2.7"..."3.0" do
+    it "is a no-op" do
+      o = Object.new.taint
+      o.untaint
+      o.should_not.tainted?
+    end
+
+    it "warns in verbose mode" do
+      -> {
+        $VERBOSE = true
+        o = Object.new.taint
+        o.untaint
+      }.should complain(/Object#untaint is deprecated and will be removed in Ruby 3.2/)
+    end
+  end
 end

--- a/core/kernel/untaint_spec.rb
+++ b/core/kernel/untaint_spec.rb
@@ -28,16 +28,16 @@ describe "Kernel#untaint" do
   ruby_version_is "2.7"..."3.0" do
     it "is a no-op" do
       o = Object.new.taint
+      o.should_not.tainted?
       o.untaint
       o.should_not.tainted?
     end
 
     it "warns in verbose mode" do
       -> {
-        $VERBOSE = true
         o = Object.new.taint
         o.untaint
-      }.should complain(/Object#untaint is deprecated and will be removed in Ruby 3.2/)
+      }.should complain(/Object#untaint is deprecated and will be removed in Ruby 3.2/, verbose: true)
     end
   end
 end

--- a/core/kernel/untrust_spec.rb
+++ b/core/kernel/untrust_spec.rb
@@ -24,4 +24,20 @@ describe "Kernel#untrust" do
       o.untrust.should equal(o)
     end
   end
+
+  ruby_version_is "2.7"..."3.0" do
+    it "is a no-op" do
+      o = Object.new
+      o.untrust
+      o.should_not.untrusted?
+    end
+
+    it "warns in verbose mode" do
+      -> {
+        $VERBOSE = true
+        o = Object.new
+        o.untrust
+      }.should complain(/Object#untrust is deprecated and will be removed in Ruby 3.2/)
+    end
+  end
 end

--- a/core/kernel/untrust_spec.rb
+++ b/core/kernel/untrust_spec.rb
@@ -34,10 +34,9 @@ describe "Kernel#untrust" do
 
     it "warns in verbose mode" do
       -> {
-        $VERBOSE = true
         o = Object.new
         o.untrust
-      }.should complain(/Object#untrust is deprecated and will be removed in Ruby 3.2/)
+      }.should complain(/Object#untrust is deprecated and will be removed in Ruby 3.2/, verbose: true)
     end
   end
 end

--- a/core/kernel/untrusted_spec.rb
+++ b/core/kernel/untrusted_spec.rb
@@ -38,10 +38,9 @@ describe "Kernel#untrusted?" do
 
     it "warns in verbose mode" do
       -> {
-        $VERBOSE = true
         o = mock('o')
         o.untrusted?
-      }.should complain(/Object#untrusted\? is deprecated and will be removed in Ruby 3.2/)
+      }.should complain(/Object#untrusted\? is deprecated and will be removed in Ruby 3.2/, verbose: true)
     end
   end
 end

--- a/core/kernel/untrusted_spec.rb
+++ b/core/kernel/untrusted_spec.rb
@@ -27,4 +27,21 @@ describe "Kernel#untrusted?" do
       -> { d.untrust }.should_not raise_error(RuntimeError)
     end
   end
+
+  ruby_version_is "2.7"..."3.0" do
+    it "is a no-op" do
+      o = mock('o')
+      o.should_not.untrusted?
+      o.untrust
+      o.should_not.untrusted?
+    end
+
+    it "warns in verbose mode" do
+      -> {
+        $VERBOSE = true
+        o = mock('o')
+        o.untrusted?
+      }.should complain(/Object#untrusted\? is deprecated and will be removed in Ruby 3.2/)
+    end
+  end
 end


### PR DESCRIPTION
relates to #745
Closes checkbox for `Object#{taint,untaint,trust,untrust}`