### PR TITLE
Fix tests with Europe/Amsterdam pre-1970 time on tzdata version 2022b.

### DIFF
--- a/core/time/shared/local.rb
+++ b/core/time/shared/local.rb
@@ -8,10 +8,10 @@ describe :time_local, shared: true do
 
   platform_is_not :windows do
     describe "timezone changes" do
-      it "correctly adjusts the timezone change to 'CEST' on 'Europe/Amsterdam'" do
+      it "correctly adjusts the timezone change to 'CET' on 'Europe/Amsterdam'" do
         with_timezone("Europe/Amsterdam") do
-          Time.send(@method, 1940, 5, 16).to_a.should ==
-            [0, 40, 1, 16, 5, 1940, 4, 137, true, "CEST"]
+          Time.send(@method, 1970, 5, 16).to_a.should ==
+            [0, 0, 0, 16, 5, 1970, 6, 136, false, "CET"]
         end
       end
     end


### PR DESCRIPTION
The Time Zone Database (tzdata) changed the pre-1970 timestamps in some zones
including Europe/Amsterdam on tzdata version 2022b or later.
See <https://github.com/eggert/tz/commit/35fa37fbbb152f5dbed4fd5edfdc968e3584fe12>.

The tzdata RPM package maintainer on Fedora project suggested changing the Ruby
test, because the change is intentional.
See <https://bugzilla.redhat.com/show_bug.cgi?id=2118259#c1>.

We use post-1970 time test data to simplify the test.

---

I tested the command in the 2 cases below.

tzdata: version 2022b,  Ruby: the latest master branch

```
<mock-chroot> sh-5.1$ cat /etc/fedora-release 
Fedora release 38 (Rawhide)

<mock-chroot> sh-5.1$ rpm -q tzdata
tzdata-2022b-1.fc38.noarch

<mock-chroot> sh-5.1$ dest/bin/ruby -v
ruby 3.2.0dev (2022-08-23T09:01:35Z master 46c3a93982) [x86_64-linux]

<mock-chroot> sh-5.1$ dest/bin/ruby -e "p Time.send(:local, 1970, 5, 16).to_a"
[0, 0, 0, 16, 5, 1970, 6, 136, false, "CET"]
```

tzdata: version 2022a,  Ruby: 3.1.1

```
$ cat /etc/fedora-release 
Fedora release 36 (Thirty Six)

$ rpm -q tzdata
tzdata-2022a-2.fc36.noarch

$ ruby -v
ruby 3.1.1p18 (2022-02-18 revision 53f5fc4236) [x86_64-linux]

$ ruby -e "p Time.send(:local, 1970, 5, 16).to_a"
[0, 0, 0, 16, 5, 1970, 6, 136, false, "CET"]
```

Note for the return value of the `Time.send(:local, 1970, 5, 16).to_a`.
https://ruby-doc.org/core-3.1.2/Time.html#method-i-to_a


