### PR TITLE
Add specs for `Data.define` with block

### DIFF
--- a/core/data/define_spec.rb
+++ b/core/data/define_spec.rb
@@ -22,5 +22,15 @@ ruby_version_is "3.2" do
       movie = Data.define("title", :year, "genre")
       movie.members.should == [:title, :year, :genre]
     end
+
+    it "accepts a block" do
+      movie = Data.define(:title, :year) do
+        def title_with_year
+          "#{title} (#{year})"
+        end
+      end
+      movie.members.should == [:title, :year]
+      movie.new("Matrix", 1999).title_with_year.should == "Matrix (1999)"
+    end
   end
 end

--- a/core/data/define_spec.rb
+++ b/core/data/define_spec.rb
@@ -9,18 +9,18 @@ ruby_version_is "3.2" do
     end
 
     it "accepts symbols" do
-      movie_with_symbol = Data.define(:title, :year)
-      movie_with_symbol.members.should == [:title, :year]
+      movie = Data.define(:title, :year)
+      movie.members.should == [:title, :year]
     end
 
     it "accepts strings" do
-      movie_with_string = Data.define("title", "year")
-      movie_with_string.members.should == [:title, :year]
+      movie = Data.define("title", "year")
+      movie.members.should == [:title, :year]
     end
 
     it "accepts a mix of strings and symbols" do
-      blockbuster_movie = Data.define("title", :year, "genre")
-      blockbuster_movie.members.should == [:title, :year, :genre]
+      movie = Data.define("title", :year, "genre")
+      movie.members.should == [:title, :year, :genre]
     end
   end
 end


### PR DESCRIPTION
Hi again 👋 🙃 

I just realized I missed a test case for `Data.define` with a block. This PR adds that.

Do you think the documentation could/should be improved as well, since it does not mention the capability of blocks:

![Screenshot 2023-01-12 at 16 54 25](https://user-images.githubusercontent.com/1409672/212115464-ee980ffd-c022-402d-b34f-fde026b99462.png)

In my opinion the signature should be something like `define(*symbols) {|Data_subclass| ... } → class`.

And it would be nice to have an code example with a block. Actually, there is an example in `Define.new`, but one may not necessarily see that when reading the documentation. 🤷 