### PR TITLE
methods on array subclass return array instance

### DIFF
--- a/core/array/drop_spec.rb
+++ b/core/array/drop_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
 
 describe "Array#drop" do
   it "removes the specified number of elements from the start of the array" do
@@ -47,5 +48,17 @@ describe "Array#drop" do
     obj.should_receive(:to_int).and_return("cat")
 
     -> { [1, 2].drop(obj) }.should raise_error(TypeError)
+  end
+
+  ruby_version_is ''...'3.0' do
+    it 'returns a subclass instance for Array subclasses' do
+      ArraySpecs::MyArray[1, 2, 3, 4, 5].drop(1).should be_an_instance_of(ArraySpecs::MyArray)
+    end
+  end
+
+  ruby_version_is '3.0' do
+    it 'returns a Array instance for Array subclasses' do
+      ArraySpecs::MyArray[1, 2, 3, 4, 5].drop(1).should be_an_instance_of(Array)
+    end
   end
 end

--- a/core/array/drop_while_spec.rb
+++ b/core/array/drop_while_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
 
 describe "Array#drop_while" do
   it "removes elements from the start of the array while the block evaluates to true" do
@@ -11,5 +12,17 @@ describe "Array#drop_while" do
 
   it "removes elements from the start of the array until the block returns false" do
     [1, 2, 3, false, 5].drop_while { |n| n }.should == [false, 5]
+  end
+
+  ruby_version_is ''...'3.0' do
+    it 'returns a subclass instance for Array subclasses' do
+      ArraySpecs::MyArray[1, 2, 3, 4, 5].drop_while { |n| n < 4 }.should be_an_instance_of(ArraySpecs::MyArray)
+    end
+  end
+
+  ruby_version_is '3.0' do
+    it 'returns a Array instance for Array subclasses' do
+      ArraySpecs::MyArray[1, 2, 3, 4, 5].drop_while { |n| n < 4 }.should be_an_instance_of(Array)
+    end
   end
 end

--- a/core/array/slice_spec.rb
+++ b/core/array/slice_spec.rb
@@ -185,6 +185,64 @@ describe "Array#slice!" do
       a.should == [3, 4]
     end
   end
+
+  describe "with a subclass of Array" do
+    before :each do
+      @array = ArraySpecs::MyArray[1, 2, 3, 4, 5]
+    end
+
+    ruby_version_is ''...'3.0' do
+      it "returns a subclass instance with [n, m]" do
+        @array.slice!(0, 2).should be_an_instance_of(ArraySpecs::MyArray)
+      end
+
+      it "returns a subclass instance with [-n, m]" do
+        @array.slice!(-3, 2).should be_an_instance_of(ArraySpecs::MyArray)
+      end
+
+      it "returns a subclass instance with [n..m]" do
+        @array.slice!(1..3).should be_an_instance_of(ArraySpecs::MyArray)
+      end
+
+      it "returns a subclass instance with [n...m]" do
+        @array.slice!(1...3).should be_an_instance_of(ArraySpecs::MyArray)
+      end
+
+      it "returns a subclass instance with [-n..-m]" do
+        @array.slice!(-3..-1).should be_an_instance_of(ArraySpecs::MyArray)
+      end
+
+      it "returns a subclass instance with [-n...-m]" do
+        @array.slice!(-3...-1).should be_an_instance_of(ArraySpecs::MyArray)
+      end
+    end
+
+    ruby_version_is '3.0' do
+      it "returns a Array instance with [n, m]" do
+        @array.slice!(0, 2).should be_an_instance_of(Array)
+      end
+
+      it "returns a Array instance with [-n, m]" do
+        @array.slice!(-3, 2).should be_an_instance_of(Array)
+      end
+
+      it "returns a Array instance with [n..m]" do
+        @array.slice!(1..3).should be_an_instance_of(Array)
+      end
+
+      it "returns a Array instance with [n...m]" do
+        @array.slice!(1...3).should be_an_instance_of(Array)
+      end
+
+      it "returns a Array instance with [-n..-m]" do
+        @array.slice!(-3..-1).should be_an_instance_of(Array)
+      end
+
+      it "returns a Array instance with [-n...-m]" do
+        @array.slice!(-3...-1).should be_an_instance_of(Array)
+      end
+    end
+  end
 end
 
 describe "Array#slice" do

--- a/core/array/take_spec.rb
+++ b/core/array/take_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
 
 describe "Array#take" do
   it "returns the first specified number of elements" do
@@ -23,5 +24,17 @@ describe "Array#take" do
 
   it "raises an ArgumentError when the argument is negative" do
     ->{ [1].take(-3) }.should raise_error(ArgumentError)
+  end
+
+  ruby_version_is ''...'3.0' do
+    it 'returns a subclass instance for Array subclasses' do
+      ArraySpecs::MyArray[1, 2, 3, 4, 5].take(1).should be_an_instance_of(ArraySpecs::MyArray)
+    end
+  end
+
+  ruby_version_is '3.0' do
+    it 'returns a Array instance for Array subclasses' do
+      ArraySpecs::MyArray[1, 2, 3, 4, 5].take(1).should be_an_instance_of(Array)
+    end
   end
 end

--- a/core/array/take_while_spec.rb
+++ b/core/array/take_while_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
 
 describe "Array#take_while" do
   it "returns all elements until the block returns false" do
@@ -11,5 +12,17 @@ describe "Array#take_while" do
 
   it "returns all elements until the block returns false" do
     [1, 2, false, 4].take_while{ |element| element }.should == [1, 2]
+  end
+
+  ruby_version_is ''...'3.0' do
+    it 'returns a subclass instance for Array subclasses' do
+      ArraySpecs::MyArray[1, 2, 3, 4, 5].take_while { |n| n < 4 }.should be_an_instance_of(ArraySpecs::MyArray)
+    end
+  end
+
+  ruby_version_is '3.0' do
+    it 'returns a Array instance for Array subclasses' do
+      ArraySpecs::MyArray[1, 2, 3, 4, 5].take_while { |n| n < 4 }.should be_an_instance_of(Array)
+    end
   end
 end


### PR DESCRIPTION
HI, here is a spec for #823,

> The following methods now return Array instances instead of
> subclass instances when called on subclass instances:
> [Bug #6087]
> 
> Array#drop
> Array#drop_while
> Array#flatten
> Array#slice!
> Array#slice / Array#[]
> Array#take
> Array#take_while
> Array#uniq
> Array#*

This PR will add spec to cover `drop, drop_while, take, take_while, slice!`
Other methods are already covered with spec:

`Array#flatten`
https://github.com/ruby/spec/blob/7526ccb1ce706a8d6548cdc46d56bf89f1518412/core/array/flatten_spec.rb#L78-L96

`Array#slice`
https://github.com/ruby/spec/blob/7526ccb1ce706a8d6548cdc46d56bf89f1518412/core/array/shared/slice.rb#L393-L450

`Array#uniq`
https://github.com/ruby/spec/blob/7526ccb1ce706a8d6548cdc46d56bf89f1518412/core/array/uniq_spec.rb#L131-L141

`Array#*`
https://github.com/ruby/spec/blob/7526ccb1ce706a8d6548cdc46d56bf89f1518412/core/array/multiply_spec.rb#L79-L93

Thanks 👍 