### PR TITLE
Add specs for Integer#| and Integer#^

### DIFF
--- a/core/integer/bit_or_spec.rb
+++ b/core/integer/bit_or_spec.rb
@@ -10,6 +10,21 @@ describe "Integer#|" do
       (0xffff | bignum_value + 0xf0f0).should == 0x8000_0000_0000_ffff
     end
 
+    it "returns self bitwise OR other when one operand is negative" do
+      ((1 << 33) | -1).should == -1
+      (-1 | (1 << 33)).should == -1
+
+      ((-(1<<33)-1) | 5).should == -8589934593
+      (5 | (-(1<<33)-1)).should == -8589934593
+    end
+
+    it "returns self bitwise OR other when both operands are negative" do
+      (-5 | -1).should == -1
+      (-3 | -4).should == -3
+      (-12 | -13).should == -9
+      (-13 | -12).should == -9
+    end
+
     it "returns self bitwise OR a bignum" do
       (-1 | 2**64).should == -1
     end

--- a/core/integer/bit_or_spec.rb
+++ b/core/integer/bit_or_spec.rb
@@ -14,6 +14,12 @@ describe "Integer#|" do
       (-1 | 2**64).should == -1
     end
 
+    it "coerces the rhs and calls #coerce" do
+      obj = mock("fixnum bit and")
+      obj.should_receive(:coerce).with(6).and_return([3, 6])
+      (6 & obj).should == 2
+    end
+
     it "raises a TypeError when passed a Float" do
       -> { (3 | 3.4) }.should raise_error(TypeError)
     end

--- a/core/integer/bit_xor_spec.rb
+++ b/core/integer/bit_xor_spec.rb
@@ -12,6 +12,12 @@ describe "Integer#^" do
       (-1 ^ 2**64).should == -18446744073709551617
     end
 
+    it "coerces the rhs and calls #coerce" do
+      obj = mock("fixnum bit and")
+      obj.should_receive(:coerce).with(6).and_return([3, 6])
+      (6 ^ obj).should == 5
+    end
+
     it "raises a TypeError when passed a Float" do
       -> { (3 ^ 3.4) }.should raise_error(TypeError)
     end

--- a/core/integer/bit_xor_spec.rb
+++ b/core/integer/bit_xor_spec.rb
@@ -8,6 +8,21 @@ describe "Integer#^" do
       (5 ^ bignum_value + 0xffff_ffff).should == 0x8000_0000_ffff_fffa
     end
 
+    it "returns self bitwise XOR other when one operand is negative" do
+      ((1 << 33) ^ -1).should == -8589934593
+      (-1 ^ (1 << 33)).should == -8589934593
+
+      ((-(1<<33)-1) ^ 5).should == -8589934598
+      (5 ^ (-(1<<33)-1)).should == -8589934598
+    end
+
+    it "returns self bitwise XOR other when both operands are negative" do
+      (-5 ^ -1).should == 4
+      (-3 ^ -4).should == 1
+      (-12 ^ -13).should == 7
+      (-13 ^ -12).should == 7
+    end
+
     it "returns self bitwise EXCLUSIVE OR a bignum" do
       (-1 ^ 2**64).should == -18446744073709551617
     end


### PR DESCRIPTION
Both methods are missing specs that are tested for `Integer#&` and should be tested as well with `Integer#|` and `Integer#^`.