### PR TITLE
Add specs for evaluation order during assignment

### DIFF
--- a/language/fixtures/variables.rb
+++ b/language/fixtures/variables.rb
@@ -82,4 +82,76 @@ module VariablesSpecs
   def self.false
     false
   end
+
+  class EvalOrder
+    attr_reader :order
+
+    def initialize
+      @order = []
+    end
+
+    def reset
+      @order = []
+    end
+
+    def foo
+      self << "foo"
+      FooClass.new(self)
+    end
+
+    def bar
+      self << "bar"
+      BarClass.new(self)
+    end
+
+    def a
+      self << "a"
+    end
+
+    def b
+      self << "b"
+    end
+
+    def node
+      self << "node"
+
+      node = Node.new
+      node.left = Node.new
+      node.left.right = Node.new
+
+      node
+    end
+
+    def <<(value)
+      order << value
+    end
+
+    class FooClass
+      attr_reader :evaluator
+
+      def initialize(evaluator)
+        @evaluator = evaluator
+      end
+
+      def []=(_index, _value)
+        evaluator << "foo[]="
+      end
+    end
+
+    class BarClass
+      attr_reader :evaluator
+
+      def initialize(evaluator)
+        @evaluator = evaluator
+      end
+
+      def baz=(_value)
+        evaluator << "bar.baz="
+      end
+    end
+
+    class Node
+      attr_accessor :left, :right
+    end
+  end
 end

--- a/language/variables_spec.rb
+++ b/language/variables_spec.rb
@@ -1,6 +1,86 @@
 require_relative '../spec_helper'
 require_relative 'fixtures/variables'
 
+describe "Evaluation order during assignment" do
+  context "with single assignment" do
+    it "evaluates from left to right" do
+      obj = VariablesSpecs::EvalOrder.new
+      obj.instance_eval do
+        foo[0] = a
+      end
+
+      obj.order.should == ["foo", "a", "foo[]="]
+    end
+  end
+
+  context "with multiple assignment" do
+    ruby_version_is ""..."3.1" do
+      it "does not evaluate from left to right" do
+        obj = VariablesSpecs::EvalOrder.new
+
+        obj.instance_eval do
+          foo[0], bar.baz = a, b
+        end
+
+        obj.order.should == ["a", "b", "foo", "foo[]=", "bar", "bar.baz="]
+      end
+
+      it "cannot be used to swap variables with nested method calls" do
+        node = VariablesSpecs::EvalOrder.new.node
+
+        original_node = node
+        original_node_left = node.left
+        original_node_left_right = node.left.right
+
+        node.left, node.left.right, node = node.left.right, node, node.left
+        # Should evaluate in the order of:
+        # RHS: node.left.right, node, node.left
+        # LHS:
+        # * node(original_node), original_node.left = original_node_left_right
+        # * node(original_node), node.left(changed in the previous assignment to original_node_left_right),
+        #   original_node_left_right.right = original_node
+        # * node = original_node_left
+
+        node.should == original_node_left
+        node.right.should_not == original_node
+        node.right.left.should_not == original_node_left_right
+      end
+    end
+
+    ruby_version_is "3.1" do
+      it "evaluates from left to right, receivers first then methods" do
+        obj = VariablesSpecs::EvalOrder.new
+        obj.instance_eval do
+          foo[0], bar.baz = a, b
+        end
+
+        obj.order.should == ["foo", "bar", "a", "b", "foo[]=", "bar.baz="]
+      end
+
+      it "can be used to swap variables with nested method calls" do
+        node = VariablesSpecs::EvalOrder.new.node
+
+        original_node = node
+        original_node_left = node.left
+        original_node_left_right = node.left.right
+
+        node.left, node.left.right, node = node.left.right, node, node.left
+        # Should evaluate in the order of:
+        # LHS: node, node.left(original_node_left)
+        # RHS: original_node_left_right, original_node, original_node_left
+        # Ops:
+        # * node(original_node), original_node.left = original_node_left_right
+        # * original_node_left.right = original_node
+        # * node = original_node_left
+
+        node.should == original_node_left
+        node.right.should == original_node
+        node.right.left.should == original_node_left_right
+      end
+    end
+  end
+end
+
 describe "Multiple assignment" do
   context "with a single RHS value" do
     it "assigns a simple MLHS" do


### PR DESCRIPTION
This PR adds specs for [Bug #4443](https://bugs.ruby-lang.org/issues/4443)

From:

* https://github.com/ruby/spec/issues/923

> Multiple assignment evaluation order has been made consistent with
> single assignment evaluation order. With single assignment, Ruby
> uses a left-to-right evaluation order. With this code:
> 
> foo[0] = bar
> The following evaluation order is used:
> 
> foo
> bar
> []= called on the result of foo
> In Ruby before 3.1.0, multiple assignment did not follow this
> evaluation order. With this code:
> 
> foo[0], bar.baz = a, b
> Versions of Ruby before 3.1.0 would evaluate in the following
> order
> 
> a
> b
> foo
> []= called on the result of foo
> bar
> baz= called on the result of bar
> Starting in Ruby 3.1.0, the evaluation order is now consistent with
> single assignment, with the left-hand side being evaluated before
> the right-hand side:
> 
> foo
> bar
> a
> b
> []= called on the result of foo
> baz= called on the result of bar
> [[Bug #4443](https://bugs.ruby-lang.org/issues/4443)]