### PR TITLE
add spec for Range objects to be frozen

### DIFF
--- a/language/range_spec.rb
+++ b/language/range_spec.rb
@@ -15,6 +15,12 @@ describe "Literal Ranges" do
     (1...).should == Range.new(1, nil, true)
   end
 
+  ruby_version_is "3.0" do
+    it "is frozen" do
+      (42..).should.frozen?
+    end
+  end
+
   ruby_version_is "2.7" do
     it "creates beginless ranges" do
       eval("(..1)").should == Range.new(nil, 1)


### PR DESCRIPTION
Hello 👋 

From #823 :

> Regexp literals and all Range objects are frozen. [[Feature #8948](https://bugs.ruby-lang.org/issues/8948)] [[Feature #16377](https://bugs.ruby-lang.org/issues/16377)] [[Feature #15504](https://bugs.ruby-lang.org/issues/15504)]

```ruby
/foo/.frozen? #=> true
(42...).frozen? # => true
```

I think spec for frozen Regexp literals already exists: 
https://github.com/ruby/spec/blob/136a6ab8189cd409801a3bc2721e7589b43faf10/language/regexp_spec.rb#L21-L25

So this PR only adds the missing spec for Range objects.
