### PR TITLE
Change ruby version for `Kernel#trust`, `#untrust` and `#untrusted`

### DIFF
--- a/core/kernel/trust_spec.rb
+++ b/core/kernel/trust_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
 describe "Kernel#trust" do
-  ruby_version_is ""..."3.0" do
+  ruby_version_is ""..."3.2" do
     it "is a no-op" do
       o = Object.new.untrust
       o.should_not.untrusted?
@@ -15,6 +15,12 @@ describe "Kernel#trust" do
         o = Object.new.untrust
         o.trust
       }.should complain(/Object#trust is deprecated and will be removed in Ruby 3.2/, verbose: true)
+    end
+  end
+
+  ruby_version_is "3.2" do
+    it "has been removed" do
+      Object.new.should_not.respond_to?(:trust)
     end
   end
 end

--- a/core/kernel/untrust_spec.rb
+++ b/core/kernel/untrust_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
 describe "Kernel#untrust" do
-  ruby_version_is ""..."3.0" do
+  ruby_version_is ""..."3.2" do
     it "is a no-op" do
       o = Object.new
       o.untrust
@@ -14,6 +14,12 @@ describe "Kernel#untrust" do
         o = Object.new
         o.untrust
       }.should complain(/Object#untrust is deprecated and will be removed in Ruby 3.2/, verbose: true)
+    end
+  end
+
+  ruby_version_is "3.2" do
+    it "has been removed" do
+      Object.new.should_not.respond_to?(:untrust)
     end
   end
 end

--- a/core/kernel/untrusted_spec.rb
+++ b/core/kernel/untrusted_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
 describe "Kernel#untrusted?" do
-  ruby_version_is ""..."3.0" do
+  ruby_version_is ""..."3.2" do
     it "is a no-op" do
       o = mock('o')
       o.should_not.untrusted?
@@ -15,6 +15,12 @@ describe "Kernel#untrusted?" do
         o = mock('o')
         o.untrusted?
       }.should complain(/Object#untrusted\? is deprecated and will be removed in Ruby 3.2/, verbose: true)
+    end
+  end
+
+  ruby_version_is "3.2" do
+    it "has been removed" do
+      Object.new.should_not.respond_to?(:untrusted?)
     end
   end
 end


### PR DESCRIPTION
#1016 
[Feature #16131](https://bugs.ruby-lang.org/issues/16131)

> The following deprecated methods are removed.
 [ ] Kernel#trust, Kernel#untrust, Kernel#untrusted?

I broke my #1024 branch so I created new one