### PR TITLE
Add specs `Struct#initialize` warns about passing only keyword arguments

### DIFF
--- a/core/struct/initialize_spec.rb
+++ b/core/struct/initialize_spec.rb
@@ -40,4 +40,12 @@ describe "Struct#initialize" do
   it "can be overridden" do
     StructClasses::SubclassX.new(:y).new.key.should == :value
   end
+
+  ruby_version_is "3.1" do
+    it "warns about passing only keyword arguments" do
+      -> {
+        StructClasses::Ruby.new(version: "3.1", platform: "OS")
+      }.should complain(/warning: Passing only keyword arguments/)
+    end
+  end
 end


### PR DESCRIPTION
Hello 👋 

This is my proposal to cover

> Passing only keyword arguments to `Struct#initialize` is warned. You need to use a Hash literal to set a Hash to a first member. [Feature #16806](https://bugs.ruby-lang.org/issues/16806)

from

* https://github.com/ruby/spec/issues/923

Let me know if I can do anything to improve it.

Thank you!