### PR TITLE
Add specs for `Fiber.blocking?`

### DIFF
--- a/core/fiber/blocking_spec.rb
+++ b/core/fiber/blocking_spec.rb
@@ -1,31 +1,61 @@
 require_relative '../../spec_helper'
+require_relative 'shared/blocking'
 
 ruby_version_is "3.0" do
   require "fiber"
 
   describe "Fiber.blocking?" do
-    context "when fiber is non-blocking" do
-      it "returns false by default" do
-        fiber = Fiber.new { Fiber.current.blocking? }
-        blocking = fiber.resume
-
-        blocking.should == false
-      end
-
-      it "returns false for blocking: false" do
-        fiber = Fiber.new(blocking: false) { Fiber.current.blocking? }
-        blocking = fiber.resume
-
-        blocking.should == false
-      end
-    end
+    it_behaves_like :non_blocking_fiber, -> { Fiber.blocking? }
 
     context "when fiber is blocking" do
-      it "returns true for blocking: true" do
-        fiber = Fiber.new(blocking: true) { Fiber.current.blocking? }
-        blocking = fiber.resume
+      context "root Fiber of the main thread" do
+        it "returns 1 for blocking: true" do
+          fiber = Fiber.new(blocking: true) { Fiber.blocking? }
+          blocking = fiber.resume
 
-        blocking.should == true
+          blocking.should == 1
+        end
+      end
+
+      context "root Fiber of a new thread" do
+        it "returns 1 for blocking: true" do
+          thread = Thread.new do
+            fiber = Fiber.new(blocking: true) { Fiber.blocking? }
+            blocking = fiber.resume
+
+            blocking.should == 1
+          end
+
+          thread.join
+        end
+      end
+    end
+  end
+
+  describe "Fiber#blocking?" do
+    it_behaves_like :non_blocking_fiber, -> { Fiber.current.blocking? }
+
+    context "when fiber is blocking" do
+      context "root Fiber of the main thread" do
+        it "returns true for blocking: true" do
+          fiber = Fiber.new(blocking: true) { Fiber.current.blocking? }
+          blocking = fiber.resume
+
+          blocking.should == true
+        end
+      end
+
+      context "root Fiber of a new thread" do
+        it "returns true for blocking: true" do
+          thread = Thread.new do
+            fiber = Fiber.new(blocking: true) { Fiber.current.blocking? }
+            blocking = fiber.resume
+
+            blocking.should == true
+          end
+
+          thread.join
+        end
       end
     end
   end

--- a/core/fiber/shared/blocking.rb
+++ b/core/fiber/shared/blocking.rb
@@ -29,7 +29,7 @@ describe :non_blocking_fiber, shared: true do
 
     it "returns false for blocking: false" do
       thread = Thread.new do
-        fiber = Fiber.new(blocking: false) { Fiber.blocking? }
+        fiber = Fiber.new(blocking: false) { @method.call }
         blocking = fiber.resume
 
         blocking.should == false


### PR DESCRIPTION
relates to #823 

> Fiber.blocking? tells whether the current execution context is
blocking. [[Feature #16786](https://bugs.ruby-lang.org/issues/16786)]
