### PR TITLE
Ruby 3.1: Omit values in hashs and kwargs

### DIFF
--- a/core/hash/hash_spec.rb
+++ b/core/hash/hash_spec.rb
@@ -41,4 +41,13 @@ describe "Hash#hash" do
     h.hash.should == {x: [h]}.hash
     # Like above, because h.eql?(x: [h])
   end
+
+  ruby_version_is "3.1" do
+    it "allows ommiting values" do
+      a = 1
+      b = 2
+
+     eval('{a:, b:}.should == { a: 1, b: 2 }')
+    end
+  end
 end

--- a/language/keyword_arguments_spec.rb
+++ b/language/keyword_arguments_spec.rb
@@ -321,6 +321,21 @@ ruby_version_is "3.0" do
         m({a: 1}).should == [[{a: 1}], {}]
       end
 
+      ruby_version_is "3.1" do
+        describe "omitted values" do
+          it "accepts short notation 'key' for 'key: value' syntax" do
+            def m(a:, b:)
+              [a, b]
+            end
+
+            a = 1
+            b = 2
+
+            eval('m(a:, b:).should == [1, 2]')
+          end
+        end
+      end
+
       ruby_version_is "3.2" do
         it "does not work with call(*ruby2_keyword_args) with missing ruby2_keywords in between" do
           class << self


### PR DESCRIPTION
Adding test for: 
> Values in Hash literals and keyword arguments can be omitted.

- See: [Feature #14579](https://bugs.ruby-lang.org/issues/14579)
- From: https://github.com/ruby/spec/issues/923