### PR TITLE
Fix a spec failure for RbConfig::CONFIG['sitelibdir'] and $LOAD_PATH.

### DIFF
--- a/library/rbconfig/rbconfig_spec.rb
+++ b/library/rbconfig/rbconfig_spec.rb
@@ -26,7 +26,7 @@ describe 'RbConfig::CONFIG' do
     it "['sitelibdir'] is set and is part of $LOAD_PATH" do
       sitelibdir = RbConfig::CONFIG['sitelibdir']
       sitelibdir.should be_kind_of String
-      $LOAD_PATH.should.include? sitelibdir
+      $LOAD_PATH.map{|path| File.realpath(path) rescue path }.should.include? sitelibdir
     end
   end
 


### PR DESCRIPTION
The spec about `RbConfig::CONFIG['sitelibdir']` is failed on some RubyCI environments with ruby_3_0 branch.
ex) http://rubyci.s3.amazonaws.com/archlinux/ruby-3.0/log/20210821T110833Z.fail.html.gz
http://rubyci.s3.amazonaws.com/rhel_zlinux/ruby-3.0/log/20210821T095237Z.fail.html.gz

These environments look like use symbolic links for configure's `--prefix` option. The `RbConfig::CONFIG["sitelibdir"]` (according to `RbConfig::CONFIG["prefix"]`)  is resolved to the realpath. But `$LOAD_PATH` contains the path including symbolic link.

I have confirmed that the ruby's master (3.2) should failed with the spec. The tests for master branch on RubyCI are green because the problematic spec wasn't run on the master branch. Because the chkbuild configurations are different from 3.0 branch and the specs with `guard ->{ RbConfig::TOPDIR }` were excluded.