### PR TITLE
Add spec for Array#intersect? in Ruby 3.1

### DIFF
--- a/core/array/intersect_spec.rb
+++ b/core/array/intersect_spec.rb
@@ -1,0 +1,17 @@
+require_relative '../../spec_helper'
+
+describe 'Array#intersect?' do
+  ruby_version_is '3.1' do # https://bugs.ruby-lang.org/issues/15198
+    describe 'when at least one element in two Arrays is the same' do
+      it 'returns true' do
+        [1, 2].intersect?([2, 3]).should == true
+      end
+    end
+
+    describe 'when there are no elements in common between two Arrays' do
+      it 'returns false' do
+        [1, 2].intersect?([3, 4]).should == false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add spec for `Array#intersect?` in Ruby 3.1