### PR TITLE
Ruby 3.1: Calls without methods inside endless methods

### DIFF
--- a/language/method_spec.rb
+++ b/language/method_spec.rb
@@ -1679,6 +1679,15 @@ ruby_version_is "3.0" do
 
         m.should == 42
       end
+
+      context "without parenthesis" do
+        evaluate <<-ruby do
+          def m = 42
+        ruby
+
+          m.should == 42
+        end
+      end
     end
 
     context "with arguments" do
@@ -1714,6 +1723,16 @@ ruby_version_is "3.0" do
         ruby
 
         m("meow", num: 2).should == "meow" * 4
+      end
+    end
+
+    ruby_version_is ""..."3.0" do
+      context "inside 'endless' method definitions" do
+        it "does not allow method calls without parenthesis" do
+          -> {
+            eval("def greet(person) = 'Hi, '.concat person")
+          }.should raise_error(SyntaxError)
+        end
       end
     end
   end
@@ -1821,6 +1840,17 @@ ruby_version_is "3.1" do
         ruby
 
         foo(1).should == [[], {bar: "baz", val: 1}]
+      end
+    end
+  end
+
+  describe "Inside 'endless' method definitions" do
+    context "allows method calls without parenthesis" do
+      evaluate <<-ruby do
+          def greet(person) = "Hi, ".concat person
+        ruby
+
+        greet("Homer").should == "Hi, Homer"
       end
     end
   end


### PR DESCRIPTION
Adding test for [Feature #17398](https://bugs.ruby-lang.org/issues/17398)

A command syntax is allowed in endless method definitions, i.e., you can now write

```
def foo = puts "Hello"
```

From: https://github.com/ruby/spec/issues/923