### PR TITLE
[Ruby 2.7] Specs for #ruby2_keywords

### DIFF
--- a/core/module/ruby2_keywords_spec.rb
+++ b/core/module/ruby2_keywords_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
 ruby_version_is "2.7" do
-  describe "Module.ruby2_keywords" do
+  describe "Module#ruby2_keywords" do
     it "marks the final hash argument as keyword hash" do
       obj = Object.new
 
@@ -16,7 +16,7 @@ ruby_version_is "2.7" do
     end
 
     ruby_version_is "2.7" ... "3.0" do
-      it "suppresses deprecation warning" do
+      it "fixes delegation warnings when calling a method accepting keywords" do
         obj = Object.new
 
         obj.singleton_class.class_exec do
@@ -54,7 +54,7 @@ ruby_version_is "2.7" do
       }.should raise_error(NameError, /undefined method `not_existing'/)
     end
 
-    it "excepts String as well" do
+    it "acceps String as well" do
       obj = Object.new
 
       obj.singleton_class.class_exec do

--- a/core/module/ruby2_keywords_spec.rb
+++ b/core/module/ruby2_keywords_spec.rb
@@ -1,0 +1,112 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+ruby_version_is "2.7" do
+  describe "Module.ruby2_keywords" do
+    it "marks the final hash argument as keyword hash" do
+      obj = Object.new
+
+      obj.singleton_class.class_exec do
+        def foo(*a) a.last end
+        ruby2_keywords :foo
+      end
+
+      last = obj.foo(1, 2, a: "a")
+      Hash.ruby2_keywords_hash?(last).should == true
+    end
+
+    ruby_version_is "2.7" ... "3.0" do
+      it "suppresses deprecation warning" do
+        obj = Object.new
+
+        obj.singleton_class.class_exec do
+          def foo(*a) bar(*a) end
+          def bar(*a, **b) end
+        end
+
+        -> { obj.foo(1, 2, {a: "a"}) }.should complain(/Using the last argument as keyword parameters is deprecated/)
+
+        obj.singleton_class.class_exec do
+          ruby2_keywords :foo
+        end
+
+        -> { obj.foo(1, 2, {a: "a"}) }.should_not complain
+      end
+    end
+
+    it "returns nil" do
+      obj = Object.new
+
+      obj.singleton_class.class_exec do
+        def foo(*a) end
+
+        ruby2_keywords(:foo).should == nil
+      end
+    end
+
+    it "raises NameError when passed not existing method name" do
+      obj = Object.new
+
+      -> {
+        obj.singleton_class.class_exec do
+          ruby2_keywords :not_existing
+        end
+      }.should raise_error(NameError, /undefined method `not_existing'/)
+    end
+
+    it "excepts String as well" do
+      obj = Object.new
+
+      obj.singleton_class.class_exec do
+        def foo(*a) a.last end
+        ruby2_keywords "foo"
+      end
+
+      last = obj.foo(1, 2, a: "a")
+      Hash.ruby2_keywords_hash?(last).should == true
+    end
+
+    it "raises TypeError when passed not Symbol or String" do
+      obj = Object.new
+
+      -> {
+        obj.singleton_class.class_exec do
+          ruby2_keywords Object.new
+        end
+      }.should raise_error(TypeError, /is not a symbol nor a string/)
+    end
+
+    it "prints warning when a method does not accept argument splat" do
+      obj = Object.new
+      def obj.foo(a, b, c) end
+
+      -> {
+        obj.singleton_class.class_exec do
+          ruby2_keywords :foo
+        end
+      }.should complain(/Skipping set of ruby2_keywords flag for/)
+    end
+
+    it "prints warning when a method accepts keywords" do
+      obj = Object.new
+      def obj.foo(a:, b:) end
+
+      -> {
+        obj.singleton_class.class_exec do
+          ruby2_keywords :foo
+        end
+      }.should complain(/Skipping set of ruby2_keywords flag for/)
+    end
+
+    it "prints warning when a method accepts keyword splat" do
+      obj = Object.new
+      def obj.foo(**a) end
+
+      -> {
+        obj.singleton_class.class_exec do
+          ruby2_keywords :foo
+        end
+      }.should complain(/Skipping set of ruby2_keywords flag for/)
+    end
+  end
+end

--- a/core/proc/ruby2_keywords_spec.rb
+++ b/core/proc/ruby2_keywords_spec.rb
@@ -11,7 +11,7 @@ ruby_version_is "2.7" do
     end
 
     ruby_version_is "2.7" ... "3.0" do
-      it "suppresses deprecation warning when calls a method" do
+      it "fixes delegation warnings when calling a method accepting keywords" do
         obj = Object.new
         def obj.foo(*a, **b) end
 
@@ -22,7 +22,7 @@ ruby_version_is "2.7" do
         -> { f.call(1, 2, {a: "a"}) }.should_not complain
       end
 
-      it "suppresses deprecation warning when calls another proc" do
+      it "fixes delegation warnings when calling a proc accepting keywords" do
         g = -> *a, **b { }
         f = -> *a { g.call(*a) }
 

--- a/core/proc/ruby2_keywords_spec.rb
+++ b/core/proc/ruby2_keywords_spec.rb
@@ -1,0 +1,64 @@
+require_relative '../../spec_helper'
+
+ruby_version_is "2.7" do
+  describe "Proc#ruby2_keywords" do
+    it "marks the final hash argument as keyword hash" do
+      f = -> *a { a.last }
+      f.ruby2_keywords
+
+      last = f.call(1, 2, a: "a")
+      Hash.ruby2_keywords_hash?(last).should == true
+    end
+
+    ruby_version_is "2.7" ... "3.0" do
+      it "suppresses deprecation warning when calls a method" do
+        obj = Object.new
+        def obj.foo(*a, **b) end
+
+        f = -> *a { obj.foo(*a) }
+
+        -> { f.call(1, 2, {a: "a"}) }.should complain(/Using the last argument as keyword parameters is deprecated/)
+        f.ruby2_keywords
+        -> { f.call(1, 2, {a: "a"}) }.should_not complain
+      end
+
+      it "suppresses deprecation warning when calls another proc" do
+        g = -> *a, **b { }
+        f = -> *a { g.call(*a) }
+
+        -> { f.call(1, 2, {a: "a"}) }.should complain(/Using the last argument as keyword parameters is deprecated/)
+        f.ruby2_keywords
+        -> { f.call(1, 2, {a: "a"}) }.should_not complain
+      end
+    end
+
+    it "returns self" do
+      f = -> *a { }
+      f.ruby2_keywords.should equal f
+    end
+
+    it "prints warning when a proc does not accept argument splat" do
+      f = -> a, b, c { }
+
+      -> {
+        f.ruby2_keywords
+      }.should complain(/Skipping set of ruby2_keywords flag for/)
+    end
+
+    it "prints warning when a proc accepts keywords" do
+      f = -> a:, b: { }
+
+      -> {
+        f.ruby2_keywords
+      }.should complain(/Skipping set of ruby2_keywords flag for/)
+    end
+
+    it "prints warning when a proc accepts keyword splat" do
+      f = -> **a { }
+
+      -> {
+        f.ruby2_keywords
+      }.should complain(/Skipping set of ruby2_keywords flag for/)
+    end
+  end
+end


### PR DESCRIPTION
Added specs for new methods introduced in Ruby 2.7
- `Proc#ruby2_keywords`
- `Module#ruby2_keywords`

Related issue - https://github.com/ruby/spec/issues/745