### PR TITLE
Add a ruby version guard to the checks of float literals as hash key

### DIFF
--- a/language/hash_spec.rb
+++ b/language/hash_spec.rb
@@ -58,11 +58,16 @@ describe "Hash literal" do
     }.should complain(/key 1000 is duplicated|duplicated key/)
     @h.keys.size.should == 1
     @h.should == {1000 => :foo}
-    -> {
-      @h = eval "{1.0 => :bar, 1.0 => :foo}"
-    }.should complain(/key 1.0 is duplicated|duplicated key/)
-    @h.keys.size.should == 1
-    @h.should == {1.0 => :foo}
+  end
+
+  ruby_version_is "3.1" do
+    it "checks duplicated float keys on initialization" do
+      -> {
+        @h = eval "{1.0 => :bar, 1.0 => :foo}"
+      }.should complain(/key 1.0 is duplicated|duplicated key/)
+      @h.keys.size.should == 1
+      @h.should == {1.0 => :foo}
+    end
   end
 
   it "accepts a hanging comma" do


### PR DESCRIPTION
This check was introduced in MRI on master branch only in commit  https://github.com/ruby/ruby/commit/37eb5e74395f148782f7d67b5218fb2e66b113d7

The check works on older ruby versions without the above commit, but only when the system is a 64 bit architecture and is using flonums. However on 32 bit systems float literals are not warned, which therefore leads to a spec failure.

A failing test looks like so: https://github.com/oneclick/rubyinstaller2/runs/3025377467?check_suite_focus=true#step:30:27