### PR TITLE
Add spec: `Struct#keyword_init?`

### DIFF
--- a/core/struct/keyword_init_spec.rb
+++ b/core/struct/keyword_init_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../../spec_helper'
+
+describe "Struct#keyword_init?" do
+  ruby_version_is '3.1' do # https://bugs.ruby-lang.org/issues/18008
+    it "returns true if it's initialized with keyword_init: true option" do
+      klass = Struct.new(:name, keyword_init: true)
+      klass.keyword_init?.should == true
+    end
+
+    it "returns false if it's initialized with keyword_init: false option" do
+      klass = Struct.new(:name, keyword_init: false)
+      klass.keyword_init?.should == false
+    end
+
+    it "returns nil if it's initialized without keyword_init option" do
+      klass = Struct.new(:name)
+      klass.keyword_init?.should == nil
+    end
+  end
+end


### PR DESCRIPTION
## Issue

A part of https://github.com/ruby/spec/pull/947

## Changes

I'm trying to cover the following part of the issue.

>StructClass#keyword_init? is added [[Feature #18008](https://bugs.ruby-lang.org/issues/18008)]

---

BTW, [this tweet](https://twitter.com/eregontp/status/1578351092303532032) encouraged me to create this pull request.

Please tell me if anything is wrong with this pull request since I'm almost new to contribution to this project!