### PR TITLE
Add check for output of stringification of Set

### DIFF
--- a/library/set/shared/inspect.rb
+++ b/library/set/shared/inspect.rb
@@ -11,6 +11,10 @@ describe "set_inspect", shared: true do
     Set["1"].send(@method).should == '#<Set: {"1"}>'
   end
 
+  it "puts spaces between the elements" do
+    Set["1", "2"].send(@method).should include('", "')
+  end
+
   it "correctly handles self-references" do
     (set = Set[]) << set
     set.send(@method).should be_kind_of(String)

--- a/library/set/shared/inspect.rb
+++ b/library/set/shared/inspect.rb
@@ -7,6 +7,10 @@ describe "set_inspect", shared: true do
     Set[:a, "b", Set[?c]].send(@method).should be_kind_of(String)
   end
 
+  it "does include the elements of the set" do
+    Set["1"].send(@method).should == '#<Set: {"1"}>'
+  end
+
   it "correctly handles self-references" do
     (set = Set[]) << set
     set.send(@method).should be_kind_of(String)


### PR DESCRIPTION
The current tests are far from complete: It checks the recursive case to see if it does include a `Set: {...}`, and it tests a number of entries to see if the result is a String.

I choose to use a Set with a single value to ensure ordering is not relevant (even though Sets in MRI are ordered, I don't think that should be a requirement). The value is a String, to check if `to_s` and `inspect` result in the same output.