### PR TITLE
Add specs for suppresssing warnings

### DIFF
--- a/command_line/dash_upper_w_spec.rb
+++ b/command_line/dash_upper_w_spec.rb
@@ -29,4 +29,14 @@ ruby_version_is "2.7" do
       result.should == ""
     end
   end
+
+  describe "The -W command line option with :no-experimental" do
+    it "suppresses experimental warnings" do
+      result = ruby_exe('0 in a', args: '2>&1')
+      result.should =~ /is experimental/
+
+      result = ruby_exe('0 in a', options: '-W:no-experimental', args: '2>&1')
+      result.should == ""
+    end
+  end
 end

--- a/command_line/rubyopt_spec.rb
+++ b/command_line/rubyopt_spec.rb
@@ -65,6 +65,12 @@ describe "Processing RUBYOPT" do
       result = ruby_exe('$; = ""', args: '2>&1')
       result.should == ""
     end
+
+    it "suppresses experimental warnings for '-W:no-experimental'" do
+      ENV["RUBYOPT"] = '-W:no-experimental'
+      result = ruby_exe('0 in a', args: '2>&1')
+      result.should == ""
+    end
   end
 
   it "requires the file for '-r'" do

--- a/command_line/rubyopt_spec.rb
+++ b/command_line/rubyopt_spec.rb
@@ -71,6 +71,12 @@ describe "Processing RUBYOPT" do
       result = ruby_exe('0 in a', args: '2>&1')
       result.should == ""
     end
+
+    it "suppresses deprecation and experimental warnings for '-W:no-deprecated -W:no-experimental'" do
+      ENV["RUBYOPT"] = '-W:no-deprecated -W:no-experimental'
+      result = ruby_exe('($; = "") in a', args: '2>&1')
+      result.should == ""
+    end
   end
 
   it "requires the file for '-r'" do

--- a/command_line/rubyopt_spec.rb
+++ b/command_line/rubyopt_spec.rb
@@ -59,6 +59,14 @@ describe "Processing RUBYOPT" do
     ruby_exe("p $VERBOSE", escape: true).chomp.should == "true"
   end
 
+  ruby_version_is "2.7" do
+    it "suppresses deprecation warnings for '-W:no-deprecated'" do
+      ENV["RUBYOPT"] = '-W:no-deprecated'
+      result = ruby_exe('$; = ""', args: '2>&1')
+      result.should == ""
+    end
+  end
+
   it "requires the file for '-r'" do
     f = fixture __FILE__, "rubyopt"
     ENV["RUBYOPT"] = "-r#{f}"


### PR DESCRIPTION
Hello 👋 

This PR covers the remaining open tasks in category _"Command Line options"_ from issue #745:

> * [ ] It works with the RUBYOPT environment variable:
> ...
> * [ ] To suppress experimental feature warnings:
> ...
> * [ ] To suppress both by using RUBYOPT, set space separated values:

(The first task in category "Command Line options" has been taken care of in #803 already)

Please let me know if anything has to be changed, thanks.