### PR TITLE
Add specs for `MachData#deconstruct_keys` and `#deconstruct`

### DIFF
--- a/core/matchdata/captures_spec.rb
+++ b/core/matchdata/captures_spec.rb
@@ -1,15 +1,6 @@
 require_relative '../../spec_helper'
-require_relative 'fixtures/classes'
+require_relative 'shared/captures'
 
 describe "MatchData#captures" do
-  it "returns an array of the match captures" do
-    /(.)(.)(\d+)(\d)/.match("THX1138.").captures.should == ["H","X","113","8"]
-  end
-
-  ruby_version_is "3.0" do
-    it "returns instances of String when given a String subclass" do
-      str = MatchDataSpecs::MyString.new("THX1138: The Movie")
-      /(.)(.)(\d+)(\d)/.match(str).captures.each { |c| c.should be_an_instance_of(String) }
-    end
-  end
+  it_behaves_like :matchdata_captures, :captures
 end

--- a/core/matchdata/deconstruct_keys_spec.rb
+++ b/core/matchdata/deconstruct_keys_spec.rb
@@ -1,0 +1,65 @@
+require_relative '../../spec_helper'
+
+describe "MatchData#deconstruct_keys" do
+  ruby_version_is "3.2" do
+    it "returns whole hash for nil as an argument" do
+      m = /(?<f>foo)(?<b>bar)/.match("foobar")
+
+      m.deconstruct_keys(nil).should == { f: "foo", b: "bar" }
+    end
+
+    it "returns only specified keys" do
+      m = /(?<f>foo)(?<b>bar)/.match("foobar")
+
+      m.deconstruct_keys([:f]).should == { f: "foo" }
+    end
+
+    it "requires one argument" do
+      m = /l/.match("l")
+
+      -> {
+        m.deconstruct_keys
+      }.should raise_error(ArgumentError, "wrong number of arguments (given 0, expected 1)")
+    end
+
+    it "it raises error when argument is neither nil nor array" do
+      m = /(?<f>foo)(?<b>bar)/.match("foobar")
+
+      -> { m.deconstruct_keys(1) }.should raise_error(TypeError, "wrong argument type Integer (expected Array)")
+      -> { m.deconstruct_keys("asd") }.should raise_error(TypeError, "wrong argument type String (expected Array)")
+      -> { m.deconstruct_keys(:x) }.should raise_error(TypeError, "wrong argument type Symbol (expected Array)")
+      -> { m.deconstruct_keys({}) }.should raise_error(TypeError, "wrong argument type Hash (expected Array)")
+    end
+
+    it "returns {} when passed []" do
+      m = /(?<f>foo)(?<b>bar)/.match("foobar")
+
+      m.deconstruct_keys([]).should == {}
+    end
+
+    it "does not accept non-Symbol keys" do
+      m = /(?<f>foo)(?<b>bar)/.match("foobar")
+
+      -> {
+        m.deconstruct_keys(['year', :foo])
+      }.should raise_error(TypeError, "wrong argument type String (expected Symbol)")
+    end
+
+    it "process keys till the first non-existing one" do
+      m = /(?<f>foo)(?<b>bar)(?<c>baz)/.match("foobarbaz")
+
+      m.deconstruct_keys([:f, :a, :b]).should == { f: "foo" }
+    end
+
+    it "returns {} when there are no named captured groups at all" do
+      m = /foo.+/.match("foobar")
+
+      m.deconstruct_keys(nil).should == {}
+    end
+
+    it "returns {} when passed more keys than named captured groups" do
+      m = /(?<f>foo)(?<b>bar)/.match("foobar")
+      m.deconstruct_keys([:f, :b, :c]).should == {}
+    end
+  end
+end

--- a/core/matchdata/deconstruct_spec.rb
+++ b/core/matchdata/deconstruct_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../spec_helper'
+require_relative 'shared/captures'
+
+describe "MatchData#deconstruct" do
+  ruby_version_is "3.2" do
+    it_behaves_like :matchdata_captures, :deconstruct
+  end
+end

--- a/core/matchdata/shared/captures.rb
+++ b/core/matchdata/shared/captures.rb
@@ -1,0 +1,15 @@
+require_relative '../../../spec_helper'
+require_relative '../fixtures/classes'
+
+describe :matchdata_captures, shared: true do
+  it "returns an array of the match captures" do
+    /(.)(.)(\d+)(\d)/.match("THX1138.").send(@method).should == ["H","X","113","8"]
+  end
+
+  ruby_version_is "3.0" do
+    it "returns instances of String when given a String subclass" do
+      str = MatchDataSpecs::MyString.new("THX1138: The Movie")
+      /(.)(.)(\d+)(\d)/.match(str).send(@method).each { |c| c.should be_an_instance_of(String) }
+    end
+  end
+end


### PR DESCRIPTION
#1016 
[[Feature #18821](https://bugs.ruby-lang.org/issues/18821)]
> MatchData#deconstruct has been added.
> MatchData#deconstruct_keys has been added. 