### PR TITLE
Add spec for Kernel.Integer where base converts to int

### DIFF
--- a/core/kernel/Integer_spec.rb
+++ b/core/kernel/Integer_spec.rb
@@ -577,6 +577,13 @@ describe "Integer() given a String and base", shared: true do
     it "raises an ArgumentError if a base is given for a non-String value" do
       -> { Integer(98, 15) }.should raise_error(ArgumentError)
     end
+
+    it "tries to convert the base to an integer using to_int" do
+      obj = mock('8')
+      obj.should_receive(:to_int).and_return(8)
+
+      Integer("777", obj).should == 0777
+    end
   end
 
   describe "when passed exception: false" do


### PR DESCRIPTION
The spec has been copied from the spec for String#to_i, where this behaviour has been made explicit.