### PR TITLE
adds spec for Bug [#17030]

### DIFF
--- a/core/enumerable/grep_spec.rb
+++ b/core/enumerable/grep_spec.rb
@@ -59,6 +59,12 @@ describe "Enumerable#grep" do
       ["abc", "def"].grep(/b/).should == ["abc"]
       $&.should == "z"
     end
+
+    it "does not modify Regexp.last_match without block" do
+      "z" =~ /z/ # Reset last match
+      ["abc", "def"].grep(/b/).should == ["abc"]
+      Regexp.last_match[0].should == "z"
+    end
   end
 
   describe "with a block" do

--- a/core/enumerable/grep_v_spec.rb
+++ b/core/enumerable/grep_v_spec.rb
@@ -39,6 +39,12 @@ describe "Enumerable#grep_v" do
       ["abc", "def"].grep_v(/e/).should == ["abc"]
       $&.should == "z"
     end
+
+    it "does not modify Regexp.last_match without block" do
+      "z" =~ /z/ # Reset last match
+      ["abc", "def"].grep_v(/e/).should == ["abc"]
+      Regexp.last_match[0].should == "z"
+    end
   end
 
   describe "without block" do


### PR DESCRIPTION
Solving https://github.com/ruby/spec/issues/823

> Enumerable#grep and Enumerable#grep_v when passed a Regexp and no block no longer modify
Regexp.last_match

There are specs already for `$&` - an global alias to `Regexp.last_match`. Maybe it make sense to leave one of them but use `Regexp.last_match` explicitly because it seems more clear IMO.