### PR TITLE
Add many tests for core/io components

### DIFF
--- a/core/io/gets_spec.rb
+++ b/core/io/gets_spec.rb
@@ -213,6 +213,8 @@ describe "IO#gets" do
 
   it "returns empty string when 0 passed as a limit" do
     @io.gets(0).should == ""
+    @io.gets(nil, 0).should == ""
+    @io.gets("", 0).should == ""
   end
 end
 

--- a/core/io/print_spec.rb
+++ b/core/io/print_spec.rb
@@ -13,6 +13,10 @@ describe "IO#print" do
     rm_r @name
   end
 
+  it "returns nil" do
+    touch(@name) { |f| f.print.should be_nil }
+  end
+
   it "writes $_.to_s followed by $\\ (if any) to the stream if no arguments given" do
     o = mock('o')
     o.should_receive(:to_s).and_return("mockmockmock")

--- a/core/io/print_spec.rb
+++ b/core/io/print_spec.rb
@@ -3,13 +3,20 @@ require_relative 'fixtures/classes'
 
 describe "IO#print" do
   before :each do
-    @old_separator = $\
-    suppress_warning {$\ = '->'}
+    @old_record_separator = $\
+    @old_field_separator = $,
+    suppress_warning {
+      $\ = '->'
+      $, = '^^'
+    }
     @name = tmp("io_print")
   end
 
   after :each do
-    suppress_warning {$\ = @old_separator}
+    suppress_warning {
+      $\ = @old_record_separator
+      $, = @old_field_separator
+    }
     rm_r @name
   end
 
@@ -42,13 +49,15 @@ describe "IO#print" do
     IO.read(@name).should == "hello#{$\}"
   end
 
-  it "writes each obj.to_s to the stream and appends $\\ (if any) given multiple objects" do
+  it "writes each obj.to_s to the stream separated by $, (if any) and appends $\\ (if any) given multiple objects" do
     o, o2 = Object.new, Object.new
     def o.to_s(); 'o'; end
     def o2.to_s(); 'o2'; end
 
-    touch(@name) { |f| f.print(o, o2) }
-    IO.read(@name).should == "#{o.to_s}#{o2.to_s}#{$\}"
+    suppress_warning {
+      touch(@name) { |f| f.print(o, o2) }
+    }
+    IO.read(@name).should == "#{o.to_s}#{$,}#{o2.to_s}#{$\}"
   end
 
   it "raises IOError on closed stream" do

--- a/core/io/read_nonblock_spec.rb
+++ b/core/io/read_nonblock_spec.rb
@@ -100,4 +100,13 @@ describe "IO#read_nonblock" do
 
     -> { @read.read_nonblock(5) }.should raise_error(EOFError)
   end
+
+  it "preserves the encoding of the given buffer" do
+    buffer = ''.encode(Encoding::ISO_8859_1)
+    @write.write("abc")
+    @write.close
+    @read.read_nonblock(10, buffer)
+
+    buffer.encoding.should == Encoding::ISO_8859_1
+  end
 end

--- a/core/io/read_nonblock_spec.rb
+++ b/core/io/read_nonblock_spec.rb
@@ -96,6 +96,21 @@ describe "IO#read_nonblock" do
     output.should equal(buffer)
   end
 
+  it "discards the existing buffer content upon successful read" do
+    buffer = "existing content"
+    @write.write("hello world")
+    @write.close
+    @read.read_nonblock(11, buffer)
+    buffer.should == "hello world"
+  end
+
+  it "discards the existing buffer content upon error" do
+    buffer = "existing content"
+    @write.close
+    -> { @read.read_nonblock(1, buffer) }.should raise_error(EOFError)
+    buffer.should be_empty
+  end
+
   it "raises IOError on closed stream" do
     -> { IOSpecs.closed_io.read_nonblock(5) }.should raise_error(IOError)
   end

--- a/core/io/read_nonblock_spec.rb
+++ b/core/io/read_nonblock_spec.rb
@@ -70,6 +70,10 @@ describe "IO#read_nonblock" do
     @read.read_nonblock(1).should == "1"
   end
 
+  it "raises ArgumentError when length is less than 0" do
+    -> { @read.read_nonblock(-1) }.should raise_error(ArgumentError)
+  end
+
   it "reads into the passed buffer" do
     buffer = ""
     @write.write("1")

--- a/core/io/read_nonblock_spec.rb
+++ b/core/io/read_nonblock_spec.rb
@@ -55,6 +55,14 @@ describe "IO#read_nonblock" do
     @read.read_nonblock(4).should == "hell"
   end
 
+  it "reads after ungetc with data in the buffer" do
+    @write.write("foobar")
+    c = @read.getc
+    @read.ungetc(c)
+    @read.read_nonblock(3).should == "foo"
+    @read.read_nonblock(3).should == "bar"
+  end
+
   it "returns less data if that is all that is available" do
     @write << "hello"
     @read.read_nonblock(10).should == "hello"

--- a/core/io/read_nonblock_spec.rb
+++ b/core/io/read_nonblock_spec.rb
@@ -55,14 +55,25 @@ describe "IO#read_nonblock" do
     @read.read_nonblock(4).should == "hell"
   end
 
-  platform_is_not :windows do # https://bugs.ruby-lang.org/issues/18881
-    it "reads after ungetc with data in the buffer" do
-      @write.write("foobar")
-      c = @read.getc
-      @read.ungetc(c)
-      @read.read_nonblock(3).should == "foo"
-      @read.read_nonblock(3).should == "bar"
-    end
+  it "reads after ungetc with data in the buffer" do
+    @write.write("foobar")
+    @read.set_encoding(
+      'utf-8', universal_newline: false
+    )
+    c = @read.getc
+    @read.ungetc(c)
+    @read.read_nonblock(3).should == "foo"
+    @read.read_nonblock(3).should == "bar"
+  end
+
+  it "raises an exception after ungetc with data in the buffer and character conversion enabled" do
+    @write.write("foobar")
+    @read.set_encoding(
+      'utf-8', universal_newline: true
+    )
+    c = @read.getc
+    @read.ungetc(c)
+    -> { @read.read_nonblock(3).should == "foo" }.should raise_error(IOError)
   end
 
   it "returns less data if that is all that is available" do

--- a/core/io/read_nonblock_spec.rb
+++ b/core/io/read_nonblock_spec.rb
@@ -55,12 +55,14 @@ describe "IO#read_nonblock" do
     @read.read_nonblock(4).should == "hell"
   end
 
-  it "reads after ungetc with data in the buffer" do
-    @write.write("foobar")
-    c = @read.getc
-    @read.ungetc(c)
-    @read.read_nonblock(3).should == "foo"
-    @read.read_nonblock(3).should == "bar"
+  platform_is_not :windows do # https://bugs.ruby-lang.org/issues/18881
+    it "reads after ungetc with data in the buffer" do
+      @write.write("foobar")
+      c = @read.getc
+      @read.ungetc(c)
+      @read.read_nonblock(3).should == "foo"
+      @read.read_nonblock(3).should == "bar"
+    end
   end
 
   it "returns less data if that is all that is available" do

--- a/core/io/read_spec.rb
+++ b/core/io/read_spec.rb
@@ -311,6 +311,9 @@ describe "IO#read" do
     -> { IOSpecs.closed_io.read }.should raise_error(IOError)
   end
 
+  it "raises ArgumentError when length is less than 0" do
+    -> { @io.read(-1) }.should raise_error(ArgumentError)
+  end
 
   platform_is_not :windows do
     it "raises IOError when stream is closed by another thread" do

--- a/core/io/read_spec.rb
+++ b/core/io/read_spec.rb
@@ -262,6 +262,13 @@ describe "IO#read" do
     @io.read(nil, buf).should equal buf
   end
 
+  it "returns the given buffer when there is nothing to read" do
+    buf = ""
+
+    @io.read
+    @io.read(nil, buf).should equal buf
+  end
+
   it "coerces the second argument to string and uses it as a buffer" do
     buf = "ABCDE"
     obj = mock("buff")

--- a/core/io/readchar_spec.rb
+++ b/core/io/readchar_spec.rb
@@ -1,6 +1,16 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
+describe :io_readchar_internal_encoding, shared: true do
+  it "returns a transcoded String" do
+    @io.readchar.should == "あ"
+  end
+
+  it "sets the String encoding to the internal encoding" do
+    @io.readchar.encoding.should equal(Encoding::UTF_8)
+  end
+end
+
 describe "IO#readchar" do
   before :each do
     @io = IOSpecs.io_fixture "lines.txt"
@@ -26,6 +36,62 @@ describe "IO#readchar" do
 
   it "raises IOError on closed stream" do
     -> { IOSpecs.closed_io.readchar }.should raise_error(IOError)
+  end
+
+  describe "with internal encoding" do
+    after :each do
+      @io.close if @io
+    end
+
+    describe "not specified" do
+      before :each do
+        @io = IOSpecs.io_fixture "read_euc_jp.txt", "r:euc-jp"
+      end
+
+      it "does not transcode the String" do
+        @io.readchar.should == ("あ").encode(Encoding::EUC_JP)
+      end
+
+      it "sets the String encoding to the external encoding" do
+        @io.readchar.encoding.should equal(Encoding::EUC_JP)
+      end
+    end
+
+    describe "specified by open mode" do
+      before :each do
+        @io = IOSpecs.io_fixture "read_euc_jp.txt", "r:euc-jp:utf-8"
+      end
+
+      it_behaves_like :io_readchar_internal_encoding, nil
+    end
+
+    describe "specified by mode: option" do
+      before :each do
+        @io = IOSpecs.io_fixture "read_euc_jp.txt", mode: "r:euc-jp:utf-8"
+      end
+
+      it_behaves_like :io_readchar_internal_encoding, nil
+    end
+
+    describe "specified by internal_encoding: option" do
+      before :each do
+        options = { mode: "r",
+                    internal_encoding: "utf-8",
+                    external_encoding: "euc-jp" }
+        @io = IOSpecs.io_fixture "read_euc_jp.txt", options
+      end
+
+      it_behaves_like :io_readchar_internal_encoding, nil
+    end
+
+    describe "specified by encoding: option" do
+      before :each do
+        options = { mode: "r", encoding: "euc-jp:utf-8" }
+        @io = IOSpecs.io_fixture "read_euc_jp.txt", options
+      end
+
+      it_behaves_like :io_readchar_internal_encoding, nil
+    end
   end
 end
 

--- a/core/io/readchar_spec.rb
+++ b/core/io/readchar_spec.rb
@@ -37,61 +37,61 @@ describe "IO#readchar" do
   it "raises IOError on closed stream" do
     -> { IOSpecs.closed_io.readchar }.should raise_error(IOError)
   end
+end
 
-  describe "with internal encoding" do
-    after :each do
-      @io.close if @io
+describe "IO#readchar with internal encoding" do
+  after :each do
+    @io.close if @io
+  end
+
+  describe "not specified" do
+    before :each do
+      @io = IOSpecs.io_fixture "read_euc_jp.txt", "r:euc-jp"
     end
 
-    describe "not specified" do
-      before :each do
-        @io = IOSpecs.io_fixture "read_euc_jp.txt", "r:euc-jp"
-      end
-
-      it "does not transcode the String" do
-        @io.readchar.should == ("あ").encode(Encoding::EUC_JP)
-      end
-
-      it "sets the String encoding to the external encoding" do
-        @io.readchar.encoding.should equal(Encoding::EUC_JP)
-      end
+    it "does not transcode the String" do
+      @io.readchar.should == ("あ").encode(Encoding::EUC_JP)
     end
 
-    describe "specified by open mode" do
-      before :each do
-        @io = IOSpecs.io_fixture "read_euc_jp.txt", "r:euc-jp:utf-8"
-      end
+    it "sets the String encoding to the external encoding" do
+      @io.readchar.encoding.should equal(Encoding::EUC_JP)
+    end
+  end
 
-      it_behaves_like :io_readchar_internal_encoding, nil
+  describe "specified by open mode" do
+    before :each do
+      @io = IOSpecs.io_fixture "read_euc_jp.txt", "r:euc-jp:utf-8"
     end
 
-    describe "specified by mode: option" do
-      before :each do
-        @io = IOSpecs.io_fixture "read_euc_jp.txt", mode: "r:euc-jp:utf-8"
-      end
+    it_behaves_like :io_readchar_internal_encoding, nil
+  end
 
-      it_behaves_like :io_readchar_internal_encoding, nil
+  describe "specified by mode: option" do
+    before :each do
+      @io = IOSpecs.io_fixture "read_euc_jp.txt", mode: "r:euc-jp:utf-8"
     end
 
-    describe "specified by internal_encoding: option" do
-      before :each do
-        options = { mode: "r",
-                    internal_encoding: "utf-8",
-                    external_encoding: "euc-jp" }
-        @io = IOSpecs.io_fixture "read_euc_jp.txt", options
-      end
+    it_behaves_like :io_readchar_internal_encoding, nil
+  end
 
-      it_behaves_like :io_readchar_internal_encoding, nil
+  describe "specified by internal_encoding: option" do
+    before :each do
+      options = { mode: "r",
+                  internal_encoding: "utf-8",
+                  external_encoding: "euc-jp" }
+      @io = IOSpecs.io_fixture "read_euc_jp.txt", options
     end
 
-    describe "specified by encoding: option" do
-      before :each do
-        options = { mode: "r", encoding: "euc-jp:utf-8" }
-        @io = IOSpecs.io_fixture "read_euc_jp.txt", options
-      end
+    it_behaves_like :io_readchar_internal_encoding, nil
+  end
 
-      it_behaves_like :io_readchar_internal_encoding, nil
+  describe "specified by encoding: option" do
+    before :each do
+      options = { mode: "r", encoding: "euc-jp:utf-8" }
+      @io = IOSpecs.io_fixture "read_euc_jp.txt", options
     end
+
+    it_behaves_like :io_readchar_internal_encoding, nil
   end
 end
 

--- a/core/io/readpartial_spec.rb
+++ b/core/io/readpartial_spec.rb
@@ -59,7 +59,7 @@ describe "IO#readpartial" do
   end
 
   it "discards the existing buffer content upon successful read" do
-    buffer = "existing"
+    buffer = "existing content"
     @wr.write("hello world")
     @wr.close
     @rd.readpartial(11, buffer)

--- a/core/io/readpartial_spec.rb
+++ b/core/io/readpartial_spec.rb
@@ -93,4 +93,11 @@ describe "IO#readpartial" do
     @rd.readpartial(0).should == ""
   end
 
+  it "preserves the encoding of the given buffer" do
+    buffer = ''.encode(Encoding::ISO_8859_1)
+    @wr.write("abc")
+    @wr.close
+    @rd.readpartial(10, buffer)
+    buffer.encoding.should == Encoding::ISO_8859_1
+  end
 end

--- a/core/io/readpartial_spec.rb
+++ b/core/io/readpartial_spec.rb
@@ -93,6 +93,12 @@ describe "IO#readpartial" do
     @rd.readpartial(0).should == ""
   end
 
+  it "clears and returns the given buffer if the length argument is 0" do
+    buffer = "existing content"
+    @rd.readpartial(0, buffer).should == buffer
+    buffer.should == ""
+  end
+
   it "preserves the encoding of the given buffer" do
     buffer = ''.encode(Encoding::ISO_8859_1)
     @wr.write("abc")

--- a/core/io/rewind_spec.rb
+++ b/core/io/rewind_spec.rb
@@ -18,6 +18,17 @@ describe "IO#rewind" do
     @io.readline.should == "Voici la ligne une.\n"
   end
 
+  it "positions the instance to the beginning of output for write-only IO" do
+    name = tmp("io_rewind_spec")
+    io = File.open(name, "w")
+    io.write("Voici la ligne une.\n")
+    io.rewind
+    io.pos.should == 0
+  ensure
+    io.close
+    rm_r name
+  end
+
   it "positions the instance to the beginning of input and clears EOF" do
     value = @io.read
     @io.rewind
@@ -30,6 +41,10 @@ describe "IO#rewind" do
     @io.lineno.should == 1
     @io.rewind
     @io.lineno.should == 0
+  end
+
+  it "returns 0" do
+    @io.rewind.should == 0
   end
 
   it "raises IOError on closed stream" do

--- a/core/io/set_encoding_by_bom_spec.rb
+++ b/core/io/set_encoding_by_bom_spec.rb
@@ -12,45 +12,232 @@ describe "IO#set_encoding_by_bom" do
     rm_r @name
   end
 
+  it "returns nil if not readable" do
+    not_readable_io = new_io(@name, 'wb')
+
+    not_readable_io.set_encoding_by_bom.should be_nil
+    not_readable_io.external_encoding.should == Encoding::ASCII_8BIT
+  ensure
+    not_readable_io.close
+  end
+
   it "returns the result encoding if found BOM UTF-8 sequence" do
+    File.binwrite(@name, "\u{FEFF}")
+
+    @io.set_encoding_by_bom.should == Encoding::UTF_8
+    @io.external_encoding.should == Encoding::UTF_8
+    @io.read.b.should == "".b
+    @io.rewind
+    @io.set_encoding(Encoding::ASCII_8BIT)
+
     File.binwrite(@name, "\u{FEFF}abc")
 
     @io.set_encoding_by_bom.should == Encoding::UTF_8
     @io.external_encoding.should == Encoding::UTF_8
+    @io.read.b.should == "abc".b
   end
 
   it "returns the result encoding if found BOM UTF_16LE sequence" do
+    File.binwrite(@name, "\xFF\xFE")
+
+    @io.set_encoding_by_bom.should == Encoding::UTF_16LE
+    @io.external_encoding.should == Encoding::UTF_16LE
+    @io.read.b.should == "".b
+    @io.rewind
+    @io.set_encoding(Encoding::ASCII_8BIT)
+
     File.binwrite(@name, "\xFF\xFEabc")
 
     @io.set_encoding_by_bom.should == Encoding::UTF_16LE
     @io.external_encoding.should == Encoding::UTF_16LE
+    @io.read.b.should == "abc".b
   end
 
   it "returns the result encoding if found BOM UTF_16BE sequence" do
+    File.binwrite(@name, "\xFE\xFF")
+
+    @io.set_encoding_by_bom.should == Encoding::UTF_16BE
+    @io.external_encoding.should == Encoding::UTF_16BE
+    @io.read.b.should == "".b
+    @io.rewind
+    @io.set_encoding(Encoding::ASCII_8BIT)
+
     File.binwrite(@name, "\xFE\xFFabc")
 
     @io.set_encoding_by_bom.should == Encoding::UTF_16BE
     @io.external_encoding.should == Encoding::UTF_16BE
+    @io.read.b.should == "abc".b
   end
 
   it "returns the result encoding if found BOM UTF_32LE sequence" do
+    File.binwrite(@name, "\xFF\xFE\x00\x00")
+
+    @io.set_encoding_by_bom.should == Encoding::UTF_32LE
+    @io.external_encoding.should == Encoding::UTF_32LE
+    @io.read.b.should == "".b
+    @io.rewind
+    @io.set_encoding(Encoding::ASCII_8BIT)
+
     File.binwrite(@name, "\xFF\xFE\x00\x00abc")
 
     @io.set_encoding_by_bom.should == Encoding::UTF_32LE
     @io.external_encoding.should == Encoding::UTF_32LE
+    @io.read.b.should == "abc".b
   end
 
   it "returns the result encoding if found BOM UTF_32BE sequence" do
+    File.binwrite(@name, "\x00\x00\xFE\xFF")
+
+    @io.set_encoding_by_bom.should == Encoding::UTF_32BE
+    @io.external_encoding.should == Encoding::UTF_32BE
+    @io.read.b.should == "".b
+    @io.rewind
+    @io.set_encoding(Encoding::ASCII_8BIT)
+
     File.binwrite(@name, "\x00\x00\xFE\xFFabc")
 
     @io.set_encoding_by_bom.should == Encoding::UTF_32BE
     @io.external_encoding.should == Encoding::UTF_32BE
+    @io.read.b.should == "abc".b
+  end
+
+  it "returns nil if io is empty" do
+    @io.set_encoding_by_bom.should be_nil
+    @io.external_encoding.should == Encoding::ASCII_8BIT
+  end
+
+  it "returns nil if UTF-8 BOM sequence is incomplete" do
+    File.write(@name, "\xEF")
+
+    @io.set_encoding_by_bom.should == nil
+    @io.external_encoding.should == Encoding::ASCII_8BIT
+    @io.read.b.should == "\xEF".b
+    @io.rewind
+
+    File.write(@name, "\xEFa")
+
+    @io.set_encoding_by_bom.should == nil
+    @io.external_encoding.should == Encoding::ASCII_8BIT
+    @io.read.b.should == "\xEFa".b
+    @io.rewind
+
+    File.write(@name, "\xEF\xBB")
+
+    @io.set_encoding_by_bom.should == nil
+    @io.external_encoding.should == Encoding::ASCII_8BIT
+    @io.read.b.should == "\xEF\xBB".b
+    @io.rewind
+
+    File.write(@name, "\xEF\xBBa")
+
+    @io.set_encoding_by_bom.should == nil
+    @io.external_encoding.should == Encoding::ASCII_8BIT
+    @io.read.b.should == "\xEF\xBBa".b
+  end
+
+  it "returns nil if UTF-16BE BOM sequence is incomplete" do
+    File.write(@name, "\xFE")
+
+    @io.set_encoding_by_bom.should == nil
+    @io.external_encoding.should == Encoding::ASCII_8BIT
+    @io.read.b.should == "\xFE".b
+    @io.rewind
+
+    File.write(@name, "\xFEa")
+
+    @io.set_encoding_by_bom.should == nil
+    @io.external_encoding.should == Encoding::ASCII_8BIT
+    @io.read.b.should == "\xFEa".b
+  end
+
+  it "returns nil if UTF-16LE/UTF-32LE BOM sequence is incomplete" do
+    File.write(@name, "\xFF")
+
+    @io.set_encoding_by_bom.should == nil
+    @io.external_encoding.should == Encoding::ASCII_8BIT
+    @io.read.b.should == "\xFF".b
+    @io.rewind
+
+    File.write(@name, "\xFFa")
+
+    @io.set_encoding_by_bom.should == nil
+    @io.external_encoding.should == Encoding::ASCII_8BIT
+    @io.read.b.should == "\xFFa".b
+  end
+
+  it "returns UTF-16LE if UTF-32LE BOM sequence is incomplete" do
+    File.write(@name, "\xFF\xFE")
+
+    @io.set_encoding_by_bom.should == Encoding::UTF_16LE
+    @io.external_encoding.should == Encoding::UTF_16LE
+    @io.read.b.should == "".b
+    @io.rewind
+    @io.set_encoding(Encoding::ASCII_8BIT)
+
+    File.write(@name, "\xFF\xFE\x00")
+
+    @io.set_encoding_by_bom.should == Encoding::UTF_16LE
+    @io.external_encoding.should == Encoding::UTF_16LE
+    @io.read.b.should == "\x00".b
+    @io.rewind
+    @io.set_encoding(Encoding::ASCII_8BIT)
+
+    File.write(@name, "\xFF\xFE\x00a")
+
+    @io.set_encoding_by_bom.should == Encoding::UTF_16LE
+    @io.external_encoding.should == Encoding::UTF_16LE
+    @io.read.b.should == "\x00a".b
+  end
+
+  it "returns nil if UTF-32BE BOM sequence is incomplete" do
+    File.write(@name, "\x00")
+
+    @io.set_encoding_by_bom.should == nil
+    @io.external_encoding.should == Encoding::ASCII_8BIT
+    @io.read.b.should == "\x00".b
+    @io.rewind
+
+    File.write(@name, "\x00a")
+
+    @io.set_encoding_by_bom.should == nil
+    @io.external_encoding.should == Encoding::ASCII_8BIT
+    @io.read.b.should == "\x00a".b
+    @io.rewind
+
+    File.write(@name, "\x00\x00")
+
+    @io.set_encoding_by_bom.should == nil
+    @io.external_encoding.should == Encoding::ASCII_8BIT
+    @io.read.b.should == "\x00\x00".b
+    @io.rewind
+
+    File.write(@name, "\x00\x00a")
+
+    @io.set_encoding_by_bom.should == nil
+    @io.external_encoding.should == Encoding::ASCII_8BIT
+    @io.read.b.should == "\x00\x00a".b
+    @io.rewind
+
+    File.write(@name, "\x00\x00\xFE")
+
+    @io.set_encoding_by_bom.should == nil
+    @io.external_encoding.should == Encoding::ASCII_8BIT
+    @io.read.b.should == "\x00\x00\xFE".b
+    @io.rewind
+
+    File.write(@name, "\x00\x00\xFEa")
+
+    @io.set_encoding_by_bom.should == nil
+    @io.external_encoding.should == Encoding::ASCII_8BIT
+    @io.read.b.should == "\x00\x00\xFEa".b
   end
 
   it "returns nil if found BOM sequence not provided" do
     File.write(@name, "abc")
 
     @io.set_encoding_by_bom.should == nil
+    @io.external_encoding.should == Encoding::ASCII_8BIT
+    @io.read(3).should == "abc".b
   end
 
   it 'returns exception if io not in binary mode' do

--- a/core/io/set_encoding_spec.rb
+++ b/core/io/set_encoding_spec.rb
@@ -188,4 +188,21 @@ describe "IO#set_encoding" do
     @io.external_encoding.should == Encoding::UTF_8
     @io.internal_encoding.should == Encoding::UTF_16BE
   end
+
+  it "saves encoding options passed as a hash in the last argument" do
+    File.write(@name, "\xff")
+    io = File.open(@name)
+    io.set_encoding(Encoding::EUC_JP, Encoding::SHIFT_JIS, invalid: :replace, replace: ".")
+    io.read.should == "."
+  ensure
+    io.close
+  end
+
+  it "raises ArgumentError when no arguments are given" do
+    -> { @io.set_encoding() }.should raise_error(ArgumentError)
+  end
+
+  it "raises ArgumentError when too many arguments are given" do
+    -> { @io.set_encoding(1, 2, 3) }.should raise_error(ArgumentError)
+  end
 end

--- a/core/io/shared/each.rb
+++ b/core/io/shared/each.rb
@@ -113,6 +113,13 @@ describe :io_each, shared: true do
       @io.send(@method, "") { |s| ScratchPad << s }
       ScratchPad.recorded.should == IOSpecs.paragraphs
     end
+
+    it "discards leading newlines" do
+      @io.readline
+      @io.readline
+      @io.send(@method, "") { |s| ScratchPad << s }
+      ScratchPad.recorded.should == IOSpecs.paragraphs[1..-1]
+    end
   end
 
   describe "with both separator and limit" do
@@ -151,6 +158,13 @@ describe :io_each, shared: true do
         it "yields each paragraph" do
           @io.send(@method, "", 1024) { |s| ScratchPad << s }
           ScratchPad.recorded.should == IOSpecs.paragraphs
+        end
+
+        it "discards leading newlines" do
+          @io.readline
+          @io.readline
+          @io.send(@method, "", 1024) { |s| ScratchPad << s }
+          ScratchPad.recorded.should == IOSpecs.paragraphs[1..-1]
         end
       end
     end

--- a/core/io/shared/each.rb
+++ b/core/io/shared/each.rb
@@ -224,6 +224,14 @@ describe :io_each, shared: true do
       ]
     end
   end
+
+  describe "when passed too many arguments" do
+    it "raises ArgumentError" do
+      -> {
+        @io.send(@method, "", 1, "excess argument", chomp: true) {}
+      }.should raise_error(ArgumentError)
+    end
+  end
 end
 
 describe :io_each_default_separator, shared: true do

--- a/core/io/shared/write.rb
+++ b/core/io/shared/write.rb
@@ -69,16 +69,6 @@ describe :io_write, shared: true do
     -> { IOSpecs.closed_io.send(@method, "hello") }.should raise_error(IOError)
   end
 
-  it "does not modify the passed argument" do
-    File.open(@filename, "w") do |f|
-      f.set_encoding(Encoding::IBM437)
-      # A character whose codepoint differs between UTF-8 and IBM437
-      f.write "ƒ".freeze
-    end
-
-    File.binread(@filename).bytes.should == [159]
-  end
-
   describe "on a pipe" do
     before :each do
       @r, @w = IO.pipe

--- a/core/io/sysread_spec.rb
+++ b/core/io/sysread_spec.rb
@@ -100,6 +100,13 @@ describe "IO#sysread on a file" do
     @file.sysread(11, buffer)
     buffer.should == "01234567890"
   end
+
+  it "discards the existing buffer content upon error" do
+    buffer = "existing content"
+    @file.seek(0, :END)
+    -> { @file.sysread(1, buffer) }.should raise_error(EOFError)
+    buffer.should be_empty
+  end
 end
 
 describe "IO#sysread" do

--- a/core/io/sysread_spec.rb
+++ b/core/io/sysread_spec.rb
@@ -124,7 +124,7 @@ describe "IO#sysread" do
     @read.sysread(3).should == "ab"
   end
 
-  platform_is_not :windows do # https://bugs.ruby-lang.org/issues/18880
+  guard_not -> { platform_is :windows and ruby_version_is ""..."3.2" } do # https://bugs.ruby-lang.org/issues/18880
     it "raises ArgumentError when length is less than 0" do
       -> { @read.sysread(-1) }.should raise_error(ArgumentError)
     end

--- a/core/io/sysread_spec.rb
+++ b/core/io/sysread_spec.rb
@@ -124,7 +124,9 @@ describe "IO#sysread" do
     @read.sysread(3).should == "ab"
   end
 
-  it "raises ArgumentError when length is less than 0" do
-    -> { @read.sysread(-1) }.should raise_error(ArgumentError)
+  platform_is_not :windows do # https://bugs.ruby-lang.org/issues/18880
+    it "raises ArgumentError when length is less than 0" do
+      -> { @read.sysread(-1) }.should raise_error(ArgumentError)
+    end
   end
 end

--- a/core/io/syswrite_spec.rb
+++ b/core/io/syswrite_spec.rb
@@ -29,6 +29,16 @@ describe "IO#syswrite on a file" do
     end
   end
 
+  it "does not modify the passed argument" do
+    File.open(@filename, "w") do |f|
+      f.set_encoding(Encoding::IBM437)
+      # A character whose codepoint differs between UTF-8 and IBM437
+      f.syswrite("ƒ".freeze)
+    end
+
+    File.binread(@filename).bytes.should == [198, 146]
+  end
+
   it "warns if called immediately after a buffered IO#write" do
     @file.write("abcde")
     -> { @file.syswrite("fghij") }.should complain(/syswrite/)

--- a/core/io/write_nonblock_spec.rb
+++ b/core/io/write_nonblock_spec.rb
@@ -31,6 +31,16 @@ platform_is_not :windows do
       end
     end
 
+    it "does not modify the passed argument" do
+      File.open(@filename, "w") do |f|
+        f.set_encoding(Encoding::IBM437)
+        # A character whose codepoint differs between UTF-8 and IBM437
+        f.write_nonblock("ƒ".freeze)
+      end
+
+      File.binread(@filename).bytes.should == [198, 146]
+    end
+
     it "checks if the file is writable if writing zero bytes" do
       -> {
          @readonly_file.write_nonblock("")

--- a/core/io/write_spec.rb
+++ b/core/io/write_spec.rb
@@ -44,6 +44,16 @@ describe "IO#write on a file" do
     @file.write("hellø").should == 6
   end
 
+  it "does not modify the passed argument" do
+    File.open(@filename, "w") do |f|
+      f.set_encoding(Encoding::IBM437)
+      # A character whose codepoint differs between UTF-8 and IBM437
+      f.write("ƒ".freeze)
+    end
+
+    File.binread(@filename).bytes.should == [159]
+  end
+
   it "uses the encoding from the given option for non-ascii encoding" do
     File.open(@filename, "w", encoding: Encoding::UTF_32LE) do |file|
       file.write("hi").should == 8


### PR DESCRIPTION
These tests cover more corner cases of various IO methods and fix several invalid tests.  They have been tested against all stable versions of MRI since version 2.7.0.

A single case for failures was discovered in `IO#readpartial` behavior for all but the latest version of each of the 2.7 and 3.0 series (2.7.6 and 3.0.4).  The affected older versions truncate a given buffer to zero bytes when told to read zero bytes.  Versions 2.7.6, 3.0.4, and all 3.1 versions return the given buffer unmodified, which makes sense since the method can simply short circuit when told to read zero bytes.

I left those failures in place since it appears that the MRI developers have addressed the behavior in recent versions.  It appears they decided that the short circuit behavior is correct.  I can augment this patch to make the broken versions succeed if desired.