### PR TITLE
Add new test case for Dir.glob with sort kwarg [Feature #8709]

### DIFF
--- a/core/dir/shared/glob.rb
+++ b/core/dir/shared/glob.rb
@@ -49,6 +49,17 @@ describe :dir_glob, shared: true do
       result.should == result.sort
     end
 
+    it "result is sorted with any non false value of sort:" do
+      result = Dir.send(@method, '*', sort: 0)
+      result.should == result.sort
+
+      result = Dir.send(@method, '*', sort: nil)
+      result.should == result.sort
+
+      result = Dir.send(@method, '*', sort: 'false')
+      result.should == result.sort
+    end
+
     it "sort: false returns same files" do
       result = Dir.send(@method,'*', sort: false)
       result.sort.should == Dir.send(@method, '*').sort


### PR DESCRIPTION
Cover the case when a non `false` value is given to the `Dir.glob`. Since we don't have type checks, I think it makes sense to [cover that behaviour](https://github.com/ruby/ruby/commit/2f1081a451f21ca017cc9fdc585883e5c6ebf618#diff-13026f61c17631884dc4c6ee9128710ef8801844114eaedaf0a13db649b4b0a2R2961)