### PR TITLE
Skip unpack_sockaddr_in with http at Solaris platform

### DIFF
--- a/library/socket/shared/pack_sockaddr.rb
+++ b/library/socket/shared/pack_sockaddr.rb
@@ -19,9 +19,11 @@ describe :socket_pack_sockaddr_in, shared: true do
     Socket.unpack_sockaddr_in(sockaddr_in).should == [0, '127.0.0.1']
   end
 
-  it 'resolves the service name to a port' do
-    sockaddr_in = Socket.public_send(@method, 'http', '127.0.0.1')
-    Socket.unpack_sockaddr_in(sockaddr_in).should == [80, '127.0.0.1']
+  platform_is_not :solaris do
+    it 'resolves the service name to a port' do
+      sockaddr_in = Socket.public_send(@method, 'http', '127.0.0.1')
+      Socket.unpack_sockaddr_in(sockaddr_in).should == [80, '127.0.0.1']
+    end
   end
 
   describe 'using an IPv4 address' do


### PR DESCRIPTION
This example failed at http://rubyci.s3.amazonaws.com/solaris10-gcc/ruby-master/log/20220929T050003Z.fail.html.gz