### PR TITLE
Ruby 3.1: Add specs for `require objspace/trace`

### DIFF
--- a/library/objectspace/fixtures/trace.rb
+++ b/library/objectspace/fixtures/trace.rb
@@ -1,0 +1,5 @@
+require "objspace/trace"
+a = "foo"
+b = "b" + "a" + "r"
+c = 42
+p a, b, c

--- a/library/objectspace/trace_spec.rb
+++ b/library/objectspace/trace_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../spec_helper'
+
+ruby_version_is "3.1" do
+  describe 'require "objspace/trace"' do
+    it "shows object allocation sites" do
+      file = fixture(__FILE__ , "trace.rb")
+      ruby_exe(file, args: "2>&1").lines(chomp: true).should == [
+        "objspace/trace is enabled",
+        "\"foo\" @ #{file}:2",
+        "\"bar\" @ #{file}:3",
+        "42"
+      ]
+    end
+  end
+end


### PR DESCRIPTION
Add specs for [Feature #17762](https://bugs.ruby-lang.org/issues/17762)

Ref:

- #923
  - > Miscellaneous changes
    - > ib/objspace/trace.rb is added, which is a tool for tracing the object allocation. Just by requiring this file, tracing is started immediately. Just by Kernel#p, you can investigate where an object was created. Note that just requiring this file brings a large performance overhead. This is only for debugging purposes. Do not use this in production. [[Feature #17762](https://bugs.ruby-lang.org/issues/17762)]
- https://github.com/ruby/ruby/commit/cf1e1879f12ad547f95fe94ab62b4d960e804eb8
