### PR TITLE
Add a spec for SizedQueue.new implicit integer conversion

### DIFF
--- a/shared/sizedqueue/new.rb
+++ b/shared/sizedqueue/new.rb
@@ -1,7 +1,12 @@
 describe :sizedqueue_new, shared: true do
-  it "raises a TypeError when the given argument is not Numeric" do
-    -> { @object.call("foo") }.should raise_error(TypeError)
+  it "raises a TypeError when the given argument doesn't respond to #to_int" do
+    -> { @object.call("12") }.should raise_error(TypeError)
     -> { @object.call(Object.new) }.should raise_error(TypeError)
+
+    @object.call(12.9).max.should == 12
+    object = Object.new
+    object.define_singleton_method(:to_int) { 42 }
+    @object.call(object).max.should == 42
   end
 
   it "raises an argument error when no argument is given" do


### PR DESCRIPTION
I discovered that TruffleRuby doesn't accept anything but true Integer instances.

MRI call `to_int` on the argument, allowing Float and a bunch of other types.

cc @eregon 