### PR TITLE
String: check result string's encoding is the same as the original one

### DIFF
--- a/core/string/byteslice_spec.rb
+++ b/core/string/byteslice_spec.rb
@@ -24,4 +24,10 @@ describe "String#byteslice on on non ASCII strings" do
     "\u3042".byteslice(1..2).should == "\x81\x82".force_encoding("UTF-8")
     "\u3042".byteslice(-1).should == "\x82".force_encoding("UTF-8")
   end
+
+  it "returns a String in the same encoding as self" do
+    "ruby".encode("UTF-8").slice(0).encoding.should == Encoding::UTF_8
+    "ruby".encode("US-ASCII").slice(0).encoding.should == Encoding::US_ASCII
+    "ruby".encode("Windows-1251").slice(0).encoding.should == Encoding::Windows_1251
+  end
 end

--- a/core/string/capitalize_spec.rb
+++ b/core/string/capitalize_spec.rb
@@ -91,6 +91,10 @@ describe "String#capitalize" do
       StringSpecs::MyString.new("Hello").capitalize.should be_an_instance_of(String)
     end
   end
+
+  it "returns a String in the same encoding as self" do
+    "h".encode("US-ASCII").capitalize.encoding.should == Encoding::US_ASCII
+  end
 end
 
 describe "String#capitalize!" do

--- a/core/string/chars_spec.rb
+++ b/core/string/chars_spec.rb
@@ -1,5 +1,4 @@
 require_relative 'shared/chars'
-require_relative 'shared/each_char_without_block'
 
 describe "String#chars" do
   it_behaves_like :string_chars, :chars

--- a/core/string/chars_spec.rb
+++ b/core/string/chars_spec.rb
@@ -7,4 +7,10 @@ describe "String#chars" do
   it "returns an array when no block given" do
     "hello".chars.should == ['h', 'e', 'l', 'l', 'o']
   end
+
+  it "returns Strings in the same encoding as self" do
+    "hello".encode("US-ASCII").chars.each do |c|
+      c.encoding.should == Encoding::US_ASCII
+    end
+  end
 end

--- a/core/string/chomp_spec.rb
+++ b/core/string/chomp_spec.rb
@@ -40,6 +40,10 @@ describe "String#chomp" do
       "".chomp.should == ""
     end
 
+    it "returns a String in the same encoding as self" do
+      "abc\n\n".encode("US-ASCII").chomp.encoding.should == Encoding::US_ASCII
+    end
+
     ruby_version_is ''...'3.0' do
       it "returns subclass instances when called on a subclass" do
         str = StringSpecs::MyString.new("hello\n").chomp

--- a/core/string/chop_spec.rb
+++ b/core/string/chop_spec.rb
@@ -60,6 +60,10 @@ describe "String#chop" do
       StringSpecs::MyString.new("hello\n").chop.should be_an_instance_of(String)
     end
   end
+
+  it "returns a String in the same encoding as self" do
+    "abc\n\n".encode("US-ASCII").chop.encoding.should == Encoding::US_ASCII
+  end
 end
 
 describe "String#chop!" do

--- a/core/string/clone_spec.rb
+++ b/core/string/clone_spec.rb
@@ -54,4 +54,8 @@ describe "String#clone" do
     orig.should == "xtring"
     clone.should == "string"
   end
+
+  it "returns a String in the same encoding as self" do
+    "a".encode("US-ASCII").clone.encoding.should == Encoding::US_ASCII
+  end
 end

--- a/core/string/delete_prefix_spec.rb
+++ b/core/string/delete_prefix_spec.rb
@@ -51,6 +51,10 @@ describe "String#delete_prefix" do
       s.delete_prefix('hell').should be_an_instance_of(String)
     end
   end
+
+  it "returns a String in the same encoding as self" do
+    'hello'.encode("US-ASCII").delete_prefix('hell').encoding.should == Encoding::US_ASCII
+  end
 end
 
 describe "String#delete_prefix!" do

--- a/core/string/delete_spec.rb
+++ b/core/string/delete_spec.rb
@@ -95,6 +95,10 @@ describe "String#delete" do
       StringSpecs::MyString.new("oh no!!!").delete("!").should be_an_instance_of(String)
     end
   end
+
+  it "returns a String in the same encoding as self" do
+    "hello".encode("US-ASCII").delete("lo").encoding.should == Encoding::US_ASCII
+  end
 end
 
 describe "String#delete!" do

--- a/core/string/delete_suffix_spec.rb
+++ b/core/string/delete_suffix_spec.rb
@@ -51,6 +51,10 @@ describe "String#delete_suffix" do
       s.delete_suffix('ello').should be_an_instance_of(String)
     end
   end
+
+  it "returns a String in the same encoding as self" do
+    "hello".encode("US-ASCII").delete_suffix("ello").encoding.should == Encoding::US_ASCII
+  end
 end
 
 describe "String#delete_suffix!" do

--- a/core/string/downcase_spec.rb
+++ b/core/string/downcase_spec.rb
@@ -8,6 +8,10 @@ describe "String#downcase" do
     "hello".downcase.should == "hello"
   end
 
+  it "returns a String in the same encoding as self" do
+    "hELLO".encode("US-ASCII").downcase.encoding.should == Encoding::US_ASCII
+  end
+
   describe "full Unicode case mapping" do
     it "works for all of Unicode with no option" do
       "ÄÖÜ".downcase.should == "äöü"

--- a/core/string/dump_spec.rb
+++ b/core/string/dump_spec.rb
@@ -390,7 +390,7 @@ describe "String#dump" do
     "\u{876}".encode('utf-16le').dump.should.end_with?(".force_encoding(\"UTF-16LE\")")
   end
 
-  it "keeps origin encoding" do
+  it "returns a String in the same encoding as self" do
     "foo".encode("ISO-8859-1").dump.encoding.should == Encoding::ISO_8859_1
     "foo".encode('windows-1251').dump.encoding.should == Encoding::Windows_1251
     1.chr.dump.encoding.should == Encoding::US_ASCII

--- a/core/string/dup_spec.rb
+++ b/core/string/dup_spec.rb
@@ -58,4 +58,8 @@ describe "String#dup" do
     orig.should == "c"
     copy.should == "b"
   end
+
+  it "returns a String in the same encoding as self" do
+    "hello".encode("US-ASCII").dup.encoding.should == Encoding::US_ASCII
+  end
 end

--- a/core/string/lines_spec.rb
+++ b/core/string/lines_spec.rb
@@ -1,7 +1,6 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/each_line'
-require_relative 'shared/each_line_without_block'
 
 describe "String#lines" do
   it_behaves_like :string_each_line, :lines

--- a/core/string/reverse_spec.rb
+++ b/core/string/reverse_spec.rb
@@ -37,6 +37,10 @@ describe "String#reverse" do
 
     str.reverse.should == "體黑正\xDE\xDF軟微"
   end
+
+  it "returns a String in the same encoding as self" do
+    "stressed".encode("US-ASCII").reverse.encoding.should == Encoding::US_ASCII
+  end
 end
 
 describe "String#reverse!" do

--- a/core/string/scan_spec.rb
+++ b/core/string/scan_spec.rb
@@ -69,6 +69,12 @@ describe "String#scan" do
   it "does not raise any errors when passed a multi-byte string" do
     "あああaaaあああ".scan("あああ").should == ["あああ", "あああ"]
   end
+
+  it "returns Strings in the same encoding as self" do
+    "cruel world".encode("US-ASCII").scan(/\w+/).each do |s|
+      s.encoding.should == Encoding::US_ASCII
+    end
+  end
 end
 
 describe "String#scan with pattern and block" do

--- a/core/string/scrub_spec.rb
+++ b/core/string/scrub_spec.rb
@@ -31,6 +31,11 @@ describe "String#scrub with a default replacement" do
     input.scrub.should == "abc?????"
   end
 
+  it "returns a String in the same encoding as self" do
+    x81 = [0x81].pack('C').force_encoding('utf-8')
+    "abc\u3042#{x81}".scrub.encoding.should == Encoding::UTF_8
+  end
+
   ruby_version_is '3.0' do
     it "returns String instances when called on a subclass" do
       StringSpecs::MyString.new("foo").scrub.should be_an_instance_of(String)
@@ -78,6 +83,11 @@ describe "String#scrub with a custom replacement" do
     block = -> { "foo#{x81}".scrub(xE4) }
 
     block.should raise_error(ArgumentError)
+  end
+
+  it "returns a String in the same encoding as self" do
+    x81 = [0x81].pack('C').force_encoding('utf-8')
+    "abc\u3042#{x81}".scrub("*").encoding.should == Encoding::UTF_8
   end
 
   it "raises TypeError when a non String replacement is given" do

--- a/core/string/shared/each_line.rb
+++ b/core/string/shared/each_line.rb
@@ -122,6 +122,12 @@ describe :string_each_line, shared: true do
     out.should == ["hello\n", "world."]
   end
 
+  it "returns Strings in the same encoding as self" do
+    "one\ntwo\r\nthree".encode("US-ASCII").send(@method) do |s|
+      s.encoding.should == Encoding::US_ASCII
+    end
+  end
+
   it "raises a TypeError when the separator can't be converted to a string" do
     -> { "hello world".send(@method, false) {}     }.should raise_error(TypeError)
     -> { "hello world".send(@method, mock('x')) {} }.should raise_error(TypeError)

--- a/core/string/shared/partition.rb
+++ b/core/string/shared/partition.rb
@@ -33,4 +33,19 @@ describe :string_partition, shared: true do
       end
     end
   end
+
+  it "returns before- and after- parts in the same encoding as self" do
+    strings = "hello".encode("US-ASCII").send(@method, "ello")
+    strings[0].encoding.should == Encoding::US_ASCII
+    strings[2].encoding.should == Encoding::US_ASCII
+
+    strings = "hello".encode("US-ASCII").send(@method, /ello/)
+    strings[0].encoding.should == Encoding::US_ASCII
+    strings[2].encoding.should == Encoding::US_ASCII
+  end
+
+  it "returns the matching part in the separator's encoding" do
+    strings = "hello".encode("US-ASCII").send(@method, "ello")
+    strings[1].encoding.should == Encoding::UTF_8
+  end
 end

--- a/core/string/shared/slice.rb
+++ b/core/string/shared/slice.rb
@@ -332,9 +332,6 @@ describe :string_slice_regexp, shared: true do
     "hello there".send(@method, /xyz/).should == nil
   end
 
-  not_supported_on :opal do
-  end
-
   it "returns a String in the same encoding as self" do
     "hello there".encode("US-ASCII").send(@method, /[aeiou](.)\1/).encoding.should == Encoding::US_ASCII
   end

--- a/core/string/shared/slice.rb
+++ b/core/string/shared/slice.rb
@@ -80,7 +80,7 @@ describe :string_slice_index_length, shared: true do
     "hello there".send(@method, -3,2).should == "er"
   end
 
-  it "returns a string with the same encoding" do
+  it "returns a string with the same encoding as self" do
     s = "hello there"
     s.send(@method, 1, 9).encoding.should == s.encoding
 
@@ -204,6 +204,10 @@ describe :string_slice_range, shared: true do
 
     "x".send(@method, 1..1).should == ""
     "x".send(@method, 1..-1).should == ""
+  end
+
+  it "returns a String in the same encoding as self" do
+    "hello there".encode("US-ASCII").send(@method, 1..1).encoding.should == Encoding::US_ASCII
   end
 
   it "returns nil if the beginning of the range falls outside of self" do
@@ -331,6 +335,10 @@ describe :string_slice_regexp, shared: true do
   not_supported_on :opal do
   end
 
+  it "returns a String in the same encoding as self" do
+    "hello there".encode("US-ASCII").send(@method, /[aeiou](.)\1/).encoding.should == Encoding::US_ASCII
+  end
+
   ruby_version_is ''...'3.0' do
     it "returns subclass instances" do
       s = StringSpecs::MyString.new("hello")
@@ -389,6 +397,10 @@ describe :string_slice_regexp_index, shared: true do
     "test".send(@method, /te(z)?/, 1).should == nil
     $~[0].should == "te"
     $~[1].should == nil
+  end
+
+  it "returns a String in the same encoding as self" do
+    "hello there".encode("US-ASCII").send(@method, /[aeiou](.)\1/, 0).encoding.should == Encoding::US_ASCII
   end
 
   it "calls to_int on the given index" do

--- a/core/string/shared/strip.rb
+++ b/core/string/shared/strip.rb
@@ -2,6 +2,10 @@ require_relative '../../../spec_helper'
 require_relative '../fixtures/classes'
 
 describe :string_strip, shared: true do
+  it "returns a String in the same encoding as self" do
+    " hello ".encode("US-ASCII").send(@method).encoding.should == Encoding::US_ASCII
+  end
+
   ruby_version_is '3.0' do
     it "returns String instances when called on a subclass" do
       StringSpecs::MyString.new(" hello ").send(@method).should be_an_instance_of(String)

--- a/core/string/shared/succ.rb
+++ b/core/string/shared/succ.rb
@@ -74,6 +74,10 @@ describe :string_succ, shared: true do
       StringSpecs::MyString.new("z").send(@method).should be_an_instance_of(String)
     end
   end
+
+  it "returns a String in the same encoding as self" do
+    "z".encode("US-ASCII").send(@method).encoding.should == Encoding::US_ASCII
+  end
 end
 
 describe :string_succ_bang, shared: true do

--- a/core/string/split_spec.rb
+++ b/core/string/split_spec.rb
@@ -456,7 +456,6 @@ describe "String#split with Regexp" do
     encodings.should == [Encoding::UTF_8, Encoding::UTF_8, Encoding::UTF_8]
   end
 
-
   it "splits a string on each character for a multibyte encoding and empty split" do
     "That's why eﬃciency could not be helped".split("").size.should == 39
   end

--- a/core/string/split_spec.rb
+++ b/core/string/split_spec.rb
@@ -246,6 +246,13 @@ describe "String#split with String" do
   it "doesn't split on non-ascii whitespace" do
     "a\u{2008}b".split(" ").should == ["a\u{2008}b"]
   end
+
+  it "returns Strings in the same encoding as self" do
+    strings = "hello world".encode("US-ASCII").split(" ")
+
+    strings[0].encoding.should == Encoding::US_ASCII
+    strings[1].encoding.should == Encoding::US_ASCII
+  end
 end
 
 describe "String#split with Regexp" do
@@ -443,7 +450,7 @@ describe "String#split with Regexp" do
     end
   end
 
-  it "retains the encoding of the source string" do
+  it "returns Strings in the same encoding as self" do
     ary = "а б в".split
     encodings = ary.map { |s| s.encoding }
     encodings.should == [Encoding::UTF_8, Encoding::UTF_8, Encoding::UTF_8]
@@ -597,5 +604,12 @@ describe "String#split with Regexp" do
     -> { "hello".split(:ll) }.should raise_error(TypeError)
     -> { "hello".split(false) }.should raise_error(TypeError)
     -> { "hello".split(Object.new) }.should raise_error(TypeError)
+  end
+
+  it "returns Strings in the same encoding as self" do
+    strings = "hello world".encode("US-ASCII").split(/ /)
+
+    strings[0].encoding.should == Encoding::US_ASCII
+    strings[1].encoding.should == Encoding::US_ASCII
   end
 end

--- a/core/string/squeeze_spec.rb
+++ b/core/string/squeeze_spec.rb
@@ -64,6 +64,11 @@ describe "String#squeeze" do
     "hello room".squeeze(other_string, other_string2).should == "hello rom"
   end
 
+  it "returns a String in the same encoding as self" do
+    "yellow moon".encode("US-ASCII").squeeze.encoding.should == Encoding::US_ASCII
+    "yellow moon".encode("US-ASCII").squeeze("a").encoding.should == Encoding::US_ASCII
+  end
+
   it "raises a TypeError when one set arg can't be converted to a string" do
     -> { "hello world".squeeze([])        }.should raise_error(TypeError)
     -> { "hello world".squeeze(Object.new)}.should raise_error(TypeError)

--- a/core/string/swapcase_spec.rb
+++ b/core/string/swapcase_spec.rb
@@ -9,6 +9,10 @@ describe "String#swapcase" do
    "+++---111222???".swapcase.should == "+++---111222???"
   end
 
+  it "returns a String in the same encoding as self" do
+    "Hello".encode("US-ASCII").swapcase.encoding.should == Encoding::US_ASCII
+  end
+
   describe "full Unicode case mapping" do
     it "works for all of Unicode with no option" do
       "äÖü".swapcase.should == "ÄöÜ"

--- a/core/string/undump_spec.rb
+++ b/core/string/undump_spec.rb
@@ -389,7 +389,7 @@ describe "String#undump" do
     '"\\bv".force_encoding("UTF-16BE")'.undump.should == "\u0876".encode('utf-16be')
   end
 
-  it "keeps origin encoding" do
+  it "returns a String in the same encoding as self" do
     '"foo"'.encode("ISO-8859-1").undump.encoding.should == Encoding::ISO_8859_1
     '"foo"'.encode('windows-1251').undump.encoding.should == Encoding::Windows_1251
   end

--- a/core/string/upcase_spec.rb
+++ b/core/string/upcase_spec.rb
@@ -8,6 +8,10 @@ describe "String#upcase" do
     "hello".upcase.should == "HELLO"
   end
 
+  it "returns a String in the same encoding as self" do
+    "hello".encode("US-ASCII").upcase.encoding.should == Encoding::US_ASCII
+  end
+
   describe "full Unicode case mapping" do
     it "works for all of Unicode with no option" do
       "äöü".upcase.should == "ÄÖÜ"

--- a/core/symbol/shared/id2name.rb
+++ b/core/symbol/shared/id2name.rb
@@ -6,4 +6,11 @@ describe :symbol_id2name, shared: true do
     :@ruby.send(@method).should == "@ruby"
     :@@ruby.send(@method).should == "@@ruby"
   end
+
+  it "returns a String in the same encoding as self" do
+    string = "ruby".encode("US-ASCII")
+    symbol = string.to_sym
+
+    symbol.send(@method).encoding.should == Encoding::US_ASCII
+  end
 end


### PR DESCRIPTION
I've added specs for String's methods that return a String or an array of Strings.

Usually result string is derived and should be in the same encoding as the original one.

There are some methods that perform encoding negotiation and result string's encoding depends also on an argument string's encoding (e.g. `#gsub`, `#sub`). So I tried to not touch such methods.