### PR TITLE
Add hash/kwarg with omitted values specs

### DIFF
--- a/language/hash_spec.rb
+++ b/language/hash_spec.rb
@@ -225,4 +225,43 @@ describe "The ** operator" do
       h.should == { two: 2 }
     end
   end
+
+  ruby_version_is "3.1" do
+    describe "hash with omitted value" do
+      it "accepts short notation 'key' for 'key: value' syntax" do
+        a, b, c = 1, 2, 3
+        h = eval('{a:}')
+        {a: 1}.should == h
+        h = eval('{a:, b:, c:}')
+        {a: 1, b: 2, c: 3}.should == h
+      end
+
+      it "ignores hanging comma on short notation" do
+        a, b, c = 1, 2, 3
+        h = eval('{a:, b:, c:,}')
+        {a: 1, b: 2, c: 3}.should == h
+      end
+
+      it "accepts mixed syntax" do
+        a, e = 1, 5
+        h = eval('{a:, :b => 2, "c" => 3, :d => 4, e:}')
+        eval('{a: 1, :b => 2, "c" => 3, "d": 4, e: 5}').should == h
+      end
+
+      it "works with methods and local vars" do
+        a = Class.new
+        a.class_eval(<<-RUBY)
+          def bar
+            "baz"
+          end
+
+          def foo(val)
+            {bar:, val:}
+          end
+        RUBY
+
+        a.new.foo(1).should == {bar: "baz", val: 1}
+      end
+    end
+  end
 end

--- a/language/method_spec.rb
+++ b/language/method_spec.rb
@@ -1873,3 +1873,44 @@ ruby_version_is '3.0' do
     end
   end
 end
+
+ruby_version_is "3.1" do
+  describe "kwarg with omitted value in a method call" do
+    context "accepts short notation 'kwarg' in method call" do
+      evaluate <<-ruby do
+          def call(*args, **kwargs) = [args, kwargs]
+        ruby
+
+        a, b, c = 1, 2, 3
+        arr, h = eval('call a:')
+        h.should == {a: 1}
+        arr.should == []
+
+        arr, h = eval('call(a:, b:, c:)')
+        h.should == {a: 1, b: 2, c: 3}
+        arr.should == []
+
+        arr, h = eval('call(a:, b: 10, c:)')
+        h.should == {a: 1, b: 10, c: 3}
+        arr.should == []
+      end
+    end
+
+    context "with methods and local variables" do
+      evaluate <<-ruby do
+          def call(*args, **kwargs) = [args, kwargs]
+
+          def bar
+            "baz"
+          end
+
+          def foo(val)
+            call bar:, val:
+          end
+        ruby
+
+        foo(1).should == [[], {bar: "baz", val: 1}]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ruby 3.1, [Feature #14579](https://bugs.ruby-lang.org/issues/14579)
