### PR TITLE
Add specs for ruby 3.2 Regexp.timeout

### DIFF
--- a/core/regexp/timeout_spec.rb
+++ b/core/regexp/timeout_spec.rb
@@ -2,10 +2,13 @@ require_relative '../../spec_helper'
 
 ruby_version_is "3.2" do
   describe "Regexp.timeout" do
+    after :each do
+      Regexp.timeout = nil
+    end
+
     it "returns global timeout" do
       Regexp.timeout = 3
       Regexp.timeout.should == 3
-      Regexp.timeout = nil
     end
 
     it "raises Regexp::TimeoutError after global timeout elapsed" do
@@ -19,8 +22,6 @@ ruby_version_is "3.2" do
       }.should raise_error(Regexp::TimeoutError, "regexp match timeout")
       t = Time.now - t
       t.should be_close(0.001, 0.010)
-
-      Regexp.timeout = nil
     end
 
     it "raises Regexp::TimeoutError after timeout keyword value elapsed" do
@@ -36,8 +37,6 @@ ruby_version_is "3.2" do
       t = Time.now - t
 
       t.should be_close(0.001, 0.010)
-
-      Regexp.timeout = nil
     end
   end
 end

--- a/core/regexp/timeout_spec.rb
+++ b/core/regexp/timeout_spec.rb
@@ -1,0 +1,38 @@
+require_relative '../../spec_helper'
+
+ruby_version_is "3.2" do
+  describe "Regexp.timeout" do
+    it "returns global timeout" do
+      Regexp.timeout = 3
+      Regexp.timeout.should == 3
+    end
+
+    it "raises Regexp::TimeoutError after global timeout elapsed" do
+      Regexp.timeout = 0.2
+      Regexp.timeout.should == 0.2
+
+      t = Time.now
+      -> {
+        # A typical ReDoS case
+        /^(a*)*$/ =~ "a" * 1000000 + "x"
+      }.should raise_error(Regexp::TimeoutError, "regexp match timeout")
+      t = Time.now - t
+      t.should be_close(0.2, 0.1)
+    end
+
+    it "raises Regexp::TimeoutError after timeout keyword value elapsed" do
+      Regexp.timeout = 3 # This should be ignored
+      Regexp.timeout.should == 3
+
+      re = Regexp.new("^a*b?a*$", timeout: 0.2)
+
+      t = Time.now
+      -> {
+        re =~ "a" * 1000000 + "x"
+      }.should raise_error(Regexp::TimeoutError, "regexp match timeout")
+      t = Time.now - t
+
+      t.should be_close(0.2, 0.1)
+    end
+  end
+end

--- a/core/regexp/timeout_spec.rb
+++ b/core/regexp/timeout_spec.rb
@@ -5,6 +5,7 @@ ruby_version_is "3.2" do
     it "returns global timeout" do
       Regexp.timeout = 3
       Regexp.timeout.should == 3
+      Regexp.timeout = nil
     end
 
     it "raises Regexp::TimeoutError after global timeout elapsed" do
@@ -18,6 +19,8 @@ ruby_version_is "3.2" do
       }.should raise_error(Regexp::TimeoutError, "regexp match timeout")
       t = Time.now - t
       t.should be_close(0.001, 0.010)
+
+      Regexp.timeout = nil
     end
 
     it "raises Regexp::TimeoutError after timeout keyword value elapsed" do
@@ -33,6 +36,8 @@ ruby_version_is "3.2" do
       t = Time.now - t
 
       t.should be_close(0.001, 0.010)
+
+      Regexp.timeout = nil
     end
   end
 end

--- a/core/regexp/timeout_spec.rb
+++ b/core/regexp/timeout_spec.rb
@@ -15,13 +15,10 @@ ruby_version_is "3.2" do
       Regexp.timeout = 0.001
       Regexp.timeout.should == 0.001
 
-      t = Time.now
       -> {
         # A typical ReDoS case
         /^(a*)*$/ =~ "a" * 1000000 + "x"
       }.should raise_error(Regexp::TimeoutError, "regexp match timeout")
-      t = Time.now - t
-      t.should be_close(0.001, 0.010)
     end
 
     it "raises Regexp::TimeoutError after timeout keyword value elapsed" do
@@ -30,13 +27,9 @@ ruby_version_is "3.2" do
 
       re = Regexp.new("^a*b?a*$", timeout: 0.001)
 
-      t = Time.now
       -> {
         re =~ "a" * 1000000 + "x"
       }.should raise_error(Regexp::TimeoutError, "regexp match timeout")
-      t = Time.now - t
-
-      t.should be_close(0.001, 0.010)
     end
   end
 end

--- a/core/regexp/timeout_spec.rb
+++ b/core/regexp/timeout_spec.rb
@@ -8,8 +8,8 @@ ruby_version_is "3.2" do
     end
 
     it "raises Regexp::TimeoutError after global timeout elapsed" do
-      Regexp.timeout = 0.2
-      Regexp.timeout.should == 0.2
+      Regexp.timeout = 0.001
+      Regexp.timeout.should == 0.001
 
       t = Time.now
       -> {
@@ -17,14 +17,14 @@ ruby_version_is "3.2" do
         /^(a*)*$/ =~ "a" * 1000000 + "x"
       }.should raise_error(Regexp::TimeoutError, "regexp match timeout")
       t = Time.now - t
-      t.should be_close(0.2, 0.1)
+      t.should be_close(0.001, 0.010)
     end
 
     it "raises Regexp::TimeoutError after timeout keyword value elapsed" do
       Regexp.timeout = 3 # This should be ignored
       Regexp.timeout.should == 3
 
-      re = Regexp.new("^a*b?a*$", timeout: 0.2)
+      re = Regexp.new("^a*b?a*$", timeout: 0.001)
 
       t = Time.now
       -> {
@@ -32,7 +32,7 @@ ruby_version_is "3.2" do
       }.should raise_error(Regexp::TimeoutError, "regexp match timeout")
       t = Time.now - t
 
-      t.should be_close(0.2, 0.1)
+      t.should be_close(0.001, 0.010)
     end
   end
 end


### PR DESCRIPTION
Add specs for ruby 3.2 `Regexp.timeout`
> Regexp.timeout [Feature #17837](https://bugs.ruby-lang.org/issues/17837) - PR https://github.com/ruby/ruby/pull/5703
