### PR TITLE
Add specs for `ENV#clone` and `#dup`

### DIFF
--- a/core/env/clone_spec.rb
+++ b/core/env/clone_spec.rb
@@ -1,0 +1,23 @@
+require_relative '../../spec_helper'
+
+describe "ENV#clone" do
+  it "raises ArgumentError when keyword argument 'freeze' is neither nil nor boolean" do
+    -> {
+      ENV.clone(freeze: 1)
+    }.should raise_error(ArgumentError)
+  end
+
+  it "raises ArgumentError when keyword argument is not 'freeze'" do
+    -> {
+      ENV.clone(foo: nil)
+    }.should raise_error(ArgumentError)
+  end
+
+  ruby_version_is "3.2" do
+    it "raises TypeError" do
+      -> {
+        ENV.clone
+      }.should raise_error(TypeError, /Cannot clone ENV, use ENV.to_h to get a copy of ENV as a hash/)
+    end
+  end
+end

--- a/core/env/dup_spec.rb
+++ b/core/env/dup_spec.rb
@@ -1,0 +1,11 @@
+require_relative '../../spec_helper'
+
+describe "ENV#dup" do
+  ruby_version_is "3.1" do
+    it "raises TypeError" do
+      -> {
+        ENV.dup
+      }.should raise_error(TypeError, /Cannot dup ENV, use ENV.to_h to get a copy of ENV as a hash/)
+    end
+  end
+end


### PR DESCRIPTION
#1016 
[[Bug #17767](https://bugs.ruby-lang.org/issues/17767)]
> Now ENV.clone raises TypeError as well as ENV.dup