### PR TITLE
Add spec for `Proc#dup`

### DIFF
--- a/core/proc/shared/dup.rb
+++ b/core/proc/shared/dup.rb
@@ -7,4 +7,12 @@ describe :proc_dup, shared: true do
 
     a.call.should == b.call
   end
+
+  ruby_version_is "3.2" do
+    it "returns an instance of subclass" do
+      cl = Class.new(Proc)
+
+      cl.new{}.send(@method).class.should == cl
+    end
+  end
 end


### PR DESCRIPTION
#1016 
New spec for `Proc#dup` from this [issue](https://bugs.ruby-lang.org/issues/17545).

> Proc#dup returns an instance of subclass. [[Bug #17545](https://bugs.ruby-lang.org/issues/17545)]