### PR TITLE
Fix class/instance method mixup in regexp/initialize_spec

### DIFF
--- a/core/regexp/initialize_spec.rb
+++ b/core/regexp/initialize_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../spec_helper'
 
 describe "Regexp#initialize" do
   it "is a private method" do
-    Regexp.should have_private_method(:initialize)
+    Regexp.should have_private_instance_method(:initialize)
   end
 
   ruby_version_is ""..."3.0" do


### PR DESCRIPTION
This was a FIXME statement marked by @TheGrizzlyDev in the Natalie project.