### PR TITLE
Add more tests for Hash#transform_keys

### DIFF
--- a/core/hash/transform_keys_spec.rb
+++ b/core/hash/transform_keys_spec.rb
@@ -47,6 +47,14 @@ describe "Hash#transform_keys" do
     it "allows a hash argument" do
       @hash.transform_keys({ a: :A, b: :B, c: :C }).should == { A: 1, B: 2, C: 3 }
     end
+
+    it "allows a partial transformation of keys when using a hash argument" do
+      @hash.transform_keys({ a: :A, c: :C }).should == { A: 1, b: 2, C: 3 }
+    end
+
+    it "allows a combination of hash and block argument" do
+      @hash.transform_keys({ a: :A }, &:to_s).should == { A: 1, 'b' => 2, 'c' => 3 }
+    end
   end
 end
 


### PR DESCRIPTION
Hello! Along with the implementation in truffleruby you can find in the mentions, I've added tests to handle "edge" cases when using transform_keys with a hash:

* using both a hash and a block
* using a hash not matching all the keys from the original