### PR TITLE
Use ruby_exe with `exception: false`

### DIFF
--- a/command_line/dash_encoding_spec.rb
+++ b/command_line/dash_encoding_spec.rb
@@ -25,6 +25,12 @@ describe "The --encoding command line option" do
   end
 
   it "does not accept a third encoding" do
-    ruby_exe(@test_string, options: "--disable-gems --encoding big5:#{@enc2}:utf-32le", args: "2>&1").should =~ /extra argument for --encoding: utf-32le/
+    options = {
+      options: "--disable-gems --encoding big5:#{@enc2}:utf-32le",
+      args: "2>&1",
+      exception: false
+    }
+
+    ruby_exe(@test_string, options).should =~ /extra argument for --encoding: utf-32le/
   end
 end

--- a/command_line/dash_encoding_spec.rb
+++ b/command_line/dash_encoding_spec.rb
@@ -28,7 +28,7 @@ describe "The --encoding command line option" do
     options = {
       options: "--disable-gems --encoding big5:#{@enc2}:utf-32le",
       args: "2>&1",
-      exception: false
+      exit_status: 1
     }
 
     ruby_exe(@test_string, options).should =~ /extra argument for --encoding: utf-32le/

--- a/command_line/dash_r_spec.rb
+++ b/command_line/dash_r_spec.rb
@@ -13,7 +13,7 @@ describe "The -r command line option" do
   end
 
   it "requires the file before parsing the main script" do
-    out = ruby_exe(fixture(__FILE__, "bad_syntax.rb"), options: "-r #{@test_file}", args: "2>&1")
+    out = ruby_exe(fixture(__FILE__, "bad_syntax.rb"), options: "-r #{@test_file}", args: "2>&1", exception: false)
     $?.should_not.success?
     out.should include("REQUIRED")
     out.should include("syntax error")

--- a/command_line/dash_r_spec.rb
+++ b/command_line/dash_r_spec.rb
@@ -13,7 +13,7 @@ describe "The -r command line option" do
   end
 
   it "requires the file before parsing the main script" do
-    out = ruby_exe(fixture(__FILE__, "bad_syntax.rb"), options: "-r #{@test_file}", args: "2>&1", exception: false)
+    out = ruby_exe(fixture(__FILE__, "bad_syntax.rb"), options: "-r #{@test_file}", args: "2>&1", exit_status: 1)
     $?.should_not.success?
     out.should include("REQUIRED")
     out.should include("syntax error")

--- a/command_line/dash_upper_e_spec.rb
+++ b/command_line/dash_upper_e_spec.rb
@@ -32,6 +32,6 @@ describe "ruby -E" do
     ruby_exe("p 1",
              options: '-Eascii:ascii -U',
              args: '2>&1',
-             exception: false).should =~ /RuntimeError/
+             exit_status: 1).should =~ /RuntimeError/
   end
 end

--- a/command_line/dash_upper_e_spec.rb
+++ b/command_line/dash_upper_e_spec.rb
@@ -31,6 +31,7 @@ describe "ruby -E" do
   it "raises a RuntimeError if used with -U" do
     ruby_exe("p 1",
              options: '-Eascii:ascii -U',
-             args: '2>&1').should =~ /RuntimeError/
+             args: '2>&1',
+             exception: false).should =~ /RuntimeError/
   end
 end

--- a/command_line/dash_upper_s_spec.rb
+++ b/command_line/dash_upper_s_spec.rb
@@ -21,7 +21,7 @@ describe 'The -S command line option' do
     end
 
     it "runs launcher found in PATH and sets the exit status to 1 if it fails" do
-      result = ruby_exe(nil, options: '-S dash_s_fail', env: { 'PATH' => @path }, args: '2>&1', exception: false)
+      result = ruby_exe(nil, options: '-S dash_s_fail', env: { 'PATH' => @path }, args: '2>&1', exit_status: 1)
       result.should =~ /\bdie\b/
       $?.exitstatus.should == 1
     end

--- a/command_line/dash_upper_s_spec.rb
+++ b/command_line/dash_upper_s_spec.rb
@@ -21,7 +21,7 @@ describe 'The -S command line option' do
     end
 
     it "runs launcher found in PATH and sets the exit status to 1 if it fails" do
-      result = ruby_exe(nil, options: '-S dash_s_fail', env: { 'PATH' => @path }, args: '2>&1')
+      result = ruby_exe(nil, options: '-S dash_s_fail', env: { 'PATH' => @path }, args: '2>&1', exception: false)
       result.should =~ /\bdie\b/
       $?.exitstatus.should == 1
     end

--- a/command_line/dash_upper_u_spec.rb
+++ b/command_line/dash_upper_u_spec.rb
@@ -32,12 +32,14 @@ describe "ruby -U" do
   it "raises a RuntimeError if used with -Eext:int" do
     ruby_exe("p 1",
              options: '-U -Eascii:ascii',
-             args: '2>&1').should =~ /RuntimeError/
+             args: '2>&1',
+             exception: false).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError if used with -E:int" do
     ruby_exe("p 1",
              options: '-U -E:ascii',
-             args: '2>&1').should =~ /RuntimeError/
+             args: '2>&1',
+             exception: false).should =~ /RuntimeError/
   end
 end

--- a/command_line/dash_upper_u_spec.rb
+++ b/command_line/dash_upper_u_spec.rb
@@ -33,13 +33,13 @@ describe "ruby -U" do
     ruby_exe("p 1",
              options: '-U -Eascii:ascii',
              args: '2>&1',
-             exception: false).should =~ /RuntimeError/
+             exit_status: 1).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError if used with -E:int" do
     ruby_exe("p 1",
              options: '-U -E:ascii',
              args: '2>&1',
-             exception: false).should =~ /RuntimeError/
+             exit_status: 1).should =~ /RuntimeError/
   end
 end

--- a/command_line/dash_x_spec.rb
+++ b/command_line/dash_x_spec.rb
@@ -9,7 +9,7 @@ describe "The -x command line option" do
 
   it "fails when /\#!.*ruby.*/-ish line in target file is not found" do
     bad_embedded_ruby = fixture __FILE__, "bin/bad_embedded_ruby.txt"
-    result = ruby_exe(bad_embedded_ruby, options: '-x', args: '2>&1')
+    result = ruby_exe(bad_embedded_ruby, options: '-x', args: '2>&1', exception: false)
     result.should include "no Ruby script found in input"
   end
 

--- a/command_line/dash_x_spec.rb
+++ b/command_line/dash_x_spec.rb
@@ -9,7 +9,7 @@ describe "The -x command line option" do
 
   it "fails when /\#!.*ruby.*/-ish line in target file is not found" do
     bad_embedded_ruby = fixture __FILE__, "bin/bad_embedded_ruby.txt"
-    result = ruby_exe(bad_embedded_ruby, options: '-x', args: '2>&1', exception: false)
+    result = ruby_exe(bad_embedded_ruby, options: '-x', args: '2>&1', exit_status: 1)
     result.should include "no Ruby script found in input"
   end
 

--- a/command_line/error_message_spec.rb
+++ b/command_line/error_message_spec.rb
@@ -2,10 +2,10 @@ require_relative '../spec_helper'
 
 describe "The error message caused by an exception" do
   it "is not printed to stdout" do
-    out = ruby_exe("this_does_not_exist", args: "2> #{File::NULL}", exception: false)
+    out = ruby_exe("this_does_not_exist", args: "2> #{File::NULL}", exit_status: 1)
     out.chomp.should.empty?
 
-    out = ruby_exe("end #syntax error", args: "2> #{File::NULL}", exception: false)
+    out = ruby_exe("end #syntax error", args: "2> #{File::NULL}", exit_status: 1)
     out.chomp.should.empty?
   end
 end

--- a/command_line/error_message_spec.rb
+++ b/command_line/error_message_spec.rb
@@ -2,10 +2,10 @@ require_relative '../spec_helper'
 
 describe "The error message caused by an exception" do
   it "is not printed to stdout" do
-    out = ruby_exe("this_does_not_exist", args: "2> #{File::NULL}")
+    out = ruby_exe("this_does_not_exist", args: "2> #{File::NULL}", exception: false)
     out.chomp.should.empty?
 
-    out = ruby_exe("end #syntax error", args: "2> #{File::NULL}")
+    out = ruby_exe("end #syntax error", args: "2> #{File::NULL}", exception: false)
     out.chomp.should.empty?
   end
 end

--- a/command_line/rubyopt_spec.rb
+++ b/command_line/rubyopt_spec.rb
@@ -87,101 +87,101 @@ describe "Processing RUBYOPT" do
 
   it "raises a RuntimeError for '-a'" do
     ENV["RUBYOPT"] = '-a'
-    ruby_exe("", args: '2>&1').should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-p'" do
     ENV["RUBYOPT"] = '-p'
-    ruby_exe("", args: '2>&1').should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-n'" do
     ENV["RUBYOPT"] = '-n'
-    ruby_exe("", args: '2>&1').should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-y'" do
     ENV["RUBYOPT"] = '-y'
-    ruby_exe("", args: '2>&1').should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-c'" do
     ENV["RUBYOPT"] = '-c'
-    ruby_exe("", args: '2>&1').should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-s'" do
     ENV["RUBYOPT"] = '-s'
-    ruby_exe("", args: '2>&1').should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-h'" do
     ENV["RUBYOPT"] = '-h'
-    ruby_exe("", args: '2>&1').should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '--help'" do
     ENV["RUBYOPT"] = '--help'
-    ruby_exe("", args: '2>&1').should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-l'" do
     ENV["RUBYOPT"] = '-l'
-    ruby_exe("", args: '2>&1').should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-S'" do
     ENV["RUBYOPT"] = '-S irb'
-    ruby_exe("", args: '2>&1').should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-e'" do
     ENV["RUBYOPT"] = '-e0'
-    ruby_exe("", args: '2>&1').should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-i'" do
     ENV["RUBYOPT"] = '-i.bak'
-    ruby_exe("", args: '2>&1').should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-x'" do
     ENV["RUBYOPT"] = '-x'
-    ruby_exe("", args: '2>&1').should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-C'" do
     ENV["RUBYOPT"] = '-C'
-    ruby_exe("", args: '2>&1').should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-X'" do
     ENV["RUBYOPT"] = '-X.'
-    ruby_exe("", args: '2>&1').should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-F'" do
     ENV["RUBYOPT"] = '-F'
-    ruby_exe("", args: '2>&1').should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-0'" do
     ENV["RUBYOPT"] = '-0'
-    ruby_exe("", args: '2>&1').should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '--copyright'" do
     ENV["RUBYOPT"] = '--copyright'
-    ruby_exe("", args: '2>&1').should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '--version'" do
     ENV["RUBYOPT"] = '--version'
-    ruby_exe("", args: '2>&1').should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '--yydebug'" do
     ENV["RUBYOPT"] = '--yydebug'
-    ruby_exe("", args: '2>&1').should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
   end
 end

--- a/command_line/rubyopt_spec.rb
+++ b/command_line/rubyopt_spec.rb
@@ -87,101 +87,101 @@ describe "Processing RUBYOPT" do
 
   it "raises a RuntimeError for '-a'" do
     ENV["RUBYOPT"] = '-a'
-    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exit_status: 1).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-p'" do
     ENV["RUBYOPT"] = '-p'
-    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exit_status: 1).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-n'" do
     ENV["RUBYOPT"] = '-n'
-    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exit_status: 1).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-y'" do
     ENV["RUBYOPT"] = '-y'
-    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exit_status: 1).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-c'" do
     ENV["RUBYOPT"] = '-c'
-    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exit_status: 1).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-s'" do
     ENV["RUBYOPT"] = '-s'
-    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exit_status: 1).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-h'" do
     ENV["RUBYOPT"] = '-h'
-    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exit_status: 1).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '--help'" do
     ENV["RUBYOPT"] = '--help'
-    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exit_status: 1).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-l'" do
     ENV["RUBYOPT"] = '-l'
-    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exit_status: 1).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-S'" do
     ENV["RUBYOPT"] = '-S irb'
-    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exit_status: 1).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-e'" do
     ENV["RUBYOPT"] = '-e0'
-    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exit_status: 1).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-i'" do
     ENV["RUBYOPT"] = '-i.bak'
-    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exit_status: 1).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-x'" do
     ENV["RUBYOPT"] = '-x'
-    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exit_status: 1).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-C'" do
     ENV["RUBYOPT"] = '-C'
-    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exit_status: 1).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-X'" do
     ENV["RUBYOPT"] = '-X.'
-    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exit_status: 1).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-F'" do
     ENV["RUBYOPT"] = '-F'
-    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exit_status: 1).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '-0'" do
     ENV["RUBYOPT"] = '-0'
-    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exit_status: 1).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '--copyright'" do
     ENV["RUBYOPT"] = '--copyright'
-    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exit_status: 1).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '--version'" do
     ENV["RUBYOPT"] = '--version'
-    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exit_status: 1).should =~ /RuntimeError/
   end
 
   it "raises a RuntimeError for '--yydebug'" do
     ENV["RUBYOPT"] = '--yydebug'
-    ruby_exe("", args: '2>&1', exception: false).should =~ /RuntimeError/
+    ruby_exe("", args: '2>&1', exit_status: 1).should =~ /RuntimeError/
   end
 end

--- a/command_line/syntax_error_spec.rb
+++ b/command_line/syntax_error_spec.rb
@@ -2,12 +2,12 @@ require_relative '../spec_helper'
 
 describe "The interpreter" do
   it "prints an error when given a file with invalid syntax" do
-    out = ruby_exe(fixture(__FILE__, "bad_syntax.rb"), args: "2>&1")
+    out = ruby_exe(fixture(__FILE__, "bad_syntax.rb"), args: "2>&1", exception: false)
     out.should include "syntax error"
   end
 
   it "prints an error when given code via -e with invalid syntax" do
-    out = ruby_exe(nil, args: "-e 'a{' 2>&1")
+    out = ruby_exe(nil, args: "-e 'a{' 2>&1", exception: false)
     out.should include "syntax error"
   end
 end

--- a/command_line/syntax_error_spec.rb
+++ b/command_line/syntax_error_spec.rb
@@ -2,12 +2,12 @@ require_relative '../spec_helper'
 
 describe "The interpreter" do
   it "prints an error when given a file with invalid syntax" do
-    out = ruby_exe(fixture(__FILE__, "bad_syntax.rb"), args: "2>&1", exception: false)
+    out = ruby_exe(fixture(__FILE__, "bad_syntax.rb"), args: "2>&1", exit_status: 1)
     out.should include "syntax error"
   end
 
   it "prints an error when given code via -e with invalid syntax" do
-    out = ruby_exe(nil, args: "-e 'a{' 2>&1", exception: false)
+    out = ruby_exe(nil, args: "-e 'a{' 2>&1", exit_status: 1)
     out.should include "syntax error"
   end
 end

--- a/core/exception/signal_exception_spec.rb
+++ b/core/exception/signal_exception_spec.rb
@@ -95,7 +95,7 @@ describe "SignalException" do
 
   platform_is_not :windows do
     it "runs after at_exit" do
-      output = ruby_exe(<<-RUBY, exception: false)
+      output = ruby_exe(<<-RUBY, exit_status: nil)
         at_exit do
           puts "hello"
           $stdout.flush
@@ -109,7 +109,7 @@ describe "SignalException" do
     end
 
     it "cannot be trapped with Signal.trap" do
-      ruby_exe(<<-RUBY, exception: false)
+      ruby_exe(<<-RUBY, exit_status: nil)
         Signal.trap("PROF") {}
         raise(SignalException, "PROF")
       RUBY
@@ -118,7 +118,7 @@ describe "SignalException" do
     end
 
     it "self-signals for USR1" do
-      ruby_exe("raise(SignalException, 'USR1')", exception: false)
+      ruby_exe("raise(SignalException, 'USR1')", exit_status: nil)
       $?.termsig.should == Signal.list.fetch('USR1')
     end
   end

--- a/core/exception/signal_exception_spec.rb
+++ b/core/exception/signal_exception_spec.rb
@@ -95,7 +95,7 @@ describe "SignalException" do
 
   platform_is_not :windows do
     it "runs after at_exit" do
-      output = ruby_exe(<<-RUBY)
+      output = ruby_exe(<<-RUBY, exception: false)
         at_exit do
           puts "hello"
           $stdout.flush
@@ -109,7 +109,7 @@ describe "SignalException" do
     end
 
     it "cannot be trapped with Signal.trap" do
-      ruby_exe(<<-RUBY)
+      ruby_exe(<<-RUBY, exception: false)
         Signal.trap("PROF") {}
         raise(SignalException, "PROF")
       RUBY
@@ -118,7 +118,7 @@ describe "SignalException" do
     end
 
     it "self-signals for USR1" do
-      ruby_exe("raise(SignalException, 'USR1')")
+      ruby_exe("raise(SignalException, 'USR1')", exception: false)
       $?.termsig.should == Signal.list.fetch('USR1')
     end
   end

--- a/core/exception/system_exit_spec.rb
+++ b/core/exception/system_exit_spec.rb
@@ -3,14 +3,14 @@ require_relative '../../spec_helper'
 describe "SystemExit" do
   it "sets the exit status and exits silently when raised" do
     code = 'raise SystemExit.new(7)'
-    result = ruby_exe(code, args: "2>&1", exception: false)
+    result = ruby_exe(code, args: "2>&1", exit_status: 7)
     result.should == ""
     $?.exitstatus.should == 7
   end
 
   it "sets the exit status and exits silently when raised when subclassed" do
     code = 'class CustomExit < SystemExit; end; raise CustomExit.new(8)'
-    result = ruby_exe(code, args: "2>&1", exception: false)
+    result = ruby_exe(code, args: "2>&1", exit_status: 8)
     result.should == ""
     $?.exitstatus.should == 8
   end

--- a/core/exception/system_exit_spec.rb
+++ b/core/exception/system_exit_spec.rb
@@ -3,14 +3,14 @@ require_relative '../../spec_helper'
 describe "SystemExit" do
   it "sets the exit status and exits silently when raised" do
     code = 'raise SystemExit.new(7)'
-    result = ruby_exe(code, args: "2>&1")
+    result = ruby_exe(code, args: "2>&1", exception: false)
     result.should == ""
     $?.exitstatus.should == 7
   end
 
   it "sets the exit status and exits silently when raised when subclassed" do
     code = 'class CustomExit < SystemExit; end; raise CustomExit.new(8)'
-    result = ruby_exe(code, args: "2>&1")
+    result = ruby_exe(code, args: "2>&1", exception: false)
     result.should == ""
     $?.exitstatus.should == 8
   end

--- a/core/exception/top_level_spec.rb
+++ b/core/exception/top_level_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../spec_helper'
 
 describe "An Exception reaching the top level" do
   it "is printed on STDERR" do
-    ruby_exe('raise "foo"', args: "2>&1").should.include?("in `<main>': foo (RuntimeError)")
+    ruby_exe('raise "foo"', args: "2>&1", exception: false).should.include?("in `<main>': foo (RuntimeError)")
   end
 
   ruby_version_is "2.6" do
@@ -20,7 +20,7 @@ describe "An Exception reaching the top level" do
         raise_wrapped
       end
       RUBY
-      lines = ruby_exe(code, args: "2>&1").lines
+      lines = ruby_exe(code, args: "2>&1", exception: false).lines
       lines.reject! { |l| l.include?('rescue in') }
       lines.map! { |l| l.chomp[/:(in.+)/, 1] }
       lines.should == ["in `raise_wrapped': wrapped (RuntimeError)",
@@ -38,7 +38,7 @@ describe "An Exception reaching the top level" do
         "/dir/bar.rb:20:in `caller'",
       ]
       RUBY
-      ruby_exe(code, args: "2>&1").should == <<-EOS
+      ruby_exe(code, args: "2>&1", exception: false).should == <<-EOS
 /dir/foo.rb:10:in `raising': foo (RuntimeError)
 \tfrom /dir/bar.rb:20:in `caller'
       EOS

--- a/core/exception/top_level_spec.rb
+++ b/core/exception/top_level_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../spec_helper'
 
 describe "An Exception reaching the top level" do
   it "is printed on STDERR" do
-    ruby_exe('raise "foo"', args: "2>&1", exception: false).should.include?("in `<main>': foo (RuntimeError)")
+    ruby_exe('raise "foo"', args: "2>&1", exit_status: 1).should.include?("in `<main>': foo (RuntimeError)")
   end
 
   ruby_version_is "2.6" do
@@ -20,7 +20,7 @@ describe "An Exception reaching the top level" do
         raise_wrapped
       end
       RUBY
-      lines = ruby_exe(code, args: "2>&1", exception: false).lines
+      lines = ruby_exe(code, args: "2>&1", exit_status: 1).lines
       lines.reject! { |l| l.include?('rescue in') }
       lines.map! { |l| l.chomp[/:(in.+)/, 1] }
       lines.should == ["in `raise_wrapped': wrapped (RuntimeError)",
@@ -38,7 +38,7 @@ describe "An Exception reaching the top level" do
         "/dir/bar.rb:20:in `caller'",
       ]
       RUBY
-      ruby_exe(code, args: "2>&1", exception: false).should == <<-EOS
+      ruby_exe(code, args: "2>&1", exit_status: 1).should == <<-EOS
 /dir/foo.rb:10:in `raising': foo (RuntimeError)
 \tfrom /dir/bar.rb:20:in `caller'
       EOS

--- a/core/kernel/at_exit_spec.rb
+++ b/core/kernel/at_exit_spec.rb
@@ -33,32 +33,32 @@ describe "Kernel.at_exit" do
       end
     EOC
 
-    result = ruby_exe(code, args: "2>&1", exception: false)
+    result = ruby_exe(code, args: "2>&1", exit_status: 1)
     result.lines.should.include?("The exception matches: true (message=foo)\n")
   end
 
   it "both exceptions in at_exit and in the main script are printed" do
     code = 'at_exit { raise "at_exit_error" }; raise "main_script_error"'
-    result = ruby_exe(code, args: "2>&1", exception: false)
+    result = ruby_exe(code, args: "2>&1", exit_status: 1)
     result.should.include?('at_exit_error (RuntimeError)')
     result.should.include?('main_script_error (RuntimeError)')
   end
 
   it "decides the exit status if both at_exit and the main script raise SystemExit" do
-    ruby_exe('at_exit { exit 43 }; exit 42', args: "2>&1", exception: false)
+    ruby_exe('at_exit { exit 43 }; exit 42', args: "2>&1", exit_status: 43)
     $?.exitstatus.should == 43
   end
 
   it "runs all at_exit even if some raise exceptions" do
     code = 'at_exit { STDERR.puts "last" }; at_exit { exit 43 }; at_exit { STDERR.puts "first" }; exit 42'
-    result = ruby_exe(code, args: "2>&1", exception: false)
+    result = ruby_exe(code, args: "2>&1", exit_status: 43)
     result.should == "first\nlast\n"
     $?.exitstatus.should == 43
   end
 
   it "runs at_exit handlers even if the main script fails to parse" do
     script = fixture(__FILE__, "at_exit.rb")
-    result = ruby_exe('{', options: "-r#{script}", args: "2>&1", exception: false)
+    result = ruby_exe('{', options: "-r#{script}", args: "2>&1", exit_status: 1)
     $?.should_not.success?
     result.should.include?("at_exit ran\n")
     result.should.include?("syntax error")

--- a/core/kernel/at_exit_spec.rb
+++ b/core/kernel/at_exit_spec.rb
@@ -33,31 +33,32 @@ describe "Kernel.at_exit" do
       end
     EOC
 
-    result = ruby_exe(code, args: "2>&1")
+    result = ruby_exe(code, args: "2>&1", exception: false)
     result.lines.should.include?("The exception matches: true (message=foo)\n")
   end
 
   it "both exceptions in at_exit and in the main script are printed" do
-    result = ruby_exe('at_exit { raise "at_exit_error" }; raise "main_script_error"', args: "2>&1")
+    code = 'at_exit { raise "at_exit_error" }; raise "main_script_error"'
+    result = ruby_exe(code, args: "2>&1", exception: false)
     result.should.include?('at_exit_error (RuntimeError)')
     result.should.include?('main_script_error (RuntimeError)')
   end
 
   it "decides the exit status if both at_exit and the main script raise SystemExit" do
-    ruby_exe('at_exit { exit 43 }; exit 42', args: "2>&1")
+    ruby_exe('at_exit { exit 43 }; exit 42', args: "2>&1", exception: false)
     $?.exitstatus.should == 43
   end
 
   it "runs all at_exit even if some raise exceptions" do
     code = 'at_exit { STDERR.puts "last" }; at_exit { exit 43 }; at_exit { STDERR.puts "first" }; exit 42'
-    result = ruby_exe(code, args: "2>&1")
+    result = ruby_exe(code, args: "2>&1", exception: false)
     result.should == "first\nlast\n"
     $?.exitstatus.should == 43
   end
 
   it "runs at_exit handlers even if the main script fails to parse" do
     script = fixture(__FILE__, "at_exit.rb")
-    result = ruby_exe('{', options: "-r#{script}", args: "2>&1")
+    result = ruby_exe('{', options: "-r#{script}", args: "2>&1", exception: false)
     $?.should_not.success?
     result.should.include?("at_exit ran\n")
     result.should.include?("syntax error")

--- a/core/process/status/equal_value_spec.rb
+++ b/core/process/status/equal_value_spec.rb
@@ -2,13 +2,13 @@ require_relative '../../../spec_helper'
 
 describe "Process::Status#==" do
   it "returns true when compared to the integer status of an exited child" do
-    ruby_exe("exit(29)")
+    ruby_exe("exit(29)", exception: false)
     $?.to_i.should == $?
     $?.should == $?.to_i
   end
 
   it "returns true when compared to the integer status of a terminated child" do
-    ruby_exe("Process.kill(:KILL, $$); exit(29)")
+    ruby_exe("Process.kill(:KILL, $$); exit(29)", exception: false)
     $?.to_i.should == $?
     $?.should == $?.to_i
   end

--- a/core/process/status/equal_value_spec.rb
+++ b/core/process/status/equal_value_spec.rb
@@ -2,13 +2,13 @@ require_relative '../../../spec_helper'
 
 describe "Process::Status#==" do
   it "returns true when compared to the integer status of an exited child" do
-    ruby_exe("exit(29)", exception: false)
+    ruby_exe("exit(29)", exit_status: 29)
     $?.to_i.should == $?
     $?.should == $?.to_i
   end
 
   it "returns true when compared to the integer status of a terminated child" do
-    ruby_exe("Process.kill(:KILL, $$); exit(29)", exception: false)
+    ruby_exe("Process.kill(:KILL, $$); exit(29)", exit_status: nil)
     $?.to_i.should == $?
     $?.should == $?.to_i
   end

--- a/core/process/status/exited_spec.rb
+++ b/core/process/status/exited_spec.rb
@@ -17,7 +17,7 @@ describe "Process::Status#exited?" do
   describe "for a terminated child" do
 
     before :each do
-      ruby_exe("Process.kill(:KILL, $$); exit(42)")
+      ruby_exe("Process.kill(:KILL, $$); exit(42)", exception: false)
     end
 
     platform_is_not :windows do

--- a/core/process/status/exited_spec.rb
+++ b/core/process/status/exited_spec.rb
@@ -17,7 +17,7 @@ describe "Process::Status#exited?" do
   describe "for a terminated child" do
 
     before :each do
-      ruby_exe("Process.kill(:KILL, $$); exit(42)", exception: false)
+      ruby_exe("Process.kill(:KILL, $$); exit(42)", exit_status: nil)
     end
 
     platform_is_not :windows do

--- a/core/process/status/exitstatus_spec.rb
+++ b/core/process/status/exitstatus_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../../spec_helper'
 
 describe "Process::Status#exitstatus" do
   before :each do
-    ruby_exe("exit(42)")
+    ruby_exe("exit(42)", exception: false)
   end
 
   it "returns the process exit code" do
@@ -11,7 +11,7 @@ describe "Process::Status#exitstatus" do
 
   describe "for a child that raised SignalException" do
     before :each do
-      ruby_exe("Process.kill(:KILL, $$); exit(42)")
+      ruby_exe("Process.kill(:KILL, $$); exit(42)", exception: false)
     end
 
     platform_is_not :windows do

--- a/core/process/status/exitstatus_spec.rb
+++ b/core/process/status/exitstatus_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../../spec_helper'
 
 describe "Process::Status#exitstatus" do
   before :each do
-    ruby_exe("exit(42)", exception: false)
+    ruby_exe("exit(42)", exit_status: 42)
   end
 
   it "returns the process exit code" do
@@ -11,7 +11,7 @@ describe "Process::Status#exitstatus" do
 
   describe "for a child that raised SignalException" do
     before :each do
-      ruby_exe("Process.kill(:KILL, $$); exit(42)", exception: false)
+      ruby_exe("Process.kill(:KILL, $$); exit(42)", exit_status: nil)
     end
 
     platform_is_not :windows do

--- a/core/process/status/signaled_spec.rb
+++ b/core/process/status/signaled_spec.rb
@@ -16,7 +16,7 @@ describe "Process::Status#signaled?" do
   describe "for a terminated child" do
 
     before :each do
-      ruby_exe("Process.kill(:KILL, $$); exit(42)", exception: false)
+      ruby_exe("Process.kill(:KILL, $$); exit(42)", exit_status: nil)
     end
 
     platform_is_not :windows do

--- a/core/process/status/signaled_spec.rb
+++ b/core/process/status/signaled_spec.rb
@@ -16,7 +16,7 @@ describe "Process::Status#signaled?" do
   describe "for a terminated child" do
 
     before :each do
-      ruby_exe("Process.kill(:KILL, $$); exit(42)")
+      ruby_exe("Process.kill(:KILL, $$); exit(42)", exception: false)
     end
 
     platform_is_not :windows do

--- a/core/process/status/success_spec.rb
+++ b/core/process/status/success_spec.rb
@@ -16,7 +16,7 @@ describe "Process::Status#success?" do
   describe "for a child that exited with a non zero status" do
 
     before :each do
-      ruby_exe("exit(42)")
+      ruby_exe("exit(42)", exception: false)
     end
 
     it "returns false" do
@@ -27,7 +27,7 @@ describe "Process::Status#success?" do
   describe "for a child that was terminated" do
 
     before :each do
-      ruby_exe("Process.kill(:KILL, $$); exit(42)")
+      ruby_exe("Process.kill(:KILL, $$); exit(42)", exception: false)
     end
 
     platform_is_not :windows do

--- a/core/process/status/success_spec.rb
+++ b/core/process/status/success_spec.rb
@@ -16,7 +16,7 @@ describe "Process::Status#success?" do
   describe "for a child that exited with a non zero status" do
 
     before :each do
-      ruby_exe("exit(42)", exception: false)
+      ruby_exe("exit(42)", exit_status: 42)
     end
 
     it "returns false" do
@@ -27,7 +27,7 @@ describe "Process::Status#success?" do
   describe "for a child that was terminated" do
 
     before :each do
-      ruby_exe("Process.kill(:KILL, $$); exit(42)", exception: false)
+      ruby_exe("Process.kill(:KILL, $$); exit(42)", exit_status: nil)
     end
 
     platform_is_not :windows do

--- a/core/process/status/termsig_spec.rb
+++ b/core/process/status/termsig_spec.rb
@@ -13,7 +13,7 @@ describe "Process::Status#termsig" do
 
   describe "for a child that raised SignalException" do
     before :each do
-      ruby_exe("raise SignalException, 'SIGTERM'")
+      ruby_exe("raise SignalException, 'SIGTERM'", exception: false)
     end
 
     platform_is_not :windows do
@@ -25,7 +25,7 @@ describe "Process::Status#termsig" do
 
   describe "for a child that was sent a signal" do
     before :each do
-      ruby_exe("Process.kill(:KILL, $$); exit(42)")
+      ruby_exe("Process.kill(:KILL, $$); exit(42)", exception: false)
     end
 
     platform_is_not :windows do

--- a/core/process/status/termsig_spec.rb
+++ b/core/process/status/termsig_spec.rb
@@ -13,7 +13,7 @@ describe "Process::Status#termsig" do
 
   describe "for a child that raised SignalException" do
     before :each do
-      ruby_exe("raise SignalException, 'SIGTERM'", exception: false)
+      ruby_exe("raise SignalException, 'SIGTERM'", exit_status: nil)
     end
 
     platform_is_not :windows do
@@ -25,7 +25,7 @@ describe "Process::Status#termsig" do
 
   describe "for a child that was sent a signal" do
     before :each do
-      ruby_exe("Process.kill(:KILL, $$); exit(42)", exception: false)
+      ruby_exe("Process.kill(:KILL, $$); exit(42)", exit_status: nil)
     end
 
     platform_is_not :windows do

--- a/core/process/status/to_i_spec.rb
+++ b/core/process/status/to_i_spec.rb
@@ -2,12 +2,12 @@ require_relative '../../../spec_helper'
 
 describe "Process::Status#to_i" do
   it "returns an integer when the child exits" do
-    ruby_exe('exit 48', exception: false)
+    ruby_exe('exit 48', exit_status: 48)
     $?.to_i.should be_an_instance_of(Integer)
   end
 
   it "returns an integer when the child is signaled" do
-    ruby_exe('raise SignalException, "TERM"', exception: false)
+    ruby_exe('raise SignalException, "TERM"', exit_status: nil)
     $?.to_i.should be_an_instance_of(Integer)
   end
 end

--- a/core/process/status/to_i_spec.rb
+++ b/core/process/status/to_i_spec.rb
@@ -2,12 +2,12 @@ require_relative '../../../spec_helper'
 
 describe "Process::Status#to_i" do
   it "returns an integer when the child exits" do
-    ruby_exe('exit 48')
+    ruby_exe('exit 48', exception: false)
     $?.to_i.should be_an_instance_of(Integer)
   end
 
   it "returns an integer when the child is signaled" do
-    ruby_exe('raise SignalException, "TERM"')
+    ruby_exe('raise SignalException, "TERM"', exception: false)
     $?.to_i.should be_an_instance_of(Integer)
   end
 end

--- a/core/signal/trap_spec.rb
+++ b/core/signal/trap_spec.rb
@@ -254,7 +254,7 @@ describe "Signal.trap" do
         r.close
         loop { w.write("a"*1024) }
       RUBY
-      out = ruby_exe(code)
+      out = ruby_exe(code, exception: false)
       status = $?
       out.should == "nil\n"
       status.should.signaled?

--- a/core/signal/trap_spec.rb
+++ b/core/signal/trap_spec.rb
@@ -254,7 +254,7 @@ describe "Signal.trap" do
         r.close
         loop { w.write("a"*1024) }
       RUBY
-      out = ruby_exe(code, exception: false)
+      out = ruby_exe(code, exit_status: nil)
       status = $?
       out.should == "nil\n"
       status.should.signaled?

--- a/language/source_encoding_spec.rb
+++ b/language/source_encoding_spec.rb
@@ -29,7 +29,7 @@ describe "Source files" do
 
       touch(path, "wb") { |f| f.write source }
       begin
-        ruby_exe(path, args: "2>&1", exception: false).should =~ /invalid multibyte char/
+        ruby_exe(path, args: "2>&1", exit_status: 1).should =~ /invalid multibyte char/
       ensure
         rm_r path
       end
@@ -51,7 +51,7 @@ describe "Source files" do
 
       touch(path, "wb") { |f| f.write source }
       begin
-        ruby_exe(path, args: "2>&1", exception: false).should =~ /invalid multibyte char/
+        ruby_exe(path, args: "2>&1", exit_status: 1).should =~ /invalid multibyte char/
       ensure
         rm_r path
       end

--- a/language/source_encoding_spec.rb
+++ b/language/source_encoding_spec.rb
@@ -29,7 +29,7 @@ describe "Source files" do
 
       touch(path, "wb") { |f| f.write source }
       begin
-        ruby_exe(path, args: "2>&1").should =~ /invalid multibyte char/
+        ruby_exe(path, args: "2>&1", exception: false).should =~ /invalid multibyte char/
       ensure
         rm_r path
       end
@@ -51,7 +51,7 @@ describe "Source files" do
 
       touch(path, "wb") { |f| f.write source }
       begin
-        ruby_exe(path, args: "2>&1").should =~ /invalid multibyte char/
+        ruby_exe(path, args: "2>&1", exception: false).should =~ /invalid multibyte char/
       ensure
         rm_r path
       end

--- a/shared/process/exit.rb
+++ b/shared/process/exit.rb
@@ -75,25 +75,25 @@ end
 
 describe :process_exit!, shared: true do
   it "exits with the given status" do
-    out = ruby_exe("#{@object}.send(:exit!, 21)", args: '2>&1', exception: false)
+    out = ruby_exe("#{@object}.send(:exit!, 21)", args: '2>&1', exit_status: 21)
     out.should == ""
     $?.exitstatus.should == 21
   end
 
   it "exits when called from a thread" do
-    out = ruby_exe("Thread.new { #{@object}.send(:exit!, 21) }.join; sleep", args: '2>&1', exception: false)
+    out = ruby_exe("Thread.new { #{@object}.send(:exit!, 21) }.join; sleep", args: '2>&1', exit_status: 21)
     out.should == ""
     $?.exitstatus.should == 21
   end
 
   it "exits when called from a fiber" do
-    out = ruby_exe("Fiber.new { #{@object}.send(:exit!, 21) }.resume", args: '2>&1', exception: false)
+    out = ruby_exe("Fiber.new { #{@object}.send(:exit!, 21) }.resume", args: '2>&1', exit_status: 21)
     out.should == ""
     $?.exitstatus.should == 21
   end
 
   it "skips at_exit handlers" do
-    out = ruby_exe("at_exit { STDERR.puts 'at_exit' }; #{@object}.send(:exit!, 21)", args: '2>&1', exception: false)
+    out = ruby_exe("at_exit { STDERR.puts 'at_exit' }; #{@object}.send(:exit!, 21)", args: '2>&1', exit_status: 21)
     out.should == ""
     $?.exitstatus.should == 21
   end
@@ -107,7 +107,7 @@ describe :process_exit!, shared: true do
     end
     raise 'original error'
     RUBY
-    out = ruby_exe(code, args: '2>&1', exception: false)
+    out = ruby_exe(code, args: '2>&1', exit_status: 21)
     out.should == "in at_exit\n$! is RuntimeError:original error\n"
     $?.exitstatus.should == 21
   end

--- a/shared/process/exit.rb
+++ b/shared/process/exit.rb
@@ -75,25 +75,25 @@ end
 
 describe :process_exit!, shared: true do
   it "exits with the given status" do
-    out = ruby_exe("#{@object}.send(:exit!, 21)", args: '2>&1')
+    out = ruby_exe("#{@object}.send(:exit!, 21)", args: '2>&1', exception: false)
     out.should == ""
     $?.exitstatus.should == 21
   end
 
   it "exits when called from a thread" do
-    out = ruby_exe("Thread.new { #{@object}.send(:exit!, 21) }.join; sleep", args: '2>&1')
+    out = ruby_exe("Thread.new { #{@object}.send(:exit!, 21) }.join; sleep", args: '2>&1', exception: false)
     out.should == ""
     $?.exitstatus.should == 21
   end
 
   it "exits when called from a fiber" do
-    out = ruby_exe("Fiber.new { #{@object}.send(:exit!, 21) }.resume", args: '2>&1')
+    out = ruby_exe("Fiber.new { #{@object}.send(:exit!, 21) }.resume", args: '2>&1', exception: false)
     out.should == ""
     $?.exitstatus.should == 21
   end
 
   it "skips at_exit handlers" do
-    out = ruby_exe("at_exit { STDERR.puts 'at_exit' }; #{@object}.send(:exit!, 21)", args: '2>&1')
+    out = ruby_exe("at_exit { STDERR.puts 'at_exit' }; #{@object}.send(:exit!, 21)", args: '2>&1', exception: false)
     out.should == ""
     $?.exitstatus.should == 21
   end
@@ -107,7 +107,7 @@ describe :process_exit!, shared: true do
     end
     raise 'original error'
     RUBY
-    out = ruby_exe(code, args: '2>&1')
+    out = ruby_exe(code, args: '2>&1', exception: false)
     out.should == "in at_exit\n$! is RuntimeError:original error\n"
     $?.exitstatus.should == 21
   end


### PR DESCRIPTION
Prepared specs to pass with not merged yet changes in MSpec (https://github.com/ruby/mspec/pull/49).

Changes:
- changed every test case where Ruby script (which is run with `ruby_exec` helper) exits with failed status (expected failure)
- specified introduced `exception: false` option.