### PR TITLE
Add spec confirming Runtime error when a class variable is overtaken

### DIFF
--- a/language/class_variable_spec.rb
+++ b/language/class_variable_spec.rb
@@ -85,7 +85,7 @@ end
 
 ruby_version_is "3.0" do
   describe 'Class variable overtaking' do
-    it "raises Runtime error when a defined class variable is overtaken" do
+    it "accessing a class variable from the toplevel scope raises a RuntimeError" do
       -> do
         eval <<-CODE
           @@cvar_a = :new_val
@@ -93,7 +93,7 @@ ruby_version_is "3.0" do
       end.should raise_error(RuntimeError, /class variable access from toplevel/)
     end
 
-    it "raises Runtime error when a child class variable is overtaken" do
+    it "raises a RuntimeError when a class variable is overtaken by the same definition in an ancestor class" do
       a = Class.new()
       b = Class.new(a)
       b.class_variable_set(:@@cvar, :value)


### PR DESCRIPTION
Ref. #823 

> When a class variable is overtaken by the same definition in an ancestor class/module, a RuntimeError is now raised (previously, it only issued a warning in verbose mode). Additionally, accessing a class variable from the top-level scope is now a RuntimeError. [[Bug #14541](https://bugs.ruby-lang.org/issues/14541)]