### PR TITLE
Fix failing spec on master

### DIFF
--- a/core/time/shared/local.rb
+++ b/core/time/shared/local.rb
@@ -6,10 +6,12 @@ describe :time_local, shared: true do
     end
   end
 
-  it "uses the 'CET' timezone with TZ=Europe/Amsterdam in 1970" do
-    with_timezone("Europe/Amsterdam") do
-      Time.send(@method, 1970, 5, 16).to_a.should ==
-        [0, 0, 0, 16, 5, 1970, 6, 136, false, "CET"]
+  platform_is_not :windows do
+    it "uses the 'CET' timezone with TZ=Europe/Amsterdam in 1970" do
+      with_timezone("Europe/Amsterdam") do
+        Time.send(@method, 1970, 5, 16).to_a.should ==
+          [0, 0, 0, 16, 5, 1970, 6, 136, false, "CET"]
+      end
     end
   end
 end
@@ -37,5 +39,4 @@ describe :time_local_10_arg, shared: true do
       end
     end
   end
-
 end


### PR DESCRIPTION
Changing the time zone with Continent/City is unsupported on Windows

ref - [commit](https://github.com/ruby/spec/commit/e69370a926502ffd08263208cc21a7079716b55c)