### PR TITLE
Don't test exact capacity of strings

### DIFF
--- a/optional/capi/string_spec.rb
+++ b/optional/capi/string_spec.rb
@@ -611,7 +611,9 @@ describe "C-API String function" do
       filename = fixture(__FILE__, "read.txt")
       str = ""
       capacities = @s.RSTRING_PTR_read(str, filename)
-      capacities.should == [30, 53]
+      capacities[0].should >= 30
+      capacities[1].should >= 53
+      capacities[0].should < capacities[1]
       str.should == "fixture file contents to test read() with RSTRING_PTR"
     end
   end


### PR DESCRIPTION
Exact capacity is implementation detail, so it shouldn't be tested.