### PR TITLE
Fix description for `Date.civil`

### DIFF
--- a/library/date/civil_spec.rb
+++ b/library/date/civil_spec.rb
@@ -2,11 +2,6 @@ require_relative '../../spec_helper'
 require_relative 'shared/civil'
 require 'date'
 
-describe "Date#civil" do
-  it_behaves_like :date_civil, :civil
-end
-
-
 describe "Date.civil" do
-  it "needs to be reviewed for spec completeness"
+  it_behaves_like :date_civil, :civil
 end


### PR DESCRIPTION
Because [`Date.civil`](https://docs.ruby-lang.org/en/3.1/Date.html#method-c-civil) isn't an instance method but a class method, I fixed the description and removed an unused test.

Ref:
https://github.com/ruby/spec/blob/71873ae4421f5b551a5af0f3427e901414736835/library/date/new_spec.rb#L6-L8