### PR TITLE
add spec for Dir.glob / Dir.[] result being sorted by default

### DIFF
--- a/core/dir/shared/glob.rb
+++ b/core/dir/shared/glob.rb
@@ -49,7 +49,7 @@ describe :dir_glob, shared: true do
       result.should == result.sort
     end
 
-    it "sorted: false returns same files" do
+    it "sort: false returns same files" do
       result = Dir.send(@method,'*', sort: false)
       result.sort.should == Dir.send(@method, '*').sort
     end


### PR DESCRIPTION
Hello 👋 

From #823 :

> Dir.glob and Dir.[] now sort the results by default, and
> accept the sort: keyword option. [[Feature #8709](https://bugs.ruby-lang.org/issues/8709)]

I am not sure if or how to add a spec for `sorted: false`. As far as I understand the result may or may not differ depending on OS. Is there a reliable/deterministic sorting logic behind `sorted: false`?