### PR TITLE
Fix failures in spawn_spec.rb on Windows

### DIFF
--- a/core/process/spawn_spec.rb
+++ b/core/process/spawn_spec.rb
@@ -482,7 +482,7 @@ describe "Process.spawn" do
       -> do
         wrapped_io = mock('wrapped IO')
         wrapped_io.should_receive(:to_io).and_return(file)
-        Process.wait Process.spawn('echo "Hello World"', out: wrapped_io)
+        Process.wait Process.spawn('echo Hello World', out: wrapped_io)
       end.should output_to_fd("Hello World\n", file)
     end
   end


### PR DESCRIPTION
Fixes the following failure:

```
Process.spawn redirects to the wrapped IO using wrapped_io.to_io if out: wrapped_io FAILED
Expected (63040): "Hello World\n"
          but got: "\"Hello World\"\n"
```