### PR TITLE
Add missing spec_helper require to process/constants_spec

### DIFF
--- a/core/process/constants_spec.rb
+++ b/core/process/constants_spec.rb
@@ -1,3 +1,4 @@
+require_relative '../../spec_helper'
 
 describe "Process::Constants" do
   platform_is :darwin, :netbsd, :freebsd do


### PR DESCRIPTION
This was a FIXME statement marked by @nanobowers in the Natalie project