### PR TITLE
Moving require_relative of spec_helper outside of the guard-block...

### DIFF
--- a/core/time/succ_spec.rb
+++ b/core/time/succ_spec.rb
@@ -1,5 +1,6 @@
+require_relative '../../spec_helper'
+
 ruby_version_is ""..."3.0" do
-  require_relative '../../spec_helper'
   require_relative 'fixtures/classes'
 
   describe "Time#succ" do

--- a/library/expect/expect_spec.rb
+++ b/library/expect/expect_spec.rb
@@ -1,5 +1,6 @@
+require_relative '../../spec_helper'
+
 platform_is_not :windows do
-  require_relative '../../spec_helper'
   require 'expect'
 
   describe "IO#expect" do


### PR DESCRIPTION
 Moving require_relative of spec_helper outside of the guard-block, as the guard-block itself is defined by loading the spec_helper.

This makes it possible to run these specs stand-alone.