### PR TITLE
Fix `ObjectSpace#memsize_of_all` to use an isolated class

### DIFF
--- a/library/objectspace/memsize_of_all_spec.rb
+++ b/library/objectspace/memsize_of_all_spec.rb
@@ -13,9 +13,10 @@ describe "ObjectSpace.memsize_of_all" do
   end
 
   it "increases when a new object is allocated" do
-    before = ObjectSpace.memsize_of_all(Class)
-    o = Class.new
-    after = ObjectSpace.memsize_of_all(Class)
+    c = Class.new
+    before = ObjectSpace.memsize_of_all(c)
+    o = c.new
+    after = ObjectSpace.memsize_of_all(c)
     after.should > before
   end
 end


### PR DESCRIPTION
The number of all instances of `Class` may be affected by GC-able anonymous classes created by other tests.

ruby/ruby@7f3786c3e86a685a1a6332a1e0c9290f9b9df414