### PR TITLE
Only run auto compact tests on platforms that support it

### DIFF
--- a/core/gc/auto_compact_spec.rb
+++ b/core/gc/auto_compact_spec.rb
@@ -2,18 +2,20 @@ require_relative '../../spec_helper'
 
 ruby_version_is "3.0" do
   describe "GC.auto_compact" do
-    before :each do
-      @default = GC.auto_compact
-    end
+    guard -> { defined?(Etc::SC_PAGE_SIZE) && GC::INTERNAL_CONSTANTS[:HEAP_PAGE_SIZE] % Etc.sysconf(Etc::SC_PAGE_SIZE) == 0 } do
+      before :each do
+        @default = GC.auto_compact
+      end
 
-    after :each do
-      GC.auto_compact = @default
-    end
+      after :each do
+        GC.auto_compact = @default
+      end
 
-    it "can set and get a boolean value" do
-      original = GC.auto_compact
-      GC.auto_compact = !original
-      GC.auto_compact.should == !original
+      it "can set and get a boolean value" do
+        original = GC.auto_compact
+        GC.auto_compact = !original
+        GC.auto_compact.should == !original
+      end
     end
   end
 end


### PR DESCRIPTION
Some platforms (ppcle for example) can't support autocompact.  Don't run
these tests on non-supported platforms

21a48d9ae02d00921694b1194a56d1d36842b782 is causing failures on some CI machines (particularly the ones that don't support compaction).  I'm not sure if this is the right way to guard against running the tests 😅 