### PR TITLE
Not all environment variables can be convertible to IBM-437

### DIFF
--- a/core/env/shift_spec.rb
+++ b/core/env/shift_spec.rb
@@ -52,7 +52,9 @@ describe "ENV.shift" do
     Encoding.default_internal = Encoding::IBM437
 
     pair = ENV.shift
+    pair.first.encode(Encoding::IBM437) rescue next
     pair.first.encoding.should equal(Encoding::IBM437)
+    pair.last.encode(Encoding::IBM437) rescue next
     pair.last.encoding.should equal(Encoding::IBM437)
   end
 end


### PR DESCRIPTION
As I set `export error_symbol=😭` to indicate the preceding command failed in the command prompt, this test failed occasionally.

ruby/ruby@0871652f21c6b7c74e67ba300175ff2a278aee6e
