### PR TITLE
Ruby 3.1: Add specs for Refinement#import_methods and deprecation of include/prepend

### DIFF
--- a/core/refinement/import_methods_spec.rb
+++ b/core/refinement/import_methods_spec.rb
@@ -1,0 +1,34 @@
+require_relative '../../spec_helper'
+
+describe "Refinement#import_methods" do
+  ruby_version_is "3.1" do
+    context "when methods are defined in Ruby code" do
+      it "imports methods" do
+        str_utils = Module.new do
+          def indent(level)
+            " " * level + self
+          end
+        end
+
+        Module.new do
+          refine String do
+            import_methods str_utils
+            "foo".indent(3).should == "   foo"
+          end
+        end
+      end
+    end
+
+    context "when methods are not defined in Ruby code" do
+      it "raises ArgumentError" do
+        Module.new do
+          refine String do
+            -> {
+              import_methods Kernel
+            }.should raise_error(ArgumentError)
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/refinement/include_spec.rb
+++ b/core/refinement/include_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../spec_helper'
+
+describe "Refinement#include" do
+  ruby_version_is "3.1" do
+    it "warns about deprecation" do
+      Module.new do
+        refine String do
+          -> {
+            include Module.new
+          }.should complain(/warning: Refinement#include is deprecated and will be removed in Ruby 3.2/)
+        end
+      end
+    end
+  end
+end

--- a/core/refinement/prepend_spec.rb
+++ b/core/refinement/prepend_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../spec_helper'
+
+describe "Refinement#prepend" do
+  ruby_version_is "3.1" do
+    it "warns about deprecation" do
+      Module.new do
+        refine String do
+          -> {
+            prepend Module.new
+          }.should complain(/warning: Refinement#prepend is deprecated and will be removed in Ruby 3.2/)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add specs for [Bug #17429](https://bugs.ruby-lang.org/issues/17429)

Ref:

- #923
  - > Refinement
    - > New class which represents a module created by Module#refine. include and prepend are deprecated, and import_methods is added  instead. [[Bug #17429](https://bugs.ruby-lang.org/issues/17429)]

- https://github.com/ruby/ruby/commit/6606597109bdb535a150606323ce3d8f5750e1f6