### PR TITLE
Use hex-encoded binary instead of UTF-8

### DIFF
--- a/core/string/valid_encoding_spec.rb
+++ b/core/string/valid_encoding_spec.rb
@@ -13,7 +13,7 @@ describe "String#valid_encoding?" do
   end
 
   it "returns true for all encodings self is valid in" do
-    str = "\u{6754}"
+    str = "\xE6\x9D\x94"
     str.force_encoding('BINARY').valid_encoding?.should be_true
     str.force_encoding('UTF-8').valid_encoding?.should be_true
     str.force_encoding('US-ASCII').valid_encoding?.should be_false


### PR DESCRIPTION
Which UTF-8 char corresponds to the binary representation is nonsense for other encodings, and just confusing.
It is a red herring.