### PR TITLE
Fix coercion of mocks in bitwise operations of Integer

### DIFF
--- a/core/integer/bit_and_spec.rb
+++ b/core/integer/bit_and_spec.rb
@@ -30,7 +30,7 @@ describe "Integer#&" do
 
     it "coerces the rhs and calls #coerce" do
       obj = mock("fixnum bit and")
-      obj.should_receive(:coerce).with(6).and_return([3, 6])
+      obj.should_receive(:coerce).with(6).and_return([6, 3])
       (6 & obj).should == 2
     end
 

--- a/core/integer/bit_or_spec.rb
+++ b/core/integer/bit_or_spec.rb
@@ -32,7 +32,7 @@ describe "Integer#|" do
     it "coerces the rhs and calls #coerce" do
       obj = mock("fixnum bit or")
       obj.should_receive(:coerce).with(6).and_return([6, 3])
-      (6 & obj).should == 2
+      (6 | obj).should == 7
     end
 
     it "raises a TypeError when passed a Float" do

--- a/core/integer/bit_or_spec.rb
+++ b/core/integer/bit_or_spec.rb
@@ -30,7 +30,7 @@ describe "Integer#|" do
     end
 
     it "coerces the rhs and calls #coerce" do
-      obj = mock("fixnum bit and")
+      obj = mock("fixnum bit or")
       obj.should_receive(:coerce).with(6).and_return([6, 3])
       (6 & obj).should == 2
     end

--- a/core/integer/bit_or_spec.rb
+++ b/core/integer/bit_or_spec.rb
@@ -31,7 +31,7 @@ describe "Integer#|" do
 
     it "coerces the rhs and calls #coerce" do
       obj = mock("fixnum bit and")
-      obj.should_receive(:coerce).with(6).and_return([3, 6])
+      obj.should_receive(:coerce).with(6).and_return([6, 3])
       (6 & obj).should == 2
     end
 

--- a/core/integer/bit_xor_spec.rb
+++ b/core/integer/bit_xor_spec.rb
@@ -28,7 +28,7 @@ describe "Integer#^" do
     end
 
     it "coerces the rhs and calls #coerce" do
-      obj = mock("fixnum bit and")
+      obj = mock("fixnum bit xor")
       obj.should_receive(:coerce).with(6).and_return([6, 3])
       (6 ^ obj).should == 5
     end

--- a/core/integer/bit_xor_spec.rb
+++ b/core/integer/bit_xor_spec.rb
@@ -29,7 +29,7 @@ describe "Integer#^" do
 
     it "coerces the rhs and calls #coerce" do
       obj = mock("fixnum bit and")
-      obj.should_receive(:coerce).with(6).and_return([3, 6])
+      obj.should_receive(:coerce).with(6).and_return([6, 3])
       (6 ^ obj).should == 5
     end
 


### PR DESCRIPTION
The mock object in a stand in for 3. Calling coerce on 3 with 6 as an argument outputs `[6, 3]`, not `[3, 6]`. Because they're all commutative operations, current implementations do actually return the correct value.