### PR TITLE
don't use identity comparison on floats

### DIFF
--- a/core/kernel/rand_spec.rb
+++ b/core/kernel/rand_spec.rb
@@ -131,8 +131,8 @@ describe "Kernel.rand" do
       x3 = Random.new(seed).rand(0.0..1)
 
       x3.should be_kind_of(Float)
-      x1.should equal(x3)
-      x2.should equal(x3)
+      x1.should eql(x3)
+      x2.should eql(x3)
 
       (0.0..1.0).should include(x3)
     end
@@ -152,8 +152,8 @@ describe "Kernel.rand" do
       x3 = Random.new(seed).rand(0.0...1)
 
       x3.should be_kind_of(Float)
-      x1.should equal(x3)
-      x2.should equal(x3)
+      x1.should eql(x3)
+      x2.should eql(x3)
 
       (0.0...1.0).should include(x3)
     end


### PR DESCRIPTION
MRI has a feature called float-nums. A side effect of this optimization is that **small floats** are represented as the same object.
```
 1.2.eql? 1.2  => true
 1.2.equal? 1.2   => true
```

however, JRuby doesn't have it, so there's a difference
```
 1.2.eql? 1.2  => true
 1.2.equal? 1.2 => false
```

this fixes two failures https://github.com/jruby/jruby/pull/6543
```
fails:Kernel.rand given an inclusive range between 0 and 1 returns a Float if at least one side is Float
fails:Kernel.rand given an exclusive range between 0 and 1 returns a Float if at least one side is Float
```

Expected 0.3745401144950984 to be identical to 0.3745401144950984

I believe these tests shouldn't rely on the internal implementation detail.