### PR TITLE
Add a spec for String#to_sym with same content but distinct encoding

### DIFF
--- a/core/string/shared/to_sym.rb
+++ b/core/string/shared/to_sym.rb
@@ -53,6 +53,15 @@ describe :string_to_sym, shared: true do
     sym.to_s.should == binary_string
   end
 
+  it "ignores exising symbols with different encoding" do
+    source = "fée"
+
+    iso_symbol = source.force_encoding(Encoding::ISO_8859_1).to_sym
+    iso_symbol.encoding.should == Encoding::ISO_8859_1
+    binary_symbol = source.force_encoding(Encoding::BINARY).to_sym
+    binary_symbol.encoding.should == Encoding::BINARY
+  end
+
   it "raises an EncodingError for UTF-8 String containing invalid bytes" do
     invalid_utf8 = "\xC3"
     invalid_utf8.should_not.valid_encoding?


### PR DESCRIPTION
I found a bug in JRuby while working on msgpack:

https://github.com/msgpack/msgpack-ruby/blob/37949d20920225972b51f4cc69c8fbec775cc9fd/spec/factory_spec.rb#L338-L341

cc @eregon 

Also cc @headius (in case this isn't a known or expected difference)