### PR TITLE
Update Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ jobs:
       matrix:
         os: [ ubuntu, macos, windows ]
         ruby: [ 2.6.9, 2.7.5, 3.0.3, 3.1.0 ]
+        exclude:
+          - { os: windows, ruby: 3.1.0 }
     runs-on: ${{ matrix.os }}-latest
     steps:
     - name: git config autocrlf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu, macos, windows ]
-        ruby: [ 2.6.8, 2.7.4, 3.0.2, 3.1.0 ]
+        ruby: [ 2.6.9, 2.7.5, 3.0.3, 3.1.0 ]
     runs-on: ${{ matrix.os }}-latest
     steps:
     - name: git config autocrlf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu, macos, windows ]
-        ruby: [ 2.6.8, 2.7.4, 3.0.2 ]
+        ruby: [ 2.6.8, 2.7.4, 3.0.2, 3.1.0 ]
     runs-on: ${{ matrix.os }}-latest
     steps:
     - name: git config autocrlf


### PR DESCRIPTION
Since Ruby 3.1.0 has been released, this pull request starts to run specs on Ruby 3.1.0 on CI. Besides, this updates other Ruby minor versions as well.

If it's not time to update, feel free to close this.

Refs:

- https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/
- https://www.ruby-lang.org/en/news/2021/11/24/ruby-3-0-3-released/
- https://www.ruby-lang.org/en/news/2021/11/24/ruby-2-7-5-released/
- https://www.ruby-lang.org/en/news/2021/11/24/ruby-2-6-9-released/
