### PR TITLE
Remove invalid test

### DIFF
--- a/core/io/read_spec.rb
+++ b/core/io/read_spec.rb
@@ -402,13 +402,6 @@ describe "IO#read in binary mode" do
     xE2 = [226].pack('C*')
     result.should == ("abc" + xE2 + "def").force_encoding(Encoding::BINARY)
   end
-
-  it "does not transcode file contents when an internal encoding is specified" do
-    result = File.open(@name, "r:binary:utf-8") { |f| f.read }.chomp
-    result.encoding.should == Encoding::BINARY
-    xE2 = [226].pack('C*')
-    result.should == ("abc" + xE2 + "def").force_encoding(Encoding::BINARY)
-  end
 end
 
 describe "IO#read in text mode" do


### PR DESCRIPTION
The test only worked because of an inconsistent behavior in the way Ruby parses IO encoding settings.  In this case, Ruby does not set the IO's internal encoding at all; however, setting the encodings using #set_encoding and separate arguments instead of a single string will cause Ruby to set the internal encoding to UTF-8 as requested which results in an error when calling #read.