### PR TITLE
Socket: add spec for converting service name to port

### DIFF
--- a/library/socket/shared/pack_sockaddr.rb
+++ b/library/socket/shared/pack_sockaddr.rb
@@ -17,6 +17,9 @@ describe :socket_pack_sockaddr_in, shared: true do
 
     sockaddr_in = Socket.public_send(@method, nil, '127.0.0.1')
     Socket.unpack_sockaddr_in(sockaddr_in).should == [0, '127.0.0.1']
+
+    sockaddr_in = Socket.public_send(@method, 'http', '127.0.0.1')
+    Socket.unpack_sockaddr_in(sockaddr_in).should == [80, '127.0.0.1']
   end
 
   describe 'using an IPv4 address' do

--- a/library/socket/shared/pack_sockaddr.rb
+++ b/library/socket/shared/pack_sockaddr.rb
@@ -17,7 +17,9 @@ describe :socket_pack_sockaddr_in, shared: true do
 
     sockaddr_in = Socket.public_send(@method, nil, '127.0.0.1')
     Socket.unpack_sockaddr_in(sockaddr_in).should == [0, '127.0.0.1']
+  end
 
+  it 'resolves the service name to a port' do
     sockaddr_in = Socket.public_send(@method, 'http', '127.0.0.1')
     Socket.unpack_sockaddr_in(sockaddr_in).should == [80, '127.0.0.1']
   end


### PR DESCRIPTION
This was helpful for us while implementing `Socket.pack_sockaddr_in` in [Natalie](https://github.com/natalie-lang/natalie).