### PR TITLE
Adds spec for Feature#17260 and Feature#17231

### DIFF
--- a/language/pattern_matching_spec.rb
+++ b/language/pattern_matching_spec.rb
@@ -5,7 +5,7 @@ describe "Pattern matching" do
     ScratchPad.record []
   end
 
-  describe "can be standalone assoc operator that" do
+  describe "Rightward assignment (`=>`) that can be standalone assoc operator that" do
     it "deconstructs value" do
       suppress_warning do
         [0, 1] => [a, b]
@@ -21,6 +21,23 @@ describe "Pattern matching" do
         }
         [a, defined?(b)].should == [0, nil]
       end
+    end
+
+    it "can work with keywords" do
+      { a: 0, b: 1 } => { a:, b: }
+      [a, b].should == [0, 1]
+    end
+  end
+
+  describe "One-line pattern matching" do
+    it "can be used to check if a pattern matches for Array-like entities" do
+      ([0, 1] in [a, b]).should == true
+      ([0, 1] in [a, b, c]).should == false
+    end
+
+    it "can be used to check if a pattern matches for Hash-like entities" do
+      ({ a: 0, b: 1 } in { a:, b: }).should == true
+      ({ a: 0, b: 1 } in { a:, b:, c: }).should == false
     end
   end
 


### PR DESCRIPTION
Refers to #823

Adds specs for one-line pattern matching syntax in Ruby 3.0+, including
both Righthand Assignment (`=>`) and one-line match (`in`).

**Notes:**

I was confused on how to add specs for only Ruby 2.7 to get `NoMatchingPatternError` for `0 in 1` as the syntax I'd found will run in Ruby 3.0.

How exhaustive do we want these tests to be? On one hand they could be reasonably inferred from full pattern matches, and we simply want to check that the syntax works. On the other we should likely test edge-cases.

What are thoughts on this?

I can certainly see a case for a more comprehensive test on possible syntax errors and odd uses to ensure consistency, but want to run that by maintainers first.