### PR TITLE
Add spec for String#unpack 'M' directive for incomplete escapes

### DIFF
--- a/core/string/unpack/m_spec.rb
+++ b/core/string/unpack/m_spec.rb
@@ -97,6 +97,11 @@ describe "String#unpack with format 'M'" do
       ["=FF=\n",                      ["\xff"]]
     ].should be_computed_by(:unpack, "M")
   end
+
+  it "unpacks incomplete escape sequences as literal characters" do
+    "foo=".unpack("M").should == ["foo="]
+    "foo=4".unpack("M").should == ["foo=4"]
+  end
 end
 
 describe "String#unpack with format 'm'" do


### PR DESCRIPTION
This spec helped me while implementing 'M' unpack (quoted-printable, RFC 2025). :hugs: 