### PR TITLE
Add a spec for Pathname#inspect

### DIFF
--- a/library/pathname/inspect_spec.rb
+++ b/library/pathname/inspect_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../spec_helper'
+require 'pathname'
+
+describe "Pathname#inspect" do
+  it "returns a consistent String" do
+    result = Pathname.new('/tmp').inspect
+    result.should be_an_instance_of(String)
+    result.should == "#<Pathname:/tmp>"
+  end
+end


### PR DESCRIPTION
I am not sure if this should be integrated or not in RubySpec, but opening the PR in case and I'll let you judge :smile:

This was triggered by my investigation on https://github.com/jruby/jruby/issues/6519.