### PR TITLE
Artichoke runs a subset of ruby/spec on every commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ ruby/spec is known to be tested in these implementations for every commit:
 * [JRuby](https://github.com/jruby/jruby/tree/master/spec/ruby) for both 1.7 and 9.x
 * [TruffleRuby](https://github.com/oracle/truffleruby/tree/master/spec/ruby)
 * [Opal](https://github.com/opal/opal/tree/master/spec)
+* [Artichoke](https://github.com/artichoke/spec/tree/artichoke-vendor)
 
 ruby/spec describes the behavior of Ruby 2.6 and more recent Ruby versions.
 More precisely, every latest stable MRI release should [pass](https://github.com/ruby/spec/actions/workflows/ci.yml) all specs of ruby/spec (2.6.x, 2.7.x, 3.0.x, etc), and those are tested in CI.


### PR DESCRIPTION
See artichoke/artichoke#1328.
See https://github.com/artichoke/spec-state.

The CI machinery for this setup is here: https://github.com/artichoke/artichoke/blob/566e77538d7deac076b35653ccd983152d1f884e/.github/workflows/spec-state.yaml.

cc @eregon.

Artichoke pins a version of ruby/spec which is (roughly) vendored into artichoke/artichoke:

- https://github.com/artichoke/spec/tree/artichoke-vendor
- https://github.com/artichoke/artichoke/tree/566e77538d7deac076b35653ccd983152d1f884e/spec-runner/vendor/spec