### PR TITLE
garbage_collect should except keywords arguments

### DIFF
--- a/core/objectspace/garbage_collect_spec.rb
+++ b/core/objectspace/garbage_collect_spec.rb
@@ -7,7 +7,7 @@ describe "ObjectSpace.garbage_collect" do
   end
 
   it "accepts keyword arguments" do
-    -> { ObjectSpace.garbage_collect(full_mark: true, immediate_sweep: true) }.should == nil
+    ObjectSpace.garbage_collect(full_mark: true, immediate_sweep: true).should == nil
   end
 
   it "ignores the supplied block" do

--- a/core/objectspace/garbage_collect_spec.rb
+++ b/core/objectspace/garbage_collect_spec.rb
@@ -6,8 +6,8 @@ describe "ObjectSpace.garbage_collect" do
     -> { ObjectSpace.garbage_collect }.should_not raise_error
   end
 
-  it "doesn't accept any arguments" do
-    -> { ObjectSpace.garbage_collect(1) }.should raise_error(ArgumentError)
+  it "accepts keyword arguments" do
+    -> { ObjectSpace.garbage_collect(full_mark: true, immediate_sweep: true) }.should == nil
   end
 
   it "ignores the supplied block" do


### PR DESCRIPTION
Since [2.1.0](https://ruby-doc.org/core-2.1.0/ObjectSpace.html#method-c-garbage_collect)