### PR TITLE
Add specs for `Exception#detailed_message`

### DIFF
--- a/core/exception/detailed_message_spec.rb
+++ b/core/exception/detailed_message_spec.rb
@@ -1,0 +1,35 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/common'
+
+describe "Exception#detailed_message" do
+  ruby_version_is "3.2" do
+    it "returns decorated message" do
+      RuntimeError.new("new error").detailed_message.should == "new error (RuntimeError)"
+    end
+
+    it "accepts highlight keyword argument and adds escape control sequences" do
+      RuntimeError.new("new error").detailed_message(highlight: true).should == "\e[1mnew error (\e[1;4mRuntimeError\e[m\e[1m)\e[m"
+    end
+
+    it "allows and ignores other keyword arguments" do
+      RuntimeError.new("new error").detailed_message(foo: true).should == "new error (RuntimeError)"
+    end
+
+    it "returns just a message if exception class is anonymous" do
+      Class.new(RuntimeError).new("message").detailed_message.should == "message"
+    end
+
+    it "returns 'unhandled exception' for an instance of RuntimeError with empty message" do
+      RuntimeError.new("").detailed_message.should == "unhandled exception"
+    end
+
+    it "returns just class name for an instance of RuntimeError sublass with empty message" do
+      DetailedMessageSpec::C.new("").detailed_message.should == "DetailedMessageSpec::C"
+    end
+
+    it "returns a generated class name for an instance of RuntimeError anonymous subclass with empty message" do
+      klass = Class.new(RuntimeError)
+      klass.new("").detailed_message.should =~  /\A#<Class:0x\h+>\z/
+    end
+  end
+end

--- a/core/exception/fixtures/common.rb
+++ b/core/exception/fixtures/common.rb
@@ -93,3 +93,7 @@ class NameErrorSpecs
     end
   end
 end
+
+module DetailedMessageSpec
+  C = Class.new(RuntimeError)
+end

--- a/core/exception/full_message_spec.rb
+++ b/core/exception/full_message_spec.rb
@@ -103,4 +103,25 @@ describe "Exception#full_message" do
     exception.full_message.should include "intermediate exception"
     exception.full_message.should include "origin exception"
   end
+
+  ruby_version_is "3.2" do
+    it "relies on #detailed_message" do
+      e = RuntimeError.new("new error")
+      e.define_singleton_method(:detailed_message) { |**opt| "DETAILED MESSAGE" }
+
+      e.full_message.lines.first.should =~ /DETAILED MESSAGE/
+    end
+
+    it "passes all its own keyword arguments to #detailed_message" do
+      e = RuntimeError.new("new error")
+      opt_ = nil
+      e.define_singleton_method(:detailed_message) do |**opt|
+        opt_ = opt
+        "DETAILED MESSAGE"
+      end
+
+      e.full_message(foo: "bar")
+      opt_.should == { foo: "bar", highlight: Exception.to_tty? }
+    end
+  end
 end


### PR DESCRIPTION
#1016 
[[Feature #18564](https://bugs.ruby-lang.org/issues/18564)]
> Exception#detailed_message has been added.
The default error printer calls this method on the Exception object
instead of #message