### PR TITLE
add specs for `Data.define`

### DIFF
--- a/core/data/define_spec.rb
+++ b/core/data/define_spec.rb
@@ -1,0 +1,26 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+ruby_version_is "3.2" do
+  describe "Data.define" do
+    it "accepts no arguments" do
+      empty_data = Data.define
+      empty_data.members.should == []
+    end
+
+    it "accepts symbols" do
+      movie_with_symbol = Data.define(:title, :year)
+      movie_with_symbol.members.should == [:title, :year]
+    end
+
+    it "accepts strings" do
+      movie_with_string = Data.define("title", "year")
+      movie_with_string.members.should == [:title, :year]
+    end
+
+    it "accepts a mix of strings and symbols" do
+      blockbuster_movie = Data.define("title", :year, "genre")
+      blockbuster_movie.members.should == [:title, :year, :genre]
+    end
+  end
+end


### PR DESCRIPTION
Hello again 👋 

Here's an attempt for `Data.define` that is related to:

* New core class to represent simple immutable value object. The class is similar to Struct and partially shares an implementation, but has more lean and strict API. [[Feature #16122](https://bugs.ruby-lang.org/issues/16122)]

I got confused by the Documentation (https://docs.ruby-lang.org/en/3.2/Data.html) that says 

> define(name, *symbols) → class
> define(*symbols) → class
>
> Defines a new Data class. If the first argument is a string, the class is stored in `Data::<name>` constant.

I believe the `define(name, *symbols)` is either wrongly documented or not implented. If I read the discussion about the Feature correctly (https://bugs.ruby-lang.org/issues/16122 ), it's not supposed to be implemented, do you agree?

I added a failing test for it nonetheless.

As always, thank you very much for your review. Let me know what else I can improve. 🙌 

