### PR TITLE
Ruby 3.1: Add specs for `Thread::Backtrace.limit`

### DIFF
--- a/core/thread/backtrace/limit_spec.rb
+++ b/core/thread/backtrace/limit_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../../spec_helper'
+
+ruby_version_is "3.1" do
+  describe "Thread::Backtrace.limit" do
+    it "returns maximum backtrace length set by --backtrace-limit command-line option" do
+      out = ruby_exe("print Thread::Backtrace.limit", options: "--backtrace-limit=2")
+      out.should == "2"
+    end
+
+    it "returns -1 when --backtrace-limit command-line option is not set" do
+      out = ruby_exe("print Thread::Backtrace.limit")
+      out.should == "-1"
+    end
+  end
+end


### PR DESCRIPTION
This PR adds specs for [Feature #17479](https://bugs.ruby-lang.org/issues/17479)

From:

- [https://github.com/ruby/spec/issues/923](https://github.com/ruby/spec/issues/923)

> Thread::Backtrace
> - Thread::Backtrace.limit, which returns the value to limit backtrace length set by `--backtrace-limit` command line option, is added. [[Feature #17479](https://bugs.ruby-lang.org/issues/17479)]

I've confirmed the default value is `-1`.
https://docs.ruby-lang.org/en/master/Thread/Backtrace.html

> The defalt is `-1` which means unlimited backtraces.