### PR TITLE
partially backported spec change of Hash#transform_keys!

### DIFF
--- a/core/hash/transform_keys_spec.rb
+++ b/core/hash/transform_keys_spec.rb
@@ -84,13 +84,23 @@ describe "Hash#transform_keys!" do
     end
   end
 
-  ruby_version_is "2.5.1" do
+  ruby_version_is "2.5.1"..."3.0" do
     it "returns the processed keys if we broke from the block" do
       @hash.transform_keys! do |v|
         break if v == :c
         v.succ
       end
       @hash.should == { b: 1, c: 2 }
+    end
+  end
+
+  ruby_version_is "3.0" do
+    it "returns the processed keys and non evaluated keys if we broke from the block" do
+      @hash.transform_keys! do |v|
+        break if v == :c
+        v.succ
+      end
+      @hash.should == { b: 1, c: 2, d: 4 }
     end
   end
 


### PR DESCRIPTION
I backported the change of Hash#transform_keys! into ruby_3_0.

https://bugs.ruby-lang.org/issues/17735

This PR should stop the test-spec failures on RubyCI.
see the commits below too.

https://github.com/ruby/ruby/commit/31e0382723bfb35cffe3ca485dd0577668cafa07
https://github.com/ruby/ruby/commit/84d9a9afc0b49d095541acb9832f8b12fb506e19