### PR TITLE
Fix Array#slice spec testing String#slice

### DIFF
--- a/core/array/shared/slice.rb
+++ b/core/array/shared/slice.rb
@@ -517,8 +517,9 @@ describe :array_slice, shared: true do
   end
 
   it "raises a RangeError if passed a range with a bound that is too large" do
-    -> { "hello".send(@method, bignum_value..(bignum_value + 1)) }.should raise_error(RangeError)
-    -> { "hello".send(@method, 0..bignum_value) }.should raise_error(RangeError)
+    array = [1, 2, 3, 4, 5, 6]
+    -> { array.send(@method, bignum_value..(bignum_value + 1)) }.should raise_error(RangeError)
+    -> { array.send(@method, 0..bignum_value) }.should raise_error(RangeError)
   end
 
   it "can accept endless ranges" do


### PR DESCRIPTION
Previously the spec was running on a String object instead of an Array, which it should be (according to the file location). I've just used an array object like in other specs in this file.

The same spec is present in string/shared/slice so no coverage is lost. 

Please let me know if anything is wrong or if I should change anything 😅 

PS.: This issue was found while working on [Natalie](https://natalie-lang.org).  
