### PR TITLE
Add test for Hash#each consistently yields a 2-element array

### DIFF
--- a/core/hash/each_spec.rb
+++ b/core/hash/each_spec.rb
@@ -8,4 +8,10 @@ describe "Hash#each" do
   it_behaves_like :hash_each, :each
   it_behaves_like :hash_iteration_no_block, :each
   it_behaves_like :enumeratorized_with_origin_size, :each, { 1 => 2, 3 => 4, 5 => 6 }
+
+  ruby_version_is "3.0" do
+    it 'consistently yields a 2-element array' do
+      -> { { a: 1 }.each(&->(k, v) { }) }.should raise_error(ArgumentError)
+    end
+  end
 end


### PR DESCRIPTION
From #823

https://bugs.ruby-lang.org/issues/12706?tab=history

> As a semantics, Hash#each yields a 2-element array (pairs of keys and
> values). So, { a: 1  }.each(&->(k, v) { }) should raise an exception
> due to lambda's arity check.