### PR TITLE
Add specs for pathname.glob

### DIFF
--- a/library/pathname/glob_spec.rb
+++ b/library/pathname/glob_spec.rb
@@ -22,15 +22,16 @@ describe 'Pathname#glob' do
   end
 
   it 'returns matching file paths' do
-    Pathname.glob(@dir + 'lib/*i*.rb').should == [Pathname.new(@file_1), Pathname.new(@file_2)]
+    Pathname.glob(@dir + 'lib/*i*.rb').sort.should == [Pathname.new(@file_1), Pathname.new(@file_2)].sort
   end
 
   it 'returns matching file paths when a flag is provided' do
-    Pathname.glob(@dir + 'lib/*i*.rb', File::FNM_DOTMATCH).should == [Pathname.new(@file_1), Pathname.new(@file_2), Pathname.new(@file_3)]
+    expected = [Pathname.new(@file_1), Pathname.new(@file_2), Pathname.new(@file_3)].sort
+    Pathname.glob(@dir + 'lib/*i*.rb', File::FNM_DOTMATCH).sort.should == expected
   end
 
   it 'returns matching file paths when supplied :base keyword argument' do
-    Pathname.glob('*i*.rb', base: @dir + 'lib').should == [Pathname.new('ipaddr.rb'), Pathname.new('irb.rb')]
+    Pathname.glob('*i*.rb', base: @dir + 'lib').sort.should == [Pathname.new('ipaddr.rb'), Pathname.new('irb.rb')].sort
   end
 
   ruby_version_is ''...'2.7' do
@@ -49,7 +50,8 @@ describe 'Pathname#glob' do
 
   ruby_version_is "2.7"..."3.0" do
     it "does not raise an ArgumentError when supplied a flag and :base keyword argument" do
-      Pathname.glob('*i*.rb', File::FNM_DOTMATCH, base: @dir + 'lib').should == [Pathname.new('ipaddr.rb'), Pathname.new('irb.rb'), Pathname.new('.hidden.rb')]
+      expected = [Pathname.new('ipaddr.rb'), Pathname.new('irb.rb'), Pathname.new('.hidden.rb')].sort
+      Pathname.glob('*i*.rb', File::FNM_DOTMATCH, base: @dir + 'lib').sort.should == expected
     end
 
     it "raises an ArgumentError when supplied a keyword argument other than :base" do

--- a/library/pathname/glob_spec.rb
+++ b/library/pathname/glob_spec.rb
@@ -34,17 +34,17 @@ describe 'Pathname#glob' do
     Pathname.glob('*i*.rb', base: @dir + 'lib').sort.should == [Pathname.new('ipaddr.rb'), Pathname.new('irb.rb')].sort
   end
 
+  it "raises an ArgumentError when supplied a keyword argument other than :base" do
+    -> {
+      Pathname.glob('*i*.rb', foo: @dir + 'lib')
+    }.should raise_error(ArgumentError, /unknown keyword: :?foo/)
+  end
+
   ruby_version_is ''...'2.7' do
     it 'raises an ArgumentError when supplied a flag and :base keyword argument' do
       -> {
         Pathname.glob(@dir + 'lib/*i*.rb', File::FNM_DOTMATCH, base: 'lib')
       }.should raise_error(ArgumentError, 'wrong number of arguments (given 3, expected 1..2)')
-    end
-
-    it "raises an ArgumentError when supplied a keyword argument other than :base" do
-      -> {
-        Pathname.glob('*i*.rb', foo: @dir + 'lib')
-      }.should raise_error(ArgumentError, 'unknown keyword: foo')
     end
   end
 
@@ -52,12 +52,6 @@ describe 'Pathname#glob' do
     it "does not raise an ArgumentError when supplied a flag and :base keyword argument" do
       expected = [Pathname.new('ipaddr.rb'), Pathname.new('irb.rb'), Pathname.new('.hidden.rb')].sort
       Pathname.glob('*i*.rb', File::FNM_DOTMATCH, base: @dir + 'lib').sort.should == expected
-    end
-
-    it "raises an ArgumentError when supplied a keyword argument other than :base" do
-      -> {
-        Pathname.glob('*i*.rb', foo: @dir + 'lib')
-      }.should raise_error(ArgumentError, 'unknown keyword: :foo')
     end
   end
 end

--- a/library/pathname/glob_spec.rb
+++ b/library/pathname/glob_spec.rb
@@ -48,7 +48,7 @@ describe 'Pathname#glob' do
     end
   end
 
-  ruby_version_is "2.7"..."3.0" do
+  ruby_version_is "2.7" do
     it "does not raise an ArgumentError when supplied a flag and :base keyword argument" do
       expected = [Pathname.new('ipaddr.rb'), Pathname.new('irb.rb'), Pathname.new('.hidden.rb')].sort
       Pathname.glob('*i*.rb', File::FNM_DOTMATCH, base: @dir + 'lib').sort.should == expected

--- a/library/pathname/glob_spec.rb
+++ b/library/pathname/glob_spec.rb
@@ -3,7 +3,7 @@ require 'pathname'
 
 describe 'Pathname#glob' do
   before :all  do
-    @dir = tmp ''
+    @dir = tmp 'pathname_glob'
     @file_1 = @dir + 'lib/ipaddr.rb'
     @file_2 = @dir + 'lib/irb.rb'
     @file_3 = @dir + 'lib/.hidden.rb'


### PR DESCRIPTION
relates to #745 

> Stdlib updates (outstanding ones only)
[ ] Pathname.glob now delegates 3 arguments to Dir.glob
to accept base keyword. Feature #14405