### PR TITLE
add spec for `Integer#zero?` overrides `Numeric#zero?`

### DIFF
--- a/core/integer/zero_spec.rb
+++ b/core/integer/zero_spec.rb
@@ -1,0 +1,21 @@
+require_relative '../../spec_helper'
+
+describe "Integer#zero?" do
+  it "returns true if self is 0" do
+    0.should.zero?
+    1.should_not.zero?
+    -1.should_not.zero?
+  end
+
+  ruby_version_is "3.0" do
+    it "Integer#zero? overrides Numeric#zero?" do
+      42.method(:zero?).owner.should == Integer
+    end
+  end
+
+  ruby_version_is ""..."3.0" do
+    it "Integer#zero? uses Numeric#zero?" do
+      42.method(:zero?).owner.should == Numeric
+    end
+  end
+end


### PR DESCRIPTION
Hello 👋 

Here's my attempt to cover this from #823 

> Integer#zero? overrides Numeric#zero? for optimization. [[Misc #16961](https://bugs.ruby-lang.org/issues/16961)]

As always I am looking forward to getting feedback, thank you.