### PR TITLE
Add specs for `Regexp#linear_time?`

### DIFF
--- a/core/regexp/linear_time_spec.rb
+++ b/core/regexp/linear_time_spec.rb
@@ -1,0 +1,25 @@
+require_relative '../../spec_helper'
+
+ruby_version_is "3.2" do
+  describe "Regexp.linear_time?" do
+    it "returns true if matching can be done in linear time" do
+      Regexp.linear_time?(/a/).should == true
+      Regexp.linear_time?('a').should == true
+    end
+
+    it "return false if matching can't be done in linear time" do
+      Regexp.linear_time?(/(a)\1/).should == false
+      Regexp.linear_time?("(a)\\1").should == false
+    end
+
+    it "accepts flags for string argument" do
+      Regexp.linear_time?('a', Regexp::IGNORECASE).should == true
+    end
+
+    it "warns about flags being ignored for regexp arguments" do
+      -> {
+        Regexp.linear_time?(/a/, Regexp::IGNORECASE)
+      }.should complain(/warning: flags ignored/)
+    end
+  end
+end


### PR DESCRIPTION
#1016 
[Issue](https://bugs.ruby-lang.org/issues/19194)

> Regexp.linear_time? is introduced. [[Feature #19194](https://bugs.ruby-lang.org/issues/19194)]