### PR TITLE
changed default for Encoding.default_external to UTF-8 on Windows

### DIFF
--- a/core/encoding/default_external_spec.rb
+++ b/core/encoding/default_external_spec.rb
@@ -20,7 +20,7 @@ describe "Encoding.default_external" do
 
   ruby_version_is "3.0" do
     platform_is :windows do
-      it 'returns default external encoding for Windows' do
+      it 'is UTF-8 by default on Windows' do
         Encoding.default_external.should == Encoding::UTF_8
       end
     end

--- a/core/encoding/default_external_spec.rb
+++ b/core/encoding/default_external_spec.rb
@@ -17,6 +17,14 @@ describe "Encoding.default_external" do
     Encoding.default_external = Encoding::SHIFT_JIS
     Encoding.default_external.should == Encoding::SHIFT_JIS
   end
+
+  ruby_version_is "3.0" do
+    platform_is :windows do
+      it 'returns default external encoding for Windows' do
+        Encoding.default_external.should == Encoding::UTF_8
+      end
+    end
+  end
 end
 
 describe "Encoding.default_external=" do


### PR DESCRIPTION
Solving https://github.com/ruby/spec/issues/823

>  Changed default for Encoding.default_external to UTF-8 on Windows [Feature #16604]