### PR TITLE
Add Kernel#Pathname spec

### DIFF
--- a/core/kernel/pathname_spec.rb
+++ b/core/kernel/pathname_spec.rb
@@ -1,0 +1,26 @@
+require_relative '../../spec_helper'
+require 'pathname'
+
+describe "Kernel#Pathname" do
+  it "is a public method" do
+    Kernel.public_methods.should include(:Pathname)
+  end
+
+  ruby_version_is ''...'2.7' do
+    it "returns a new pathname when called with a pathname argument" do
+      path = Pathname('foo')
+      new_path = Pathname(path)
+
+      (path.object_id == new_path.object_id).should be_false
+    end
+  end
+
+  ruby_version_is '2.7' do
+    it "returns same argument when called with a pathname argument" do
+      path = Pathname('foo')
+      new_path = Pathname(path)
+
+      (path.object_id == new_path.object_id).should be_true
+    end
+  end
+end

--- a/core/kernel/pathname_spec.rb
+++ b/core/kernel/pathname_spec.rb
@@ -11,7 +11,7 @@ describe "Kernel#Pathname" do
       path = Pathname('foo')
       new_path = Pathname(path)
 
-      (path.object_id == new_path.object_id).should be_false
+      path.should_not.equal?(new_path)
     end
   end
 
@@ -20,7 +20,7 @@ describe "Kernel#Pathname" do
       path = Pathname('foo')
       new_path = Pathname(path)
 
-      (path.object_id == new_path.object_id).should be_true
+      path.should.equal?(new_path)
     end
   end
 end

--- a/library/pathname/pathname_spec.rb
+++ b/library/pathname/pathname_spec.rb
@@ -2,8 +2,12 @@ require_relative '../../spec_helper'
 require 'pathname'
 
 describe "Kernel#Pathname" do
-  it "is a public method" do
-    Kernel.public_methods.should include(:Pathname)
+  it "is a private instance method" do
+    Kernel.should have_private_instance_method(:Pathname)
+  end
+
+  it "is also a public method" do
+    Kernel.should have_method(:Pathname)
   end
 
   ruby_version_is ''...'2.7' do


### PR DESCRIPTION
relates to #745 

> [ ]  Kernel#Pathname when called with a Pathname argument now returns
the argument instead of creating a new Pathname. This is more
similar to other Kernel methods, but can break code that modifies
the return value and expects the argument not to be modified.