### PR TITLE
adds spec Kernel#open is not redefined by open-uri

### DIFF
--- a/core/kernel/open_spec.rb
+++ b/core/kernel/open_spec.rb
@@ -148,6 +148,18 @@ describe "Kernel#open" do
       ruby_exe(code, args: "2>&1").should == "true\n"
     end
   end
+
+  ruby_version_is "3.0" do
+    it "is not redefined by open-uri" do
+      code = <<~RUBY
+        before = Kernel.instance_method(:open)
+        require 'open-uri'
+        after = Kernel.instance_method(:open)
+        p before == after
+      RUBY
+      ruby_exe(code, args: "2>&1").should == "true\n"
+    end
+  end
 end
 
 describe "Kernel.open" do


### PR DESCRIPTION
Solving #823

> Requiring 'open-uri' no longer redefines Kernel#open.
Call URI.open directly or use URI#open instead. [Misc #15893]

I'm not sure this is correct location of spec but have found other example at this place and think that they should be together.