### PR TITLE
Matrix#** accept 0 from 3.1.x

### DIFF
--- a/library/matrix/exponent_spec.rb
+++ b/library/matrix/exponent_spec.rb
@@ -34,7 +34,7 @@ describe "Matrix#**" do
       end
     end
 
-    ruby_version_is '3.0.1' do # https://bugs.ruby-lang.org/issues/17521
+    ruby_version_is '3.1' do # https://bugs.ruby-lang.org/issues/17521
       describe "that is 0" do
         it "returns the identity for square matrices" do
           m = Matrix[ [1, 1], [1, 1] ]


### PR DESCRIPTION
The changeset  https://github.com/ruby/ruby/commit/d8c8b79d24bf0f3177535501ad9b801e552fb2ad introduce the spec for Matrix#** in ruby/ruby repo and it was slightly changed on ruby/spec to expect ruby-3.0.1 to behave like current master.

But I don't want to backport this behavior change into ruby_3_0.

See https://bugs.ruby-lang.org/issues/17521 too.

To fix failures in RubyCI, I'd like to run the spec on only 3.1 (master).