### PR TITLE
Add specs to cover the fix for [Bug #14266]

### DIFF
--- a/library/set/clone_spec.rb
+++ b/library/set/clone_spec.rb
@@ -1,0 +1,17 @@
+require_relative '../../spec_helper'
+require 'set'
+
+describe "Set#clone" do
+  ruby_version_is "3.0" do
+    it "does not freeze the new Set" do
+      set1 = Set[1, 2]
+      set1.freeze
+      set2 = set1.clone(freeze: false)
+      set1.frozen?.should == true
+      set2.frozen?.should == false
+      set2.add 3
+      set1.should == Set[1, 2]
+      set2.should == Set[1, 2, 3]
+    end
+  end
+end


### PR DESCRIPTION
Covering "Set#clone(freeze: false) makes frozen internal hash" from #823 

```
Kernel#clone when called with the freeze: false keyword will call
#initialize_clone with the freeze: false keyword.
[Bug #14266]
```