### PR TITLE
Unnest "When passed a Numeric/Complex" from String in Rational

### DIFF
--- a/shared/rational/Rational.rb
+++ b/shared/rational/Rational.rb
@@ -65,40 +65,40 @@ describe :kernel_Rational, shared: true do
       r_s.should == r
       r_s.should_not == f_r
     end
+  end
 
-    describe "when passed a Numeric" do
-      it "calls #to_r to convert the first argument to a Rational" do
-        num = RationalSpecs::SubNumeric.new(2)
+  describe "when passed a Numeric" do
+    it "calls #to_r to convert the first argument to a Rational" do
+      num = RationalSpecs::SubNumeric.new(2)
 
-        Rational(num).should == Rational(2)
-      end
+      Rational(num).should == Rational(2)
+    end
+  end
+
+  describe "when passed a Complex" do
+    it "returns a Rational from the real part if the imaginary part is 0" do
+      Rational(Complex(1, 0)).should == Rational(1)
     end
 
-    describe "when passed a Complex" do
-      it "returns a Rational from the real part if the imaginary part is 0" do
-        Rational(Complex(1, 0)).should == Rational(1)
-      end
-
-      it "raises a RangeError if the imaginary part is not 0" do
-        -> { Rational(Complex(1, 2)) }.should raise_error(RangeError)
-      end
+    it "raises a RangeError if the imaginary part is not 0" do
+      -> { Rational(Complex(1, 2)) }.should raise_error(RangeError)
     end
+  end
 
-    it "raises a TypeError if the first argument is nil" do
-      -> { Rational(nil) }.should raise_error(TypeError)
-    end
+  it "raises a TypeError if the first argument is nil" do
+    -> { Rational(nil) }.should raise_error(TypeError)
+  end
 
-    it "raises a TypeError if the second argument is nil" do
-      -> { Rational(1, nil) }.should raise_error(TypeError)
-    end
+  it "raises a TypeError if the second argument is nil" do
+    -> { Rational(1, nil) }.should raise_error(TypeError)
+  end
 
-    it "raises a TypeError if the first argument is a Symbol" do
-      -> { Rational(:sym) }.should raise_error(TypeError)
-    end
+  it "raises a TypeError if the first argument is a Symbol" do
+    -> { Rational(:sym) }.should raise_error(TypeError)
+  end
 
-    it "raises a TypeError if the second argument is a Symbol" do
-      -> { Rational(1, :sym) }.should raise_error(TypeError)
-    end
+  it "raises a TypeError if the second argument is a Symbol" do
+    -> { Rational(1, :sym) }.should raise_error(TypeError)
   end
 
   describe "when passed exception: false" do


### PR DESCRIPTION
The spec was structured like this:
```ruby
describe "when passed a String" do
  describe "when passed a Numeric" do
  end
  describe "when passed a Complex" do
  end
end
```
This change removes this nesting, since the Numeric and Complex input are unrelated to String input. It is easier to read with whitespace changes ignored.

I've copied this change from the Natalie project: https://github.com/natalie-lang/natalie/blob/c1ee5df2d700393a4fc81505f4fd3d189b1ddbbb/spec/shared/rational/Rational.rb