### PR TITLE
Fix character encoding of iso-8859-9-encoding.rb

### DIFF
--- a/core/string/fixtures/iso-8859-9-encoding.rb
+++ b/core/string/fixtures/iso-8859-9-encoding.rb
@@ -4,6 +4,6 @@ module StringSpecs
     def source_encoding; __ENCODING__; end
     def x_escape; [0xDF].pack('C').force_encoding("iso-8859-9"); end
     def ascii_only; "glark"; end
-    def cedilla; "Åž"; end
+    def cedilla; "Þ"; end
   end
 end


### PR DESCRIPTION
The `Ş` character in `iso-8859-9-encoding.rb` appears to be encoded in UTF-8 form instead of `iso-8859-9`. That seems wrong to me. Therefore this PR recodes the file from UTF-8 to `iso-8859-9` to match the `encoding` comment.