### PR TITLE
Ruby 3.1: `Enumerable#each_cons` and `each_slice` to return a receiver

### DIFF
--- a/core/enumerable/each_cons_spec.rb
+++ b/core/enumerable/each_cons_spec.rb
@@ -56,6 +56,12 @@ describe "Enumerable#each_cons" do
     multi.each_cons(2).to_a.should == [[[1, 2], [3, 4, 5]], [[3, 4, 5], [6, 7, 8, 9]]]
   end
 
+  ruby_version_is "3.1" do
+    it "returns self when a block is given" do
+      @enum.each_cons(3){}.should == @enum
+    end
+  end
+
   describe "when no block is given" do
     it "returns an enumerator" do
       e = @enum.each_cons(3)

--- a/core/enumerable/each_slice_spec.rb
+++ b/core/enumerable/each_slice_spec.rb
@@ -57,6 +57,12 @@ describe "Enumerable#each_slice" do
     e.to_a.should == @sliced
   end
 
+  ruby_version_is "3.1" do
+    it "returns self when a block is given" do
+      @enum.each_slice(3){}.should == @enum
+    end
+  end
+
   it "gathers whole arrays as elements when each yields multiple" do
     multi = EnumerableSpecs::YieldsMulti.new
     multi.each_slice(2).to_a.should == [[[1, 2], [3, 4, 5]], [[6, 7, 8, 9]]]


### PR DESCRIPTION
This PR adds spec for https://github.com/ruby/ruby/pull/1509

```ruby
[1, 2, 3].each_cons(2){}
# 3.0 => nil
# 3.1 => [1, 2, 3]

[1, 2, 3].each_slice(2){}
# 3.0 => nil
# 3.1 => [1, 2, 3]
```

From: 

* [Write specs for new Ruby 3.1 features and changes #923](https://github.com/ruby/spec/issues/923)