### PR TITLE
Use SHA256 instead of SHA1

### DIFF
--- a/library/openssl/x509/name/verify_spec.rb
+++ b/library/openssl/x509/name/verify_spec.rb
@@ -12,7 +12,7 @@ describe "OpenSSL::X509::Name.verify" do
     cert.public_key = key.public_key
     cert.not_before = Time.now - 10
     cert.not_after = cert.not_before + 365 * 24 * 60 * 60
-    cert.sign key, OpenSSL::Digest.new('SHA1')
+    cert.sign key, OpenSSL::Digest.new('SHA256')
     store = OpenSSL::X509::Store.new
     store.add_cert(cert)
     [store.verify(cert), store.error, store.error_string].should == [true, 0, "ok"]
@@ -28,7 +28,7 @@ describe "OpenSSL::X509::Name.verify" do
     cert.public_key = key.public_key
     cert.not_before = Time.now - 10
     cert.not_after = Time.now - 5
-    cert.sign key, OpenSSL::Digest.new('SHA1')
+    cert.sign key, OpenSSL::Digest.new('SHA256')
     store = OpenSSL::X509::Store.new
     store.add_cert(cert)
     store.verify(cert).should == false


### PR DESCRIPTION
Systems such as CentOS 9 / RHEL 9 are moving away from SHA1 disabling it by default via a system-wide crypto policy. This replaces SHA1 with SHA256 in similar way as [[1]].

[1]: https://github.com/ruby/openssl/pull/554