### PR TITLE
Add spec for behavior of autoload in Class.new

### DIFF
--- a/core/kernel/autoload_spec.rb
+++ b/core/kernel/autoload_spec.rb
@@ -56,6 +56,20 @@ describe "Kernel#autoload" do
     end
   end
 
+  describe "inside a Class.new method body" do
+    it "should define on the new anonymous class" do
+      cls = Class.new do
+        def go
+          autoload :Object, 'bogus'
+          autoload? :Object
+        end
+      end
+
+      cls.new.go.should == 'bogus'
+      cls.autoload?(:Object).should == 'bogus'
+    end
+  end
+
   describe "when Object is frozen" do
     it "raises a FrozenError before defining the constant" do
       ruby_exe(fixture(__FILE__, "autoload_frozen.rb")).should == "FrozenError - nil"


### PR DESCRIPTION
The spec added here defines current behavior of CRuby in which a bare `autoload` called from an instance method inside a `Class.new` should be defined on that new class. This differs from constant lookup, which will skip the new class and use whatever "concrete" class scope is above it.

As noted in the commit, this behavior is problematic at least because this autoload and a parallel constant lookup will go to different target classes due to autoload using CRuby's concept of "cbase" and constant lookup using "cref".

This behavior changed sometime after Ruby 1.8.7. Prior to the change, the autoload appears to use the same "cref" target that constants use.

I push this spec as a PR to discuss whether this is correct behavior. I believe it is unexpected and should be deprecated, with `Kernel#autoload` being modified in the future to always target the same "cref" class that would be used for defining constants in the given scope.

All alternative implementations of Ruby I tested fail this spec.