### PR TITLE
Add test for Method#to_proc with one and three arguments when calling Hash#each

### DIFF
--- a/core/enumerable/shared/collect.rb
+++ b/core/enumerable/shared/collect.rb
@@ -51,7 +51,20 @@ describe :enumerable_collect, shared: true do
     ScratchPad.recorded.should == [1]
   end
 
-  it "yields 2 arguments for a Hash" do
+  it "yields an Array of 2 elements for a Hash when block arity is 1" do
+    c = Class.new do
+      def register(a)
+        ScratchPad << a
+      end
+    end
+    m = c.new.method(:register)
+
+    ScratchPad.record []
+    { 1 => 'a', 2 => 'b' }.map(&m)
+    ScratchPad.recorded.should == [[1, 'a'], [2, 'b']]
+  end
+
+  it "yields 2 arguments for a Hash when block arity is 2" do
     c = Class.new do
       def register(a, b)
         ScratchPad << [a, b]
@@ -62,6 +75,18 @@ describe :enumerable_collect, shared: true do
     ScratchPad.record []
     { 1 => 'a', 2 => 'b' }.map(&m)
     ScratchPad.recorded.should == [[1, 'a'], [2, 'b']]
+  end
+
+  it "raises an error for a Hash when an arity enforcing block of arity >2 is passed in" do
+    c = Class.new do
+      def register(a, b, c)
+      end
+    end
+    m = c.new.method(:register)
+
+    -> do
+      { 1 => 'a', 2 => 'b' }.map(&m)
+    end.should raise_error(ArgumentError)
   end
 
   it_should_behave_like :enumerable_enumeratorized_with_origin_size

--- a/core/hash/shared/each.rb
+++ b/core/hash/shared/each.rb
@@ -54,6 +54,27 @@ describe :hash_each, shared: true do
     end
   end
 
+  it "yields an Array of 2 elements when given a callable of arity 1" do
+    obj = Object.new
+    def obj.foo(key_value)
+      ScratchPad << key_value
+    end
+
+    ScratchPad.record([])
+    { "a" => 1 }.send(@method, &obj.method(:foo))
+    ScratchPad.recorded.should == [["a", 1]]
+  end
+
+  it "raises an error for a Hash when an arity enforcing callable of arity >2 is passed in" do
+    obj = Object.new
+    def obj.foo(key, value, extra)
+    end
+
+    -> {
+      { "a" => 1 }.send(@method, &obj.method(:foo))
+    }.should raise_error(ArgumentError)
+  end
+
   it "uses the same order as keys() and values()" do
     h = { a: 1, b: 2, c: 3, d: 5 }
     keys = []


### PR DESCRIPTION
This tests a bug that was found in JRuby: jruby/jruby#5896

This passes on MRI 2.7.2 but fails on JRuby 9.2.13.0. I've opened a PR to fix JRuby here: https://github.com/jruby/jruby/pull/6451

```
marshall@lappy7 spec % git rev-parse HEAD
3d552358e3544339096b99f645d414a6bf062f2e
```
```
marshall@lappy7 spec % RBENV_VERSION=2.7.2 ../mspec/bin/mspec  core/method/to_proc_spec.rb         
$ ruby /Users/marshall/src/ruby/mspec/bin/mspec-run core/method/to_proc_spec.rb
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin19]
[- | ==================100%================== | 00:00:00]      0F      0E 

Finished in 0.003202 seconds

1 file, 12 examples, 40 expectations, 0 failures, 0 errors, 0 tagged
```
```
marshall@lappy7 spec % RBENV_VERSION=jruby-9.2.13.0 ../mspec/bin/mspec  core/method/to_proc_spec.rb
$ ruby /Users/marshall/src/ruby/mspec/bin/mspec-run core/method/to_proc_spec.rb
uri:classloader:/jruby/kernel/kernel.rb:4: warning: unsupported exec option: close_others
jruby 9.2.13.0 (2.5.7) 2020-08-03 9a89c94bcc OpenJDK 64-Bit Server VM 11.0.8+11 on 11.0.8+11 +jit [darwin-x86_64]
                                                                                             
1)
Method#to_proc returns a proc that properly handles when one or more items are yielded ERROR
ArgumentError: wrong number of arguments (given 1, expected 2)
/Users/marshall/src/ruby/spec/core/method/to_proc_spec.rb:113:in `two_params'
org/jruby/RubyHash.java:1415:in `each'
org/jruby/RubyEnumerable.java:886:in `map'
/Users/marshall/src/ruby/spec/core/method/to_proc_spec.rb:113:in `block in <main>'
org/jruby/RubyBasicObject.java:2694:in `instance_exec'
org/jruby/RubyEnumerable.java:1809:in `all?'
org/jruby/RubyArray.java:1809:in `each'
/Users/marshall/src/ruby/spec/core/method/to_proc_spec.rb:4:in `<main>'
org/jruby/RubyKernel.java:1009:in `load'
org/jruby/RubyBasicObject.java:2694:in `instance_exec'
org/jruby/RubyArray.java:1809:in `each'
[\ | ==================100%================== | 00:00:00]      0F      1E 

Finished in 0.053561 seconds

1 file, 12 examples, 38 expectations, 0 failures, 1 error, 0 tagged
```