### PR TITLE
Add string-like test for Regexp#===

### DIFF
--- a/core/regexp/case_compare_spec.rb
+++ b/core/regexp/case_compare_spec.rb
@@ -22,4 +22,14 @@ describe "Regexp#===" do
     (/abc/ === nil).should be_false
     (/abc/ === /abc/).should be_false
   end
+
+  it "uses #to_str on string-like objects" do
+    stringlike = Class.new do
+      def to_str
+        "abc"
+      end
+    end.new
+
+    (/abc/ === stringlike).should be_true
+  end
 end


### PR DESCRIPTION
Adds test to ensure case comparison on Regexp instances compare string-like objects by calling `#to_str` on them.