### PR TITLE
add spec for ENV.except

### DIFF
--- a/core/env/except_spec.rb
+++ b/core/env/except_spec.rb
@@ -1,0 +1,36 @@
+require_relative 'spec_helper'
+require_relative 'shared/to_hash'
+
+ruby_version_is "3.0" do
+  describe "ENV.except" do
+    before do
+      @orig_hash = ENV.to_hash
+    end
+
+    after do
+      ENV.replace @orig_hash
+    end
+
+    # Testing the method without arguments is covered via
+    it_behaves_like :env_to_hash, :except
+
+    it "returns a hash without the requested subset" do
+      ENV.clear
+
+      ENV['one'] = '1'
+      ENV['two'] = '2'
+      ENV['three'] = '3'
+
+      ENV.except('one', 'three').should == { 'two' => '2' }
+    end
+
+    it "ignores keys not present in the original hash" do
+      ENV.clear
+
+      ENV['one'] = '1'
+      ENV['two'] = '2'
+
+      ENV.except('one', 'three').should == { 'two' => '2' }
+    end
+  end
+end


### PR DESCRIPTION
Hello 👋 

Here's my take on `ENV.except` from #823 

> ENV.except has been added, which returns a hash excluding the
given keys and their values. [Feature #15822](https://bugs.ruby-lang.org/issues/15822)

Two notes:

* Creating the spec for `ENV.except` using `../mspec/bin/mkspec -b core -c ENV` didn't work, I created the file manually.
* Testing `.except` without arguments is covered via `it_behaves_like :env_to_hash, :except` which is not super-obvious, I guess.

Please letme know if you like any changes etc.

Thanks, as always. 🙌 