### PR TITLE
add spec for CLI option "-W:no-deprecated" introduced in Ruby 2.7

### DIFF
--- a/command_line/dash_upper_w_spec.rb
+++ b/command_line/dash_upper_w_spec.rb
@@ -18,3 +18,15 @@ end
 describe "The -W command line option with 2" do
   it_behaves_like :command_line_verbose, "-W2"
 end
+
+ruby_version_is "2.7" do
+  describe "The -W command line option with :no-deprecated" do
+    it "suppresses deprecation warnings" do
+      result = ruby_exe('$; = ""', args: '2>&1')
+      result.should =~ /is deprecated/
+
+      result = ruby_exe('$; = ""', options: '-W:no-deprecated', args: '2>&1')
+      result.should == ""
+    end
+  end
+end


### PR DESCRIPTION
Hello 👋 

Here's my suggestion to cover this one from #745 

> The -W option has been extended with a following :, to manage categorized
warnings. Feature #16345 Feature #16420

I always find it tricky to assert for _nothing_ (empty string), that's why I also added an assertion for the deprecation warning if option `-W:no-deprecated` is *not* given. Do you think this makes sense?

Looking forward to receiving your feedback.