### PR TITLE
Add test for Float#to_i raising FloatDomainError when NaN

### DIFF
--- a/core/float/shared/to_i.rb
+++ b/core/float/shared/to_i.rb
@@ -1,11 +1,14 @@
 describe :float_to_i, shared: true do
   it "returns self truncated to an Integer" do
-    -> { (0.0 / 0.0).send(@method) }.should raise_error(FloatDomainError)
     899.2.send(@method).should eql(899)
     -1.122256e-45.send(@method).should eql(0)
     5_213_451.9201.send(@method).should eql(5213451)
     1.233450999123389e+12.send(@method).should eql(1233450999123)
     -9223372036854775808.1.send(@method).should eql(-9223372036854775808)
     9223372036854775808.1.send(@method).should eql(9223372036854775808)
+  end
+
+  it "raises a FloatDomainError for NaN" do
+    -> { nan_value.send(@method) }.should raise_error(FloatDomainError)
   end
 end

--- a/core/float/shared/to_i.rb
+++ b/core/float/shared/to_i.rb
@@ -1,5 +1,6 @@
 describe :float_to_i, shared: true do
   it "returns self truncated to an Integer" do
+    -> { (0.0 / 0.0).send(@method) }.should raise_error(FloatDomainError)
     899.2.send(@method).should eql(899)
     -1.122256e-45.send(@method).should eql(0)
     5_213_451.9201.send(@method).should eql(5213451)


### PR DESCRIPTION
Hey all!

While working on https://github.com/natalie-lang/natalie I noticed that the specs for `to_i` on Floats did not check that it raises a `FloatDomainError` when NaN 

So adding a little extra check for that. Let me know if the assertion has been added to the correct example

Context: [FloatDomainError ](https://github.com/ruby/ruby/blob/55c771c302f94f1d1d95bf41b42459b4d2d1c337/numeric.c#L6016)