### PR TITLE
Add spec for `Thread#native_thread_id`

### DIFF
--- a/core/thread/native_thread_id_spec.rb
+++ b/core/thread/native_thread_id_spec.rb
@@ -6,6 +6,7 @@ ruby_version_is ''...'3.1' do
       -> {
         th = Thread.new {}
         th.native_thread_id
+        th.join
       }.should raise_error(NoMethodError)
     end
   end
@@ -13,9 +14,20 @@ end
 
 ruby_version_is "3.1" do
   describe "Thread#native_thread_id" do
-    it "returns an integer" do
-      th = Thread.new {}
-      th.native_thread_id.should be_kind_of(Integer)
+    platform_is_not :linux do
+      it "returns an integer" do
+        th = Thread.new {}
+        th.native_thread_id.should be_kind_of(Integer)
+        th.join
+      end
+    end
+
+    platform_is :linux do
+      it "returns nil" do
+        th = Thread.new {}
+        th.native_thread_id.should be_nil
+        th.join
+      end
     end
   end
 end

--- a/core/thread/native_thread_id_spec.rb
+++ b/core/thread/native_thread_id_spec.rb
@@ -3,11 +3,9 @@ require_relative '../../spec_helper'
 ruby_version_is ''...'3.1' do
   describe "Thread#native_thread_id" do
     it "raises NoMethodError" do
-      -> {
-        th = Thread.new {}
-        th.native_thread_id
-        th.join
-      }.should raise_error(NoMethodError)
+      th = Thread.new {}
+      -> { th.native_thread_id }.should raise_error(NoMethodError)
+      th.join
     end
   end
 end

--- a/core/thread/native_thread_id_spec.rb
+++ b/core/thread/native_thread_id_spec.rb
@@ -1,31 +1,15 @@
 require_relative '../../spec_helper'
 
-ruby_version_is ''...'3.1' do
-  describe "Thread#native_thread_id" do
-    it "raises NoMethodError" do
-      th = Thread.new {}
-      -> { th.native_thread_id }.should raise_error(NoMethodError)
-      th.join
-    end
-  end
-end
-
 ruby_version_is "3.1" do
   describe "Thread#native_thread_id" do
-    platform_is_not :linux do
-      it "returns an integer" do
-        th = Thread.new {}
-        th.native_thread_id.should be_kind_of(Integer)
-        th.join
-      end
+    it "returns an integer when the thread is alive" do
+      Thread.current.native_thread_id.should be_kind_of(Integer)
     end
 
-    platform_is :linux do
-      it "returns nil" do
-        th = Thread.new {}
-        th.native_thread_id.should be_nil
-        th.join
-      end
+    it "returns nil when the thread is not running" do
+      t = Thread.new {}
+      t.join
+      t.native_thread_id.should == nil
     end
   end
 end

--- a/core/thread/native_thread_id_spec.rb
+++ b/core/thread/native_thread_id_spec.rb
@@ -1,0 +1,21 @@
+require_relative '../../spec_helper'
+
+ruby_version_is ''...'3.1' do
+  describe "Thread#native_thread_id" do
+    it "raises NoMethodError" do
+      -> {
+        th = Thread.new {}
+        th.native_thread_id
+      }.should raise_error(NoMethodError)
+    end
+  end
+end
+
+ruby_version_is "3.1" do
+  describe "Thread#native_thread_id" do
+    it "returns an integer" do
+      th = Thread.new {}
+      th.native_thread_id.should be_kind_of(Integer)
+    end
+  end
+end


### PR DESCRIPTION
Relates to https://github.com/ruby/spec/issues/923

> Thread#native_thread_id is added. [[Feature #17853](https://bugs.ruby-lang.org/issues/17853)]