### PR TITLE
Fix core/rational/minus_spec.rb

### DIFF
--- a/core/rational/minus_spec.rb
+++ b/core/rational/minus_spec.rb
@@ -5,3 +5,15 @@ describe "Rational#-" do
   it_behaves_like :rational_minus, :-
   it_behaves_like :rational_arithmetic_exception_in_coerce, :-
 end
+
+describe "Rational#- passed a Rational" do
+  it_behaves_like :rational_minus_rat, :-
+end
+
+describe "Rational#- passed a Float" do
+  it_behaves_like :rational_minus_float, :-
+end
+
+describe "Rational#- passed an Integer" do
+  it_behaves_like :rational_minus_int, :-
+end


### PR DESCRIPTION
The shared examples are defined in `shared/rational/minus.rb` but the spec is not making use of them.