### PR TITLE
Change `#public?`, `#protected?` and `#private?` specs for `Method`

### DIFF
--- a/core/method/private_spec.rb
+++ b/core/method/private_spec.rb
@@ -1,8 +1,8 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-ruby_version_is "3.1"..."3.2" do
-  describe "Method#private?" do
+describe "Method#private?" do
+  ruby_version_is "3.1"..."3.2" do
     it "returns false when the method is public" do
       obj = MethodSpecs::Methods.new
       obj.method(:my_public_method).private?.should == false
@@ -16,6 +16,13 @@ ruby_version_is "3.1"..."3.2" do
     it "returns true when the method is private" do
       obj = MethodSpecs::Methods.new
       obj.method(:my_private_method).private?.should == true
+    end
+  end
+
+  ruby_version_is "3.2" do
+    it "has been removed" do
+      obj = MethodSpecs::Methods.new
+      obj.method(:my_private_method).should_not.respond_to?(:private?)
     end
   end
 end

--- a/core/method/protected_spec.rb
+++ b/core/method/protected_spec.rb
@@ -1,8 +1,8 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-ruby_version_is "3.1"..."3.2" do
-  describe "Method#protected?" do
+describe "Method#protected?" do
+  ruby_version_is "3.1"..."3.2" do
     it "returns false when the method is public" do
       obj = MethodSpecs::Methods.new
       obj.method(:my_public_method).protected?.should == false
@@ -16,6 +16,13 @@ ruby_version_is "3.1"..."3.2" do
     it "returns false when the method is private" do
       obj = MethodSpecs::Methods.new
       obj.method(:my_private_method).protected?.should == false
+    end
+  end
+
+  ruby_version_is "3.2" do
+    it "has been removed" do
+      obj = MethodSpecs::Methods.new
+      obj.method(:my_protected_method).should_not.respond_to?(:protected?)
     end
   end
 end

--- a/core/method/public_spec.rb
+++ b/core/method/public_spec.rb
@@ -1,8 +1,8 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-ruby_version_is "3.1"..."3.2" do
-  describe "Method#public?" do
+describe "Method#public?" do
+  ruby_version_is "3.1"..."3.2" do
     it "returns true when the method is public" do
       obj = MethodSpecs::Methods.new
       obj.method(:my_public_method).public?.should == true
@@ -16,6 +16,13 @@ ruby_version_is "3.1"..."3.2" do
     it "returns false when the method is private" do
       obj = MethodSpecs::Methods.new
       obj.method(:my_private_method).public?.should == false
+    end
+  end
+
+  ruby_version_is "3.2" do
+    it "has been removed" do
+      obj = MethodSpecs::Methods.new
+      obj.method(:my_public_method).should_not.respond_to?(:public?)
     end
   end
 end

--- a/core/unboundmethod/private_spec.rb
+++ b/core/unboundmethod/private_spec.rb
@@ -1,8 +1,8 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-ruby_version_is "3.1"..."3.2" do
-  describe "UnboundMethod#private?" do
+describe "UnboundMethod#private?" do
+  ruby_version_is "3.1"..."3.2" do
     it "returns false when the method is public" do
       obj = UnboundMethodSpecs::Methods.new
       obj.method(:my_public_method).unbind.private?.should == false
@@ -16,6 +16,13 @@ ruby_version_is "3.1"..."3.2" do
     it "returns true when the method is private" do
       obj = UnboundMethodSpecs::Methods.new
       obj.method(:my_private_method).unbind.private?.should == true
+    end
+  end
+
+  ruby_version_is "3.2" do
+    it "has been removed" do
+      obj = UnboundMethodSpecs::Methods.new
+      obj.method(:my_private_method).unbind.should_not.respond_to?(:private?)
     end
   end
 end

--- a/core/unboundmethod/protected_spec.rb
+++ b/core/unboundmethod/protected_spec.rb
@@ -1,8 +1,8 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-ruby_version_is "3.1"..."3.2" do
-  describe "UnboundMethod#protected?" do
+describe "UnboundMethod#protected?" do
+  ruby_version_is "3.1"..."3.2" do
     it "returns false when the method is public" do
       obj = UnboundMethodSpecs::Methods.new
       obj.method(:my_public_method).unbind.protected?.should == false
@@ -16,6 +16,13 @@ ruby_version_is "3.1"..."3.2" do
     it "returns false when the method is private" do
       obj = UnboundMethodSpecs::Methods.new
       obj.method(:my_private_method).unbind.protected?.should == false
+    end
+  end
+
+  ruby_version_is "3.2" do
+    it "has been removed" do
+      obj = UnboundMethodSpecs::Methods.new
+      obj.method(:my_protected_method).unbind.should_not.respond_to?(:protected?)
     end
   end
 end

--- a/core/unboundmethod/public_spec.rb
+++ b/core/unboundmethod/public_spec.rb
@@ -1,8 +1,8 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-ruby_version_is "3.1"..."3.2" do
-  describe "UnboundMethod#public?" do
+describe "UnboundMethod#public?" do
+  ruby_version_is "3.1"..."3.2" do
     it "returns true when the method is public" do
       obj = UnboundMethodSpecs::Methods.new
       obj.method(:my_public_method).unbind.public?.should == true
@@ -16,6 +16,13 @@ ruby_version_is "3.1"..."3.2" do
     it "returns false when the method is private" do
       obj = UnboundMethodSpecs::Methods.new
       obj.method(:my_private_method).unbind.public?.should == false
+    end
+  end
+
+  ruby_version_is "3.2" do
+    it "has been removed" do
+      obj = UnboundMethodSpecs::Methods.new
+      obj.method(:my_public_method).unbind.should_not.respond_to?(:public?)
     end
   end
 end


### PR DESCRIPTION
#1016 
[[Bug #18729](https://bugs.ruby-lang.org/issues/18729)] [[Bug #18751](https://bugs.ruby-lang.org/issues/18751)] [[Bug #18435](https://bugs.ruby-lang.org/issues/18435)]
> The following deprecated methods are removed.
Method#public?, Method#private?, Method#protected?,
UnboundMethod#public?, UnboundMethod#private?, UnboundMethod#protected?