### PR TITLE
Add top-level yield outside of the method test

### DIFF
--- a/language/yield_spec.rb
+++ b/language/yield_spec.rb
@@ -213,3 +213,13 @@ describe "Using yield in a singleton class literal" do
     end
   end
 end
+
+describe "Using yield in non-lambda block" do
+  it 'raises a SyntaxError' do
+    code = <<~RUBY
+        1.times { yield }
+      RUBY
+
+    -> { eval(code) }.should raise_error(SyntaxError, /Invalid yield/)
+  end
+end


### PR DESCRIPTION
As a part of the [Feature #15575](https://bugs.ruby-lang.org/issues/15575) behaviour of the top-level yield outside of the method changed from `LocalJumpError` to `SyntaxError`. A new test should cover that case.

_P.S: I'm not sure does it makes sense to preserve the old behaviour in tests and decide not to_