### PR TITLE
add spec for Warning[category] = true|false to emit/suppress warnings

### DIFF
--- a/core/warning/element_reference_spec.rb
+++ b/core/warning/element_reference_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../../spec_helper'
+
+ruby_version_is '2.7.2' do
+  describe "Warning.[]" do
+    it "returns default values for categories :deprecated and :experimental" do
+      ruby_exe('p Warning[:deprecated]').chomp.should == "false"
+      ruby_exe('p Warning[:experimental]').chomp.should == "true"
+    end
+
+    it "raises for unknown category" do
+      -> { Warning[:noop] }.should raise_error(ArgumentError, /unknown category: noop/)
+    end
+  end
+end

--- a/core/warning/element_set_spec.rb
+++ b/core/warning/element_set_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../../spec_helper'
+
+ruby_version_is '2.7' do
+  describe "Warning.[]=" do
+    it "emits and suppresses warnings for :deprecated" do
+      ruby_exe('Warning[:deprecated] = true; $; = ""', args: "2>&1").should =~ /is deprecated/
+      ruby_exe('Warning[:deprecated] = false; $; = ""', args: "2>&1").should == ""
+    end
+
+    it "emits and suppresses warnings for :experimental" do
+      ruby_exe('Warning[:experimental] = true; eval("0 in a")', args: "2>&1").should =~ /is experimental/
+      ruby_exe('Warning[:experimental] = false; eval("0 in a")', args: "2>&1").should == ""
+    end
+
+    it "raises for unknown category" do
+      -> { Warning[:noop] = false }.should raise_error(ArgumentError, /unknown category: noop/)
+    end
+  end
+end


### PR DESCRIPTION
Hello :wave:

This time I'll try to cover this one from #745

> * [ ] Added Warning.[] and Warning.[]= to manage emitting/suppressing
some categories of warnings. Feature #16345 Feature #16420


However, I discovered that suppressing experimental (`Warning[:experimental] = false`) does not seem to work when invoking a script with `ruby -e '...'`. In `irb` it works as expected.

Example:

```shell
# Tested with Ruby v2.7.2 on macOS 10.15 (Catalina) and Debian 10 (buster)

# :deprecated
ruby -e 'Warning[:deprecated] = true; $; = ""'  # => -e:1: warning: `$;' is deprecated
ruby -e 'Warning[:deprecated] = false; $; = ""' # =>

# :experimental
ruby -e 'Warning[:experimental] = true; 0 in a'  # => -e:1: warning: Pattern matching is experimental ...
ruby -e 'Warning[:experimental] = false; 0 in a' # => -e:1: warning: Pattern matching is experimental ...
```

Is this expected, or am I missing something here?