### PR TITLE
[zlib] add encoding spec

### DIFF
--- a/library/zlib/deflate/deflate_spec.rb
+++ b/library/zlib/deflate/deflate_spec.rb
@@ -58,6 +58,11 @@ describe "Zlib::Deflate#deflate" do
                       Array.new(31, 0) +
                       [24, 128, 0, 0, 1]).pack('C*')
   end
+
+  it "has a binary encoding" do
+    @deflator.deflate("").encoding.should == Encoding::BINARY
+    @deflator.finish.encoding.should == Encoding::BINARY
+  end
 end
 
 describe "Zlib::Deflate#deflate" do

--- a/library/zlib/inflate/inflate_spec.rb
+++ b/library/zlib/inflate/inflate_spec.rb
@@ -39,6 +39,13 @@ describe "Zlib::Inflate#inflate" do
     @inflator.finish.should == 'uncompressed_data'
   end
 
+  it "has a binary encoding" do
+    data = [120, 156, 99, 96, 128, 1, 0, 0, 10, 0, 1].pack('C*')
+    unzipped = @inflator.inflate data
+    @inflator.finish.encoding.should == Encoding::BINARY
+    unzipped.encoding.should == Encoding::BINARY
+  end
+
 end
 
 describe "Zlib::Inflate.inflate" do


### PR DESCRIPTION
relates to a JRuby bug where the output is US-ASCII in some cases, it should be binary