### PR TITLE
Add specs for `Module#undefined_instance_methods`

### DIFF
--- a/core/module/fixtures/classes.rb
+++ b/core/module/fixtures/classes.rb
@@ -596,6 +596,32 @@ module ModuleSpecs
     private :foo
   end
   EmptyFooMethod = m.instance_method(:foo)
+
+  # for undefined_instance_methods spec
+  module UndefinedInstanceMethods
+    module Super
+      def super_included_method; end
+    end
+
+    class Parent
+      def undefed_method; end
+      undef_method :undefed_method
+
+      def parent_method; end
+      def another_parent_method; end
+    end
+
+    class Child < Parent
+      include Super
+
+      undef_method :parent_method
+      undef_method :another_parent_method
+    end
+
+    class Grandchild < Child
+      undef_method :super_included_method
+    end
+  end
 end
 
 class Object

--- a/core/module/undefined_instance_methods_spec.rb
+++ b/core/module/undefined_instance_methods_spec.rb
@@ -1,0 +1,26 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Module#undefined_instance_methods" do
+  ruby_version_is "3.2" do
+    it "returns methods undefined in the class" do
+      methods = ModuleSpecs::UndefinedInstanceMethods::Parent.undefined_instance_methods
+      methods.should == [:undefed_method]
+    end
+
+    it "returns inherited methods undefined in the class" do
+      methods = ModuleSpecs::UndefinedInstanceMethods::Child.undefined_instance_methods
+      methods.should include(:parent_method, :another_parent_method)
+    end
+
+    it "returns methods from an included module that are undefined in the class" do
+      methods = ModuleSpecs::UndefinedInstanceMethods::Grandchild.undefined_instance_methods
+      methods.should include(:super_included_method)
+    end
+
+    it "does not returns ancestors undefined methods" do
+      methods = ModuleSpecs::UndefinedInstanceMethods::Grandchild.undefined_instance_methods
+      methods.should_not include(:parent_method, :another_parent_method)
+    end
+  end
+end


### PR DESCRIPTION
#1016 
[[Feature #12655](https://bugs.ruby-lang.org/issues/12655)]

> Module#undefined_instance_methods has been added.

I hope all the most important test cases are included.