### PR TITLE
Ruby 3.1: Add specs for `Time#new` `in` keyword

### DIFF
--- a/core/time/at_spec.rb
+++ b/core/time/at_spec.rb
@@ -266,5 +266,10 @@ describe "Time.at" do
       time.zone.should == zone
       time.to_i.should == @epoch_time
     end
+
+    it "raises ArgumentError if format is invalid" do
+      -> { Time.at(@epoch_time, in: "+09:99") }.should raise_error(ArgumentError)
+      -> { Time.at(@epoch_time, in: "ABC") }.should raise_error(ArgumentError)
+    end
   end
 end

--- a/core/time/new_spec.rb
+++ b/core/time/new_spec.rb
@@ -332,4 +332,55 @@ describe "Time.new with a timezone argument" do
       end
     end
   end
+
+  ruby_version_is '3.1' do # https://bugs.ruby-lang.org/issues/17485
+    describe ":in keyword argument" do
+      it "could be UTC offset as a String in '+HH:MM or '-HH:MM' format" do
+        time = Time.new(2000, 1, 1, 12, 0, 0, in: "+05:00")
+
+        time.utc_offset.should == 5*60*60
+        time.zone.should == nil
+
+        time = Time.new(2000, 1, 1, 12, 0, 0, in: "-09:00")
+
+        time.utc_offset.should == -9*60*60
+        time.zone.should == nil
+      end
+
+      it "could be UTC offset as a number of seconds" do
+        time = Time.new(2000, 1, 1, 12, 0, 0, in: 5*60*60)
+
+        time.utc_offset.should == 5*60*60
+        time.zone.should == nil
+
+        time = Time.new(2000, 1, 1, 12, 0, 0, in: -9*60*60)
+
+        time.utc_offset.should == -9*60*60
+        time.zone.should == nil
+      end
+
+      it "could be a timezone object" do
+        zone = TimeSpecs::TimezoneWithName.new(name: "Asia/Colombo")
+        time = Time.new(2000, 1, 1, 12, 0, 0, in: zone)
+
+        time.utc_offset.should == 5*3600+30*60
+        time.zone.should == zone
+
+        zone = TimeSpecs::TimezoneWithName.new(name: "PST")
+        time = Time.new(2000, 1, 1, 12, 0, 0, in: zone)
+
+        time.utc_offset.should == -9*60*60
+        time.zone.should == zone
+      end
+
+      it "raises ArgumentError if format is invalid" do
+        -> { Time.new(2000, 1, 1, 12, 0, 0, in: "+09:99") }.should raise_error(ArgumentError)
+        -> { Time.new(2000, 1, 1, 12, 0, 0, in: "ABC") }.should raise_error(ArgumentError)
+      end
+
+      it "raises ArgumentError if two offset arguments are given" do
+        -> { Time.new(2000, 1, 1, 12, 0, 0, "+05:00", in: "+05:00") }.should raise_error(ArgumentError)
+      end
+    end
+  end
 end

--- a/core/time/now_spec.rb
+++ b/core/time/now_spec.rb
@@ -3,4 +3,49 @@ require_relative 'shared/now'
 
 describe "Time.now" do
   it_behaves_like :time_now, :now
+
+  describe ":in keyword argument" do
+    it "could be UTC offset as a String in '+HH:MM or '-HH:MM' format" do
+      time = Time.now(in: "+05:00")
+
+      time.utc_offset.should == 5*60*60
+      time.zone.should == nil
+
+      time = Time.now(in: "-09:00")
+
+      time.utc_offset.should == -9*60*60
+      time.zone.should == nil
+    end
+
+    it "could be UTC offset as a number of seconds" do
+      time = Time.now(in: 5*60*60)
+
+      time.utc_offset.should == 5*60*60
+      time.zone.should == nil
+
+      time = Time.now(in: -9*60*60)
+
+      time.utc_offset.should == -9*60*60
+      time.zone.should == nil
+    end
+
+    it "could be a timezone object" do
+      zone = TimeSpecs::TimezoneWithName.new(name: "Asia/Colombo")
+      time = Time.now(in: zone)
+
+      time.utc_offset.should == 5*3600+30*60
+      time.zone.should == zone
+
+      zone = TimeSpecs::TimezoneWithName.new(name: "PST")
+      time = Time.now(in: zone)
+
+      time.utc_offset.should == -9*60*60
+      time.zone.should == zone
+    end
+
+    it "raises ArgumentError if format is invalid" do
+      -> { Time.now(in: "+09:99") }.should raise_error(ArgumentError)
+      -> { Time.now(in: "ABC") }.should raise_error(ArgumentError)
+    end
+  end
 end


### PR DESCRIPTION
## Issue

* [Write specs for new Ruby 3.1 features and changes #923](https://github.com/ruby/spec/issues/923)

## Change

This pull request covers the spec below. 

> * [ ]    Time.new now accepts optional `in:` keyword argument for the
>   timezone, as well as `Time.at` and `Time.now`, so that is now
>   you can omit minor arguments to `Time.new`. [[Feature #17485](https://bugs.ruby-lang.org/issues/17485)]
>   
>     ```ruby
>     Time.new(2021, 12, 25, in: "+07:00")
>     #=> 2021-12-25 00:00:00 +0700
>     ```
>   
>     At the same time, time component strings are converted to
>     integers more strictly now.
>   
>     ```ruby
>     Time.new(2021, 12, 25, "+07:30")
>     #=> invalid value for Integer(): "+07:30" (ArgumentError)
>     ```
>   
>     Ruby 3.0 or earlier returned probably unexpected result
>     `2021-12-25 07:00:00`, not `2021-12-25 07:30:00` nor
>     `2021-12-25 00:00:00 +07:30`.


I used [test cases for `Time.at`](https://github.com/ruby/spec/blob/5b20199dfe609e3c20beacc00866a05d768e95bd/core/time/at_spec.rb#L221) as a reference.