### PR TITLE
add spec for `SortedSet` being extracted from the `set` library

### DIFF
--- a/library/set/sortedset/new_spec.rb
+++ b/library/set/sortedset/new_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../spec_helper'
+require 'set'
+
+ruby_version_is "3.0" do
+  describe "SortedSet.new" do
+    it "throws error including message that it has been extracted" do
+      -> {
+        SortedSet.new
+      }.should raise_error(RuntimeError) { |e|
+        e.message.should.include?("The `SortedSet` class has been extracted from the `set` library")
+      }
+    end
+  end
+end
+
+ruby_version_is ""..."3.0" do
+  describe "SortedSet.new" do
+    it "returns an instance of SortedSet" do
+      SortedSet.new.should be_an_instance_of(SortedSet)
+    end
+  end
+end


### PR DESCRIPTION
Hello 👋

From #823 

> ## Stdlib updates
>
> #### Set
>
> SortedSet has been removed for dependency and performance reasons.

and 

> ## Compatibility issues
> [...]
>
> SortedSet has been removed for dependency and performance reasons.

 (It's listed twice 🙃)

---

I am not really sure how to test this. My idea here is to to add a simple spec for `SortedSet.new`, asserting to be instance of `SortedSet` for versions `""..."3.0"` and assert to throw an error in version `"3.0"`.

Is there a better way?