### PR TITLE
Ruby 3.1: Add specs for exception in finalizer

### DIFF
--- a/core/objectspace/define_finalizer_spec.rb
+++ b/core/objectspace/define_finalizer_spec.rb
@@ -169,4 +169,26 @@ describe "ObjectSpace.define_finalizer" do
 
     ruby_exe(code).lines.sort.should == ["finalized1\n", "finalized2\n"]
   end
+
+  ruby_version_is "3.1" do
+    describe "when $VERBOSE is not nil" do
+      it "warns if an exception is raised in finalizer" do
+        code = <<-RUBY
+          ObjectSpace.define_finalizer(Object.new) { raise "finalizing" }
+        RUBY
+
+        ruby_exe(code, args: "2>&1").should include("warning: Exception in finalizer", "finalizing")
+      end
+    end
+
+    describe "when $VERBOSE is nil" do
+      it "does not warn even if an exception is raised in finalizer" do
+        code = <<-RUBY
+          ObjectSpace.define_finalizer(Object.new) { raise "finalizing" }
+        RUBY
+
+        ruby_exe(code, args: "2>&1", options: "-W0").should == ""
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add specs for [Feature #17798](https://bugs.ruby-lang.org/issues/17798)

Ref:

- #923
  - > Miscellaneous changes
    - > Now exceptions raised in finalizers will be printed to STDERR, unless $VERBOSE is nil. [[Feature #17798](https://bugs.ruby-lang.org/issues/17798)]
- https://github.com/ruby/ruby/pull/4670