### PR TITLE
Ruby 3.1: Add specs for `ERB.new`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -115,6 +115,10 @@ Lint/EmptyWhen:
     - language/case_spec.rb
     - optional/capi/spec_helper.rb
 
+Lint/ErbNewArguments:
+  Exclude:
+    - 'library/erb/new_spec.rb'
+
 Lint/FormatParameterMismatch:
   Exclude:
     - 'core/kernel/shared/sprintf.rb'

--- a/library/erb/new_spec.rb
+++ b/library/erb/new_spec.rb
@@ -138,4 +138,20 @@ END
     ERB.new(@eruby_str).result
     ->{ ERB.new("<%= list %>").result }.should raise_error(NameError)
   end
+
+  describe "warning about arguments" do
+    ruby_version_is "3.1" do
+      it "warns when passed safe_level and later arguments" do
+        -> {
+          ERB.new(@eruby_str, nil, '%')
+        }.should complain(/warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments./)
+      end
+
+      it "does not warn when passed arguments as keyword argument" do
+        -> {
+          ERB.new(@eruby_str, trim_mode: '%')
+        }.should_not complain(/warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments./)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Issue

A part of https://github.com/ruby/spec/issues/923

## Change

This pull request adds a spec for [Feature #14256](https://bugs.ruby-lang.org/issues/14256). `ERB.new` warns deprecation when passed `safe_level` and later arguments.