### PR TITLE
Add specs for `String#to_c`

### DIFF
--- a/core/string/to_c_spec.rb
+++ b/core/string/to_c_spec.rb
@@ -38,4 +38,16 @@ describe "String#to_c" do
       '79+4i'.encode("UTF-16").to_c
     }.should raise_error(Encoding::CompatibilityError, "ASCII incompatible encoding: UTF-16")
   end
+
+  ruby_version_is "3.2" do
+    it "treats a sequence of underscores as an end of Complex string" do
+      "5+3_1i".to_c.should == Complex(5, 31)
+      "5+3__1i".to_c.should == Complex(5)
+      "5+3___1i".to_c.should == Complex(5)
+
+      "12_3".to_c.should == Complex(123)
+      "12__3".to_c.should == Complex(12)
+      "12___3".to_c.should == Complex(12)
+    end
+  end
 end


### PR DESCRIPTION
#1016
[[Bug #19087](https://bugs.ruby-lang.org/issues/19087)]
>  String#to_c currently treat a sequence of underscores as an end of Complex
string. 