### PR TITLE
returns String instances when called on a subclass in Ruby 3.0.0

### DIFF
--- a/core/string/lstrip_spec.rb
+++ b/core/string/lstrip_spec.rb
@@ -1,7 +1,10 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative 'shared/strip'
 
 describe "String#lstrip" do
+  it_behaves_like :string_strip, :lstrip
+
   it "returns a copy of self with leading whitespace removed" do
    "  hello  ".lstrip.should == "hello  "
    "  hello world  ".lstrip.should == "hello world  "

--- a/core/string/partition_spec.rb
+++ b/core/string/partition_spec.rb
@@ -1,7 +1,10 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative 'shared/partition'
 
 describe "String#partition with String" do
+  it_behaves_like :string_partition, :partition
+
   it "returns an array of substrings based on splitting on the given string" do
     "hello world".partition("o").should == ["hell", "o", " world"]
   end

--- a/core/string/reverse_spec.rb
+++ b/core/string/reverse_spec.rb
@@ -10,6 +10,22 @@ describe "String#reverse" do
     "".reverse.should == ""
   end
 
+  ruby_version_is '3.0' do
+    it "returns String instances when called on a subclass" do
+      StringSpecs::MyString.new("stressed").reverse.should be_an_instance_of(String)
+      StringSpecs::MyString.new("m").reverse.should be_an_instance_of(String)
+      StringSpecs::MyString.new("").reverse.should be_an_instance_of(String)
+    end
+  end
+
+  ruby_version_is ''...'3.0.0' do
+    it "returns subclass instances when called on a subclass" do
+      StringSpecs::MyString.new("stressed").reverse.should be_an_instance_of(StringSpecs::MyString)
+      StringSpecs::MyString.new("m").reverse.should be_an_instance_of(StringSpecs::MyString)
+      StringSpecs::MyString.new("").reverse.should be_an_instance_of(StringSpecs::MyString)
+    end
+  end
+
   ruby_version_is ''...'2.7' do
     it "taints the result if self is tainted" do
       "".taint.reverse.should.tainted?
@@ -20,7 +36,6 @@ describe "String#reverse" do
   it "reverses a string with multi byte characters" do
     "微軟正黑體".reverse.should == "體黑正軟微"
   end
-
 end
 
 describe "String#reverse!" do

--- a/core/string/reverse_spec.rb
+++ b/core/string/reverse_spec.rb
@@ -18,7 +18,7 @@ describe "String#reverse" do
     end
   end
 
-  ruby_version_is ''...'3.0.0' do
+  ruby_version_is ''...'3.0' do
     it "returns subclass instances when called on a subclass" do
       StringSpecs::MyString.new("stressed").reverse.should be_an_instance_of(StringSpecs::MyString)
       StringSpecs::MyString.new("m").reverse.should be_an_instance_of(StringSpecs::MyString)

--- a/core/string/rpartition_spec.rb
+++ b/core/string/rpartition_spec.rb
@@ -1,7 +1,10 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative 'shared/partition'
 
 describe "String#rpartition with String" do
+  it_behaves_like :string_partition, :rpartition
+
   it "returns an array of substrings based on splitting on the given string" do
     "hello world".rpartition("o").should == ["hello w", "o", "rld"]
   end

--- a/core/string/rstrip_spec.rb
+++ b/core/string/rstrip_spec.rb
@@ -1,7 +1,10 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative 'shared/strip'
 
 describe "String#rstrip" do
+  it_behaves_like :string_strip, :rstrip
+
   it "returns a copy of self with trailing whitespace removed" do
     "  hello  ".rstrip.should == "  hello"
     "  hello world  ".rstrip.should == "  hello world"

--- a/core/string/scrub_spec.rb
+++ b/core/string/scrub_spec.rb
@@ -34,7 +34,7 @@ describe "String#scrub with a default replacement" do
     end
   end
 
-  ruby_version_is ''...'3.0.0' do
+  ruby_version_is ''...'3.0' do
     it "returns subclass instances when called on a subclass" do
       StringSpecs::MyString.new("foo").scrub.should be_an_instance_of(StringSpecs::MyString)
     end

--- a/core/string/scrub_spec.rb
+++ b/core/string/scrub_spec.rb
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
 
 describe "String#scrub with a default replacement" do
   it "returns self for valid strings" do
@@ -19,11 +20,24 @@ describe "String#scrub with a default replacement" do
     input.scrub.should == "foo"
   end
 
-
   it "replaces invalid byte sequences when using ASCII as the input encoding" do
     xE3x80 = [0xE3, 0x80].pack('CC').force_encoding 'utf-8'
     input = "abc\u3042#{xE3x80}".force_encoding('ASCII')
     input.scrub.should == "abc?????"
+  end
+
+  ruby_version_is '3.0' do
+    it "returns String instances when called on a subclass" do
+      StringSpecs::MyString.new("foo").scrub.should be_an_instance_of(String)
+      input = [0x81].pack('C').force_encoding('utf-8')
+      StringSpecs::MyString.new(input).scrub.should be_an_instance_of(String)
+    end
+  end
+
+  ruby_version_is ''...'3.0.0' do
+    it "returns subclass instances when called on a subclass" do
+      StringSpecs::MyString.new("foo").scrub.should be_an_instance_of(StringSpecs::MyString)
+    end
   end
 end
 
@@ -65,6 +79,14 @@ describe "String#scrub with a custom replacement" do
 
     block.should raise_error(TypeError)
   end
+
+  ruby_version_is '3.0' do
+    it "returns String instances when called on a subclass" do
+      StringSpecs::MyString.new("foo").scrub("*").should be_an_instance_of(String)
+      input = [0x81].pack('C').force_encoding('utf-8')
+      StringSpecs::MyString.new(input).scrub("*").should be_an_instance_of(String)
+    end
+  end
 end
 
 describe "String#scrub with a block" do
@@ -88,6 +110,14 @@ describe "String#scrub with a block" do
     end
 
     replaced.should == "€€"
+  end
+
+  ruby_version_is '3.0' do
+    it "returns String instances when called on a subclass" do
+      StringSpecs::MyString.new("foo").scrub { |b| "*" }.should be_an_instance_of(String)
+      input = [0x81].pack('C').force_encoding('utf-8')
+      StringSpecs::MyString.new(input).scrub { |b| "<#{b.unpack("H*")[0]}>" }.should be_an_instance_of(String)
+    end
   end
 end
 

--- a/core/string/shared/partition.rb
+++ b/core/string/shared/partition.rb
@@ -18,7 +18,7 @@ describe :string_partition, shared: true do
     end
   end
 
-  ruby_version_is ''...'3.0.0' do
+  ruby_version_is ''...'3.0' do
     it "returns subclass instances when called on a subclass" do
       StringSpecs::MyString.new("hello").send(@method, StringSpecs::MyString.new("l")).each do |item|
         item.should be_an_instance_of(StringSpecs::MyString)

--- a/core/string/shared/partition.rb
+++ b/core/string/shared/partition.rb
@@ -1,0 +1,36 @@
+require_relative '../../../spec_helper'
+require_relative '../fixtures/classes'
+
+describe :string_partition, shared: true do
+  ruby_version_is '3.0' do
+    it "returns String instances when called on a subclass" do
+      StringSpecs::MyString.new("hello").send(@method, "l").each do |item|
+        item.should be_an_instance_of(String)
+      end
+
+      StringSpecs::MyString.new("hello").send(@method, "x").each do |item|
+        item.should be_an_instance_of(String)
+      end
+
+      StringSpecs::MyString.new("hello").send(@method, /l./).each do |item|
+        item.should be_an_instance_of(String)
+      end
+    end
+  end
+
+  ruby_version_is ''...'3.0.0' do
+    it "returns subclass instances when called on a subclass" do
+      StringSpecs::MyString.new("hello").send(@method, StringSpecs::MyString.new("l")).each do |item|
+        item.should be_an_instance_of(StringSpecs::MyString)
+      end
+
+      StringSpecs::MyString.new("hello").send(@method, "x").each do |item|
+        item.should be_an_instance_of(StringSpecs::MyString)
+      end
+
+      StringSpecs::MyString.new("hello").send(@method, /l./).each do |item|
+        item.should be_an_instance_of(StringSpecs::MyString)
+      end
+    end
+  end
+end

--- a/core/string/shared/strip.rb
+++ b/core/string/shared/strip.rb
@@ -1,0 +1,20 @@
+require_relative '../../../spec_helper'
+require_relative '../fixtures/classes'
+
+describe :string_strip, shared: true do
+  ruby_version_is '3.0' do
+    it "returns String instances when called on a subclass" do
+      StringSpecs::MyString.new(" hello ").send(@method).should be_an_instance_of(String)
+      StringSpecs::MyString.new(" ").send(@method).should be_an_instance_of(String)
+      StringSpecs::MyString.new("").send(@method).should be_an_instance_of(String)
+    end
+  end
+
+  ruby_version_is ''...'3.0.0' do
+    it "returns subclass instances when called on a subclass" do
+      StringSpecs::MyString.new(" hello ").send(@method).should be_an_instance_of(StringSpecs::MyString)
+      StringSpecs::MyString.new(" ").send(@method).should be_an_instance_of(StringSpecs::MyString)
+      StringSpecs::MyString.new("").send(@method).should be_an_instance_of(StringSpecs::MyString)
+    end
+  end
+end

--- a/core/string/shared/strip.rb
+++ b/core/string/shared/strip.rb
@@ -10,7 +10,7 @@ describe :string_strip, shared: true do
     end
   end
 
-  ruby_version_is ''...'3.0.0' do
+  ruby_version_is ''...'3.0' do
     it "returns subclass instances when called on a subclass" do
       StringSpecs::MyString.new(" hello ").send(@method).should be_an_instance_of(StringSpecs::MyString)
       StringSpecs::MyString.new(" ").send(@method).should be_an_instance_of(StringSpecs::MyString)

--- a/core/string/strip_spec.rb
+++ b/core/string/strip_spec.rb
@@ -1,7 +1,10 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative 'shared/strip'
 
 describe "String#strip" do
+  it_behaves_like :string_strip, :strip
+
   it "returns a new string with leading and trailing whitespace removed" do
     "   hello   ".strip.should == "hello"
     "   hello world   ".strip.should == "hello world"


### PR DESCRIPTION
Hello 👋

I hope I am getting this right. While looking through #823 I realized that some specs are not implemented for

> The following methods now return or yield String instances
> instead of subclass instances when called on subclass instances:
> [[Bug #10845](https://bugs.ruby-lang.org/issues/10845)]

Here's what I think is implemented/missing:

* [x] String#*
* [x] String#capitalize
* [x] String#center
* [x] String#chomp
* [x] String#chop
* [x] String#delete
* [x] String#delete_prefix
* [x] String#delete_suffix
* [x] String#downcase
* [x] String#dump
* [x] String#each_char
* [x] String#each_grapheme_cluster
* [x] String#each_line
* [x] String#gsub
* [x] String#ljust
* [ ] String#lstrip
* [ ] String#partition
* [ ] String#reverse
* [x] String#rjust
* [ ] String#rpartition
* [ ] String#rstrip
* [ ] String#scrub
* [x] String#slice!
* [x] String#slice / String#[]
* [x] String#split
* [x] String#squeeze
* [ ] String#strip
* [x] String#sub
* [x] String#succ / String#next
* [x] String#swapcase
* [x] String#tr
* [x] String#tr_s
* [x] String#upcase

This PR currently adds the tests for `String#lstrip`, but I'd like to proceed and add the tests for the remaining methods in the list.

Before I do that, I'd like to ask you if my list is correct or if I overlook something?

Thanks a lot for your feedback and assistance.