### PR TITLE
Add Math.ldexp specs for edge case

### DIFF
--- a/core/math/ldexp_spec.rb
+++ b/core/math/ldexp_spec.rb
@@ -45,6 +45,12 @@ describe "Math.ldexp" do
   it "accepts any second argument that can be coerced with Integer()" do
     Math.ldexp(3.23, MathSpecs::Integer.new).should be_close(12.92, TOLERANCE)
   end
+
+  it "returns correct value that closes to the max value of double type" do
+    Math.ldexp(0.5122058490966879, 1024).should == 9.207889385574391e+307
+    Math.ldexp(0.9999999999999999, 1024).should == 1.7976931348623157e+308
+    Math.ldexp(0.99999999999999999, 1024).should == Float::INFINITY
+  end
 end
 
 describe "Math#ldexp" do


### PR DESCRIPTION
 See https://github.com/jruby/jruby/issues/7234

And truffleruby seems to have the same issue.
https://github.com/jruby/jruby/pull/7236#discussion_r887965490