### PR TITLE
add spec for Struct can be initialized with keyword arguments in 3.2

### DIFF
--- a/core/struct/initialize_spec.rb
+++ b/core/struct/initialize_spec.rb
@@ -48,4 +48,14 @@ describe "Struct#initialize" do
       }.should complain(/warning: Passing only keyword arguments/)
     end
   end
+
+  ruby_version_is "3.2" do
+    it "can be initialized with keyword arguments" do
+      positional_args = StructClasses::Ruby.new("3.2", "OS")
+      keyword_args = StructClasses::Ruby.new(version: "3.2", platform: "OS")
+
+      positional_args.version.should == keyword_args.version
+      positional_args.platform.should == keyword_args.platform
+    end
+  end
 end


### PR DESCRIPTION
Hello 👋 

This PR adds a test for:

* A Struct class can also be initialized with keyword arguments without `keyword_init: true` on `Struct.new` [[Feature #16806](https://bugs.ruby-lang.org/issues/16806)]

Please let me know if something can be improved, thank you !