### PR TITLE
Correct duplicate tests

### DIFF
--- a/core/nil/match_spec.rb
+++ b/core/nil/match_spec.rb
@@ -2,17 +2,13 @@ require_relative '../../spec_helper'
 
 describe "NilClass#=~" do
   it "returns nil matching any object" do
-    o = Object.new
-
-    suppress_warning do
-      (o =~ /Object/).should   be_nil
-      (o =~ 'Object').should   be_nil
-      (o =~ Object).should     be_nil
-      (o =~ Object.new).should be_nil
-      (o =~ nil).should        be_nil
-      (o =~ false).should      be_nil
-      (o =~ true).should       be_nil
-    end
+    (nil =~ /Object/).should   be_nil
+    (nil =~ 'Object').should   be_nil
+    (nil =~ Object).should     be_nil
+    (nil =~ Object.new).should be_nil
+    (nil =~ nil).should        be_nil
+    (nil =~ false).should      be_nil
+    (nil =~ true).should       be_nil
   end
 
   it "should not warn" do

--- a/core/string/allocate_spec.rb
+++ b/core/string/allocate_spec.rb
@@ -14,6 +14,6 @@ describe "String.allocate" do
   end
 
   it "returns a binary String" do
-    String.new.encoding.should == Encoding::BINARY
+    String.allocate.encoding.should == Encoding::BINARY
   end
 end


### PR DESCRIPTION
The spec for [`NilClass#=~`](https://github.com/ruby/spec/blob/master/core/nil/match_spec.rb) has a test that is the same as [`Kernel#=~`](https://github.com/ruby/spec/blob/master/core/kernel/match_spec.rb), where `o` is an `Object` instance. In the `NilClass#=~` spec, `o` should instead be `nil`, right?