### PR TITLE
Add end-of-line-space specs for Array#pack with 'M' directive

### DIFF
--- a/core/array/pack/m_spec.rb
+++ b/core/array/pack/m_spec.rb
@@ -80,8 +80,16 @@ describe "Array#pack with format 'M'" do
     ].should be_computed_by(:pack, "M")
   end
 
-  it "encodes a tab followed by a newline with an encoded newline" do
+  it "encodes a tab at the end of a line with an encoded newline" do
+    ["\t"].pack("M").should == "\t=\n"
     ["\t\n"].pack("M").should == "\t=\n\n"
+    ["abc\t\nxyz"].pack("M").should == "abc\t=\n\nxyz=\n"
+  end
+
+  it "encodes a space at the end of a line with an encoded newline" do
+    [" "].pack("M").should == " =\n"
+    [" \n"].pack("M").should == " =\n\n"
+    ["abc \nxyz"].pack("M").should == "abc =\n\nxyz=\n"
   end
 
   it "encodes 127..255 in hex format" do


### PR DESCRIPTION
[RFC 2045](https://www.rfc-editor.org/rfc/rfc2045) states:

```
In this encoding, octets are to be represented as determined by the
following rules:

...snip...

(3)   (White Space) Octets with values of 9 and 32 MAY be
      represented as US-ASCII TAB (HT) and SPACE characters,
      respectively, but MUST NOT be so represented at the end
      of an encoded line.  Any TAB (HT) or SPACE characters
      on an encoded line MUST thus be followed on that line
      by a printable character.  In particular, an "=" at the
      end of an encoded line, indicating a soft line break
      (see rule #5) may follow one or more TAB (HT) or SPACE
      characters.
```