### PR TITLE
Insert require_relative for spec_helper for specs where it was missing

### DIFF
--- a/core/basicobject/method_missing_spec.rb
+++ b/core/basicobject/method_missing_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/basicobject/method_missing'
 
 describe "BasicObject#method_missing" do

--- a/core/encoding/invalid_byte_sequence_error/destination_encoding_name_spec.rb
+++ b/core/encoding/invalid_byte_sequence_error/destination_encoding_name_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 require_relative '../fixtures/classes'
 
 describe "Encoding::InvalidByteSequenceError#destination_encoding_name" do

--- a/core/encoding/invalid_byte_sequence_error/destination_encoding_spec.rb
+++ b/core/encoding/invalid_byte_sequence_error/destination_encoding_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 require_relative '../fixtures/classes'
 
 describe "Encoding::InvalidByteSequenceError#destination_encoding" do

--- a/core/encoding/invalid_byte_sequence_error/error_bytes_spec.rb
+++ b/core/encoding/invalid_byte_sequence_error/error_bytes_spec.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+require_relative "../../../spec_helper"
 require_relative '../fixtures/classes'
 
 describe "Encoding::InvalidByteSequenceError#error_bytes" do

--- a/core/encoding/invalid_byte_sequence_error/readagain_bytes_spec.rb
+++ b/core/encoding/invalid_byte_sequence_error/readagain_bytes_spec.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+require_relative "../../../spec_helper"
 require_relative '../fixtures/classes'
 
 describe "Encoding::InvalidByteSequenceError#readagain_bytes" do

--- a/core/encoding/invalid_byte_sequence_error/source_encoding_name_spec.rb
+++ b/core/encoding/invalid_byte_sequence_error/source_encoding_name_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 require_relative '../fixtures/classes'
 
 describe "Encoding::UndefinedConversionError#source_encoding_name" do

--- a/core/encoding/invalid_byte_sequence_error/source_encoding_spec.rb
+++ b/core/encoding/invalid_byte_sequence_error/source_encoding_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 require_relative '../fixtures/classes'
 
 describe "Encoding::InvalidByteSequenceError#source_encoding" do

--- a/core/encoding/name_spec.rb
+++ b/core/encoding/name_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative 'shared/name'
 
 describe "Encoding#name" do

--- a/core/encoding/to_s_spec.rb
+++ b/core/encoding/to_s_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative 'shared/name'
 
 describe "Encoding#to_s" do

--- a/core/encoding/undefined_conversion_error/destination_encoding_name_spec.rb
+++ b/core/encoding/undefined_conversion_error/destination_encoding_name_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 require_relative '../fixtures/classes'
 
 describe "Encoding::UndefinedConversionError#destination_encoding_name" do

--- a/core/encoding/undefined_conversion_error/destination_encoding_spec.rb
+++ b/core/encoding/undefined_conversion_error/destination_encoding_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 require_relative '../fixtures/classes'
 
 describe "Encoding::UndefinedConversionError#destination_encoding" do

--- a/core/encoding/undefined_conversion_error/error_char_spec.rb
+++ b/core/encoding/undefined_conversion_error/error_char_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 require_relative '../fixtures/classes'
 
 describe "Encoding::UndefinedConversionError#error_char" do

--- a/core/encoding/undefined_conversion_error/source_encoding_name_spec.rb
+++ b/core/encoding/undefined_conversion_error/source_encoding_name_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 require_relative '../fixtures/classes'
 
 describe "Encoding::UndefinedConversionError#source_encoding_name" do

--- a/core/encoding/undefined_conversion_error/source_encoding_spec.rb
+++ b/core/encoding/undefined_conversion_error/source_encoding_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 require_relative '../fixtures/classes'
 
 describe "Encoding::UndefinedConversionError#source_encoding" do

--- a/core/float/magnitude_spec.rb
+++ b/core/float/magnitude_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative 'shared/abs'
 
 describe "Float#magnitude" do

--- a/core/numeric/magnitude_spec.rb
+++ b/core/numeric/magnitude_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative 'shared/abs'
 
 describe "Numeric#magnitude" do

--- a/core/random/new_spec.rb
+++ b/core/random/new_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 describe "Random.new" do
   it "returns a new instance of Random" do
     Random.new.should be_an_instance_of(Random)

--- a/core/rational/abs_spec.rb
+++ b/core/rational/abs_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/abs'
 
 describe "Rational#abs" do

--- a/core/rational/ceil_spec.rb
+++ b/core/rational/ceil_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/ceil'
 
 describe "Rational#ceil" do

--- a/core/rational/coerce_spec.rb
+++ b/core/rational/coerce_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/coerce'
 
 describe "Rational#coerce" do

--- a/core/rational/comparison_spec.rb
+++ b/core/rational/comparison_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/comparison'
 
 describe "Rational#<=> when passed a Rational object" do

--- a/core/rational/denominator_spec.rb
+++ b/core/rational/denominator_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/denominator'
 
 describe "Rational#denominator" do

--- a/core/rational/div_spec.rb
+++ b/core/rational/div_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/div'
 
 describe "Rational#div" do

--- a/core/rational/divide_spec.rb
+++ b/core/rational/divide_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/divide'
 require_relative '../../shared/rational/arithmetic_exception_in_coerce'
 

--- a/core/rational/divmod_spec.rb
+++ b/core/rational/divmod_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/divmod'
 
 describe "Rational#divmod when passed a Rational" do

--- a/core/rational/equal_value_spec.rb
+++ b/core/rational/equal_value_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/equal_value'
 
 describe "Rational#==" do

--- a/core/rational/exponent_spec.rb
+++ b/core/rational/exponent_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/exponent'
 
 describe "Rational#**" do

--- a/core/rational/fdiv_spec.rb
+++ b/core/rational/fdiv_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/fdiv'
 
 describe "Rational#fdiv" do

--- a/core/rational/floor_spec.rb
+++ b/core/rational/floor_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/floor'
 
 describe "Rational#floor" do

--- a/core/rational/hash_spec.rb
+++ b/core/rational/hash_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/hash'
 
 describe "Rational#hash" do

--- a/core/rational/inspect_spec.rb
+++ b/core/rational/inspect_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/inspect'
 
 describe "Rational#inspect" do

--- a/core/rational/integer_spec.rb
+++ b/core/rational/integer_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 describe "Rational#integer?" do
   # Guard against the Mathn library
   guard -> { !defined?(Math.rsqrt) } do

--- a/core/rational/magnitude_spec.rb
+++ b/core/rational/magnitude_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/abs'
 
 describe "Rational#abs" do

--- a/core/rational/modulo_spec.rb
+++ b/core/rational/modulo_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/modulo'
 
 describe "Rational#%" do

--- a/core/rational/multiply_spec.rb
+++ b/core/rational/multiply_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/multiply'
 require_relative '../../shared/rational/arithmetic_exception_in_coerce'
 

--- a/core/rational/numerator_spec.rb
+++ b/core/rational/numerator_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/numerator'
 
 describe "Rational#numerator" do

--- a/core/rational/plus_spec.rb
+++ b/core/rational/plus_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/plus'
 require_relative '../../shared/rational/arithmetic_exception_in_coerce'
 

--- a/core/rational/quo_spec.rb
+++ b/core/rational/quo_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/divide'
 
 describe "Rational#quo" do

--- a/core/rational/remainder_spec.rb
+++ b/core/rational/remainder_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/remainder'
 
 describe "Rational#remainder" do

--- a/core/rational/to_f_spec.rb
+++ b/core/rational/to_f_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/to_f'
 
 describe "Rational#to_f" do

--- a/core/rational/to_i_spec.rb
+++ b/core/rational/to_i_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/to_i'
 
 describe "Rational#to_i" do

--- a/core/rational/to_r_spec.rb
+++ b/core/rational/to_r_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/to_r'
 
 describe "Rational#to_r" do

--- a/core/rational/to_s_spec.rb
+++ b/core/rational/to_s_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/to_s'
 
 describe "Rational#to_s" do

--- a/core/rational/truncate_spec.rb
+++ b/core/rational/truncate_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative '../../shared/rational/truncate'
 
 describe "Rational#truncate" do

--- a/core/rational/zero_spec.rb
+++ b/core/rational/zero_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 describe "Rational#zero?" do
   it "returns true if the numerator is 0" do
     Rational(0,26).zero?.should be_true

--- a/core/string/chars_spec.rb
+++ b/core/string/chars_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative 'shared/chars'
 
 describe "String#chars" do

--- a/core/string/each_char_spec.rb
+++ b/core/string/each_char_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative 'shared/chars'
 require_relative 'shared/each_char_without_block'
 

--- a/core/string/each_grapheme_cluster_spec.rb
+++ b/core/string/each_grapheme_cluster_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative 'shared/chars'
 require_relative 'shared/grapheme_clusters'
 require_relative 'shared/each_char_without_block'

--- a/core/string/grapheme_clusters_spec.rb
+++ b/core/string/grapheme_clusters_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative 'shared/chars'
 require_relative 'shared/grapheme_clusters'
 

--- a/library/date/strftime_spec.rb
+++ b/library/date/strftime_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require 'date'
 require_relative '../../shared/time/strftime_for_date'
 

--- a/library/delegate/delegate_class/respond_to_missing_spec.rb
+++ b/library/delegate/delegate_class/respond_to_missing_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 require 'delegate'
 
 describe "DelegateClass#respond_to_missing?" do

--- a/library/set/to_s_spec.rb
+++ b/library/set/to_s_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../spec_helper"
 require_relative 'shared/inspect'
 require 'set'
 

--- a/library/socket/tcpsocket/open_spec.rb
+++ b/library/socket/tcpsocket/open_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 require_relative 'shared/new'
 
 describe "TCPSocket.open" do

--- a/library/win32ole/win32ole/_getproperty_spec.rb
+++ b/library/win32ole/win32ole/_getproperty_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require_relative '../fixtures/classes'
 

--- a/library/win32ole/win32ole/_invoke_spec.rb
+++ b/library/win32ole/win32ole/_invoke_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require_relative '../fixtures/classes'
 

--- a/library/win32ole/win32ole/codepage_spec.rb
+++ b/library/win32ole/win32ole/codepage_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require_relative '../fixtures/classes'
 

--- a/library/win32ole/win32ole/connect_spec.rb
+++ b/library/win32ole/win32ole/connect_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require_relative '../fixtures/classes'
 

--- a/library/win32ole/win32ole/const_load_spec.rb
+++ b/library/win32ole/win32ole/const_load_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require_relative '../fixtures/classes'
 

--- a/library/win32ole/win32ole/constants_spec.rb
+++ b/library/win32ole/win32ole/constants_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require_relative '../fixtures/classes'
 

--- a/library/win32ole/win32ole/create_guid_spec.rb
+++ b/library/win32ole/win32ole/create_guid_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require_relative '../fixtures/classes'
 

--- a/library/win32ole/win32ole/invoke_spec.rb
+++ b/library/win32ole/win32ole/invoke_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require_relative '../fixtures/classes'
 

--- a/library/win32ole/win32ole/locale_spec.rb
+++ b/library/win32ole/win32ole/locale_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require_relative '../fixtures/classes'
 

--- a/library/win32ole/win32ole/new_spec.rb
+++ b/library/win32ole/win32ole/new_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require_relative '../fixtures/classes'
 

--- a/library/win32ole/win32ole/ole_func_methods_spec.rb
+++ b/library/win32ole/win32ole/ole_func_methods_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require_relative '../fixtures/classes'
 

--- a/library/win32ole/win32ole/ole_get_methods_spec.rb
+++ b/library/win32ole/win32ole/ole_get_methods_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require_relative '../fixtures/classes'
 

--- a/library/win32ole/win32ole/ole_method_help_spec.rb
+++ b/library/win32ole/win32ole/ole_method_help_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require_relative '../fixtures/classes'
   require_relative 'shared/ole_method'

--- a/library/win32ole/win32ole/ole_method_spec.rb
+++ b/library/win32ole/win32ole/ole_method_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require_relative '../fixtures/classes'
   require_relative 'shared/ole_method'

--- a/library/win32ole/win32ole/ole_methods_spec.rb
+++ b/library/win32ole/win32ole/ole_methods_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require_relative '../fixtures/classes'
 

--- a/library/win32ole/win32ole/ole_obj_help_spec.rb
+++ b/library/win32ole/win32ole/ole_obj_help_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 
 platform_is :windows do
   require_relative '../fixtures/classes'

--- a/library/win32ole/win32ole/ole_put_methods_spec.rb
+++ b/library/win32ole/win32ole/ole_put_methods_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require_relative '../fixtures/classes'
 

--- a/library/win32ole/win32ole/setproperty_spec.rb
+++ b/library/win32ole/win32ole/setproperty_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require_relative '../fixtures/classes'
   require_relative 'shared/setproperty'

--- a/library/win32ole/win32ole_event/new_spec.rb
+++ b/library/win32ole/win32ole_event/new_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require_relative '../fixtures/classes'
 

--- a/library/win32ole/win32ole_event/on_event_spec.rb
+++ b/library/win32ole/win32ole_event/on_event_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require_relative '../fixtures/classes'
   guard -> { WIN32OLESpecs::MSXML_AVAILABLE } do

--- a/library/win32ole/win32ole_method/dispid_spec.rb
+++ b/library/win32ole/win32ole_method/dispid_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_method/event_interface_spec.rb
+++ b/library/win32ole/win32ole_method/event_interface_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require_relative '../fixtures/classes'
   guard -> { WIN32OLESpecs::SYSTEM_MONITOR_CONTROL_AVAILABLE } do

--- a/library/win32ole/win32ole_method/event_spec.rb
+++ b/library/win32ole/win32ole_method/event_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require_relative '../fixtures/classes'
   guard -> { WIN32OLESpecs::SYSTEM_MONITOR_CONTROL_AVAILABLE } do

--- a/library/win32ole/win32ole_method/helpcontext_spec.rb
+++ b/library/win32ole/win32ole_method/helpcontext_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_method/helpfile_spec.rb
+++ b/library/win32ole/win32ole_method/helpfile_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_method/helpstring_spec.rb
+++ b/library/win32ole/win32ole_method/helpstring_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_method/invkind_spec.rb
+++ b/library/win32ole/win32ole_method/invkind_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_method/invoke_kind_spec.rb
+++ b/library/win32ole/win32ole_method/invoke_kind_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_method/name_spec.rb
+++ b/library/win32ole/win32ole_method/name_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 require_relative 'shared/name'
 
 platform_is :windows do

--- a/library/win32ole/win32ole_method/new_spec.rb
+++ b/library/win32ole/win32ole_method/new_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_method/offset_vtbl_spec.rb
+++ b/library/win32ole/win32ole_method/offset_vtbl_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_method/params_spec.rb
+++ b/library/win32ole/win32ole_method/params_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_method/return_type_detail_spec.rb
+++ b/library/win32ole/win32ole_method/return_type_detail_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_method/return_type_spec.rb
+++ b/library/win32ole/win32ole_method/return_type_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_method/return_vtype_spec.rb
+++ b/library/win32ole/win32ole_method/return_vtype_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_method/size_opt_params_spec.rb
+++ b/library/win32ole/win32ole_method/size_opt_params_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_method/size_params_spec.rb
+++ b/library/win32ole/win32ole_method/size_params_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_method/to_s_spec.rb
+++ b/library/win32ole/win32ole_method/to_s_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 require_relative 'shared/name'
 
 platform_is :windows do

--- a/library/win32ole/win32ole_method/visible_spec.rb
+++ b/library/win32ole/win32ole_method/visible_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_param/default_spec.rb
+++ b/library/win32ole/win32ole_param/default_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_param/input_spec.rb
+++ b/library/win32ole/win32ole_param/input_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_param/name_spec.rb
+++ b/library/win32ole/win32ole_param/name_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 require_relative 'shared/name'
 
 platform_is :windows do

--- a/library/win32ole/win32ole_param/ole_type_detail_spec.rb
+++ b/library/win32ole/win32ole_param/ole_type_detail_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_param/ole_type_spec.rb
+++ b/library/win32ole/win32ole_param/ole_type_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_param/optional_spec.rb
+++ b/library/win32ole/win32ole_param/optional_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_param/retval_spec.rb
+++ b/library/win32ole/win32ole_param/retval_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_param/to_s_spec.rb
+++ b/library/win32ole/win32ole_param/to_s_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 require_relative 'shared/name'
 
 platform_is :windows do

--- a/library/win32ole/win32ole_type/guid_spec.rb
+++ b/library/win32ole/win32ole_type/guid_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_type/helpcontext_spec.rb
+++ b/library/win32ole/win32ole_type/helpcontext_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_type/helpfile_spec.rb
+++ b/library/win32ole/win32ole_type/helpfile_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_type/helpstring_spec.rb
+++ b/library/win32ole/win32ole_type/helpstring_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_type/major_version_spec.rb
+++ b/library/win32ole/win32ole_type/major_version_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_type/minor_version_spec.rb
+++ b/library/win32ole/win32ole_type/minor_version_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_type/name_spec.rb
+++ b/library/win32ole/win32ole_type/name_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 require_relative 'shared/name'
 
 platform_is :windows do

--- a/library/win32ole/win32ole_type/new_spec.rb
+++ b/library/win32ole/win32ole_type/new_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_type/ole_classes_spec.rb
+++ b/library/win32ole/win32ole_type/ole_classes_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_type/ole_methods_spec.rb
+++ b/library/win32ole/win32ole_type/ole_methods_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_type/ole_type_spec.rb
+++ b/library/win32ole/win32ole_type/ole_type_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_type/progid_spec.rb
+++ b/library/win32ole/win32ole_type/progid_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_type/progids_spec.rb
+++ b/library/win32ole/win32ole_type/progids_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_type/src_type_spec.rb
+++ b/library/win32ole/win32ole_type/src_type_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_type/to_s_spec.rb
+++ b/library/win32ole/win32ole_type/to_s_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 require_relative 'shared/name'
 
 platform_is :windows do

--- a/library/win32ole/win32ole_type/typekind_spec.rb
+++ b/library/win32ole/win32ole_type/typekind_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_type/typelibs_spec.rb
+++ b/library/win32ole/win32ole_type/typelibs_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_type/variables_spec.rb
+++ b/library/win32ole/win32ole_type/variables_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_type/visible_spec.rb
+++ b/library/win32ole/win32ole_type/visible_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_variable/name_spec.rb
+++ b/library/win32ole/win32ole_variable/name_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 require_relative 'shared/name'
 
 platform_is :windows do

--- a/library/win32ole/win32ole_variable/ole_type_detail_spec.rb
+++ b/library/win32ole/win32ole_variable/ole_type_detail_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_variable/ole_type_spec.rb
+++ b/library/win32ole/win32ole_variable/ole_type_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_variable/to_s_spec.rb
+++ b/library/win32ole/win32ole_variable/to_s_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 require_relative 'shared/name'
 
 platform_is :windows do

--- a/library/win32ole/win32ole_variable/value_spec.rb
+++ b/library/win32ole/win32ole_variable/value_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_variable/variable_kind_spec.rb
+++ b/library/win32ole/win32ole_variable/variable_kind_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_variable/varkind_spec.rb
+++ b/library/win32ole/win32ole_variable/varkind_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/win32ole/win32ole_variable/visible_spec.rb
+++ b/library/win32ole/win32ole_variable/visible_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 platform_is :windows do
   require 'win32ole'
 

--- a/library/zlib/gzipreader/each_line_spec.rb
+++ b/library/zlib/gzipreader/each_line_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 require_relative 'shared/each'
 
 describe "Zlib::GzipReader#each_line" do

--- a/library/zlib/gzipreader/each_spec.rb
+++ b/library/zlib/gzipreader/each_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 require_relative 'shared/each'
 
 describe "Zlib::GzipReader#each" do

--- a/library/zlib/inflate/finish_spec.rb
+++ b/library/zlib/inflate/finish_spec.rb
@@ -1,3 +1,4 @@
+require_relative "../../../spec_helper"
 require 'zlib'
 
 describe "Zlib::Inflate#finish" do


### PR DESCRIPTION
This is helpful for testing the specs when run they are run standalone with Ruby, which is what the Natalie implementation of Ruby does currently.

Related to #988