### PR TITLE
Add specs for `Kernel#taint`, `#tainted?` and `#untaint`

### DIFF
--- a/core/kernel/taint_spec.rb
+++ b/core/kernel/taint_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
 describe "Kernel#taint" do
-  ruby_version_is ""..."3.0" do
+  ruby_version_is ""..."3.2" do
     it "is a no-op" do
       o = Object.new
       o.taint
@@ -14,6 +14,12 @@ describe "Kernel#taint" do
         obj = mock("tainted")
         obj.taint
       }.should complain(/Object#taint is deprecated and will be removed in Ruby 3.2/, verbose: true)
+    end
+  end
+
+  ruby_version_is "3.2" do
+    it "has been removed" do
+      Object.new.should_not.respond_to?(:taint)
     end
   end
 end

--- a/core/kernel/tainted_spec.rb
+++ b/core/kernel/tainted_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
 describe "Kernel#tainted?" do
-  ruby_version_is ""..."3.0" do
+  ruby_version_is ""..."3.2" do
     it "is a no-op" do
       o = mock('o')
       p = mock('p')
@@ -16,6 +16,12 @@ describe "Kernel#tainted?" do
         o = mock('o')
         o.tainted?
       }.should complain(/Object#tainted\? is deprecated and will be removed in Ruby 3.2/, verbose: true)
+    end
+  end
+
+  ruby_version_is "3.2" do
+    it "has been removed" do
+      Object.new.should_not.respond_to?(:tainted?)
     end
   end
 end

--- a/core/kernel/untaint_spec.rb
+++ b/core/kernel/untaint_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
 describe "Kernel#untaint" do
-  ruby_version_is ""..."3.0" do
+  ruby_version_is ""..."3.2" do
     it "is a no-op" do
       o = Object.new.taint
       o.should_not.tainted?
@@ -15,6 +15,12 @@ describe "Kernel#untaint" do
         o = Object.new.taint
         o.untaint
       }.should complain(/Object#untaint is deprecated and will be removed in Ruby 3.2/, verbose: true)
+    end
+  end
+
+  ruby_version_is "3.2" do
+    it "has been removed" do
+      Object.new.should_not.respond_to?(:untaint)
     end
   end
 end


### PR DESCRIPTION
#1016
[[Feature #16131](https://bugs.ruby-lang.org/issues/16131)]
> The following deprecated methods are removed.
Kernel#taint, Kernel#untaint, Kernel#tainted?

I also changed ruby version to `3.1` in other specs same as in #1031 