### PR TITLE
Fix swapped descriptions of regex interpolation in language/case_spec

### DIFF
--- a/language/case_spec.rb
+++ b/language/case_spec.rb
@@ -103,7 +103,7 @@ describe "The 'case'-construct" do
     $1.should == "42"
   end
 
-  it "tests with a regexp interpolated within another regexp" do
+  it "tests with a string interpolated in a regexp" do
     digits = '\d+'
     case "foo44"
     when /oo(#{digits})/
@@ -116,7 +116,7 @@ describe "The 'case'-construct" do
     $1.should == "44"
   end
 
-  it "tests with a string interpolated in a regexp" do
+  it "tests with a regexp interpolated within another regexp" do
     digits_regexp = /\d+/
     case "foo43"
     when /oo(#{digits_regexp})/


### PR DESCRIPTION
This was a FIXME statement marked by @FnControlOption in the Natalie project.