### PR TITLE
Ruby 3.1: Add spec for TracePoint.allow_reentry

### DIFF
--- a/core/tracepoint/allow_reentry_spec.rb
+++ b/core/tracepoint/allow_reentry_spec.rb
@@ -1,0 +1,32 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+ruby_version_is "3.1" do
+  describe 'TracePoint.allow_reentry' do
+    it 'allows the reentrance in a given block' do
+      event_lines = []
+      l1 = l2 = l3 = l4 = nil
+      TracePoint.new(:line) do |tp|
+        next unless TracePointSpec.target_thread?
+
+        event_lines << tp.lineno
+        next if (__LINE__ + 2 .. __LINE__ + 4).cover?(tp.lineno)
+        TracePoint.allow_reentry do
+          a = 1; l3 = __LINE__
+          b = 2; l4 = __LINE__
+        end
+      end.enable do
+        c = 3; l1 = __LINE__
+        d = 4; l2 = __LINE__
+      end
+
+      event_lines.should == [l1, l3, l4, l2, l3, l4]
+    end
+
+    it 'raises RuntimeError' do
+      -> {
+        TracePoint.allow_reentry{}
+      }.should raise_error(RuntimeError)
+    end
+  end
+end

--- a/core/tracepoint/allow_reentry_spec.rb
+++ b/core/tracepoint/allow_reentry_spec.rb
@@ -23,7 +23,7 @@ ruby_version_is "3.1" do
       event_lines.should == [l1, l3, l4, l2, l3, l4]
     end
 
-    it 'raises RuntimeError' do
+    it 'raises RuntimeError when not called inside a TracePoint' do
       -> {
         TracePoint.allow_reentry{}
       }.should raise_error(RuntimeError)


### PR DESCRIPTION
This PR adds specs for [Feature #15912](https://bugs.ruby-lang.org/issues/15912)

From: 
- https://github.com/ruby/spec/issues/923

TracePoint.allow_reentry
> TracePoint.allow_reentry is added to allow reenter while TracePoint callback. [[Feature #15912](https://bugs.ruby-lang.org/issues/15912)]