### PR TITLE
Add tests for Enumerable#compact and Enumerator::Lazy#compact

### DIFF
--- a/core/enumerable/compact_spec.rb
+++ b/core/enumerable/compact_spec.rb
@@ -1,0 +1,11 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+ruby_version_is '3.1' do
+  describe "Enumerable#compact" do
+    it 'returns array without nil elements' do
+      arr = EnumerableSpecs::Numerous.new(nil, 1, 2, nil, true)
+      arr.compact.should == [1, 2, true]
+    end
+  end
+end

--- a/core/enumerator/lazy/lazy_spec.rb
+++ b/core/enumerator/lazy/lazy_spec.rb
@@ -16,6 +16,10 @@ describe "Enumerator::Lazy" do
     ]
     lazy_methods += [:chunk_while, :uniq]
 
+    ruby_version_is('3.1') do
+      lazy_methods += [:compact]
+    end
+
     Enumerator::Lazy.instance_methods(false).should include(*lazy_methods)
   end
 end
@@ -24,5 +28,15 @@ describe "Enumerator::Lazy#lazy" do
   it "returns self" do
     lazy = (1..3).to_enum.lazy
     lazy.lazy.should equal(lazy)
+  end
+end
+
+ruby_version_is '3.1' do
+  describe "Enumerator::Lazy#compact" do
+    it 'returns array without nil elements' do
+      arr = [1, nil, 3, false, 5].to_enum.lazy.compact
+      arr.should be_an_instance_of(Enumerator::Lazy)
+      arr.force.should == [1, 3, false, 5]
+    end
   end
 end


### PR DESCRIPTION
Added basic tests cases for `Enumerable#compact` & ` Enumerator::Lazy#compact`. Ref [17312](https://bugs.ruby-lang.org/issues/17312)