### PR TITLE
adds IO#set_encoding_by_bom spec

### DIFF
--- a/core/io/set_encoding_by_bom_spec.rb
+++ b/core/io/set_encoding_by_bom_spec.rb
@@ -14,10 +14,24 @@ describe "IO#set_encoding_by_bom" do
 
   ruby_version_is "2.7" do
     it "returns the result encoding if found BOM UTF-8 sequence" do
-      File.write(@name, "\u{FEFF}abc")
+      File.binwrite(@name, "\u{FEFF}abc")
 
       @io.set_encoding_by_bom.should == Encoding::UTF_8
       @io.external_encoding.should == Encoding::UTF_8
+    end
+
+    it "returns the result encoding if found BOM UTF_16LE sequence" do
+      File.binwrite(@name, "\xFF\xFEabc")
+
+      @io.set_encoding_by_bom.should == Encoding::UTF_16LE
+      @io.external_encoding.should == Encoding::UTF_16LE
+    end
+
+    it "returns the result encoding if found BOM UTF_16BE sequence" do
+      File.binwrite(@name, "\xFE\xFFabc")
+
+      @io.set_encoding_by_bom.should == Encoding::UTF_16BE
+      @io.external_encoding.should == Encoding::UTF_16BE
     end
 
     it "returns nil if found BOM sequence not provided" do
@@ -30,6 +44,7 @@ describe "IO#set_encoding_by_bom" do
       not_binary_io = new_io(@name, 'r')
 
       -> { not_binary_io.set_encoding_by_bom }.should raise_error(ArgumentError, 'ASCII incompatible encoding needs binmode')
+    ensure
       not_binary_io.close
     end
 

--- a/core/io/set_encoding_by_bom_spec.rb
+++ b/core/io/set_encoding_by_bom_spec.rb
@@ -1,0 +1,42 @@
+require_relative '../../spec_helper'
+
+describe "IO#set_encoding_by_bom" do
+  before :each do
+    @name = tmp('io_set_encoding_by_bom.txt')
+    touch(@name)
+    @io = new_io(@name, 'rb')
+  end
+
+  after :each do
+    @io.close unless @io.closed?
+    rm_r @name
+  end
+
+  ruby_version_is "2.7" do
+    it "returns the result encoding if found BOM UTF-8 sequence" do
+      File.write(@name, "\u{FEFF}abc")
+
+      @io.set_encoding_by_bom.should == Encoding::UTF_8
+      @io.external_encoding.should == Encoding::UTF_8
+    end
+
+    it "returns nil if found BOM sequence not provided" do
+      File.write(@name, "abc")
+
+      @io.set_encoding_by_bom.should == nil
+    end
+
+    it 'returns exception if io not in binary mode' do
+      not_binary_io = new_io(@name, 'r')
+
+      -> { not_binary_io.set_encoding_by_bom }.should raise_error(ArgumentError, 'ASCII incompatible encoding needs binmode')
+      not_binary_io.close
+    end
+
+    it 'returns exception if encoding already set' do
+      @io.set_encoding("utf-8")
+
+      -> { @io.set_encoding_by_bom }.should raise_error(ArgumentError, 'encoding is set to UTF-8 already')
+    end
+  end
+end


### PR DESCRIPTION
Solving #745

> 
> Added IO#set_encoding_by_bom to check the BOM and set the external
> encoding. Bug #15210