### PR TITLE
add spec for `Symbol#name` to be `frozen?`

### DIFF
--- a/core/symbol/name_spec.rb
+++ b/core/symbol/name_spec.rb
@@ -2,13 +2,17 @@ require_relative '../../spec_helper'
 
 ruby_version_is "3.0" do
   describe "Symbol#name" do
-    it "returns a string" do
+    it "returns string" do
       :ruby.name.should == "ruby"
       :ルビー.name.should == "ルビー"
-      :"ruby_#{1+2}".name.should == "ruby_3"
     end
 
-    it "returns a frozen string" do
+    it "returns same string instance" do
+      :"ruby_3".name.should.equal?(:ruby_3.name)
+      :"ruby_#{1+2}".name.should.equal?(:ruby_3.name)
+    end
+
+    it "returns frozen string" do
       :symbol.name.should.frozen?
     end
   end

--- a/core/symbol/name_spec.rb
+++ b/core/symbol/name_spec.rb
@@ -2,6 +2,12 @@ require_relative '../../spec_helper'
 
 ruby_version_is "3.0" do
   describe "Symbol#name" do
+    it "returns a string" do
+      :ruby.name.should == "ruby"
+      :ルビー.name.should == "ルビー"
+      :"ruby_#{1+2}".name.should == "ruby_3"
+    end
+
     it "returns a frozen string" do
       :symbol.name.should.frozen?
     end

--- a/core/symbol/name_spec.rb
+++ b/core/symbol/name_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../../spec_helper'
+
+ruby_version_is "3.0" do
+  describe "Symbol#name" do
+    it "returns a frozen string" do
+      :symbol.name.should.frozen?
+    end
+  end
+end


### PR DESCRIPTION
Hello 👋 

Here's my attempt on `Symbol#name` from #823

> Symbol#name has been added, which returns the name of the symbol
if it is named. The returned string is frozen. [Feature #16150](https://bugs.ruby-lang.org/issues/16150)

I am looking forward to getting feedback.