### PR TITLE
Add spec for `GC.stat({})`

### DIFF
--- a/core/gc/stat_spec.rb
+++ b/core/gc/stat_spec.rb
@@ -7,6 +7,16 @@ describe "GC.stat" do
     stat.keys.should.include?(:count)
   end
 
+  it "updates the given hash values" do
+    hash = { count: "hello", __other__: "world" }
+    stat = GC.stat(hash)
+
+    stat.should be_kind_of(Hash)
+    stat.should equal hash
+    stat[:count].should be_kind_of(Integer)
+    stat[:__other__].should == "world"
+  end
+
   it "the values are all Integer since rb_gc_stat() returns size_t" do
     GC.stat.values.each { |value| value.should be_kind_of(Integer) }
   end


### PR DESCRIPTION
Ref: https://github.com/Shopify/gctime/pull/1

I recently noticed that TruffleRuby was behaving weirdly when using this API:

```ruby
>> stats = {}
=> {}
>> GC.stat(stats)
=> 0
>> stats
=> {}
```

Compared to MRI:

```ruby
>>  stats = {}
=> {}
>>  GC.stat(stats)
=> {:count=>19, :heap_allocated_pages=>75, ...}
>> stats
=> {:count=>19, :heap_allocated_pages=>75, ...}
```

cc @eregon 