### PR TITLE
Add specs for `Coverage.supported?`

### DIFF
--- a/library/coverage/supported_spec.rb
+++ b/library/coverage/supported_spec.rb
@@ -1,0 +1,32 @@
+require_relative '../../spec_helper'
+require 'coverage'
+
+describe "Coverage.supported?" do
+  ruby_version_is "3.2" do
+    it "returns true or false if coverage measurement is supported for the given mode" do
+      [true, false].should.include?(Coverage.supported?(:lines))
+      [true, false].should.include?(Coverage.supported?(:branches))
+      [true, false].should.include?(Coverage.supported?(:methods))
+      [true, false].should.include?(Coverage.supported?(:eval))
+    end
+
+    it "returns false for not existing modes" do
+      Coverage.supported?(:foo).should == false
+      Coverage.supported?(:bar).should == false
+    end
+
+    it "raise TypeError if argument is not Symbol" do
+      -> {
+        Coverage.supported?("lines")
+      }.should raise_error(TypeError, "wrong argument type String (expected Symbol)")
+
+      -> {
+        Coverage.supported?([])
+      }.should raise_error(TypeError, "wrong argument type Array (expected Symbol)")
+
+      -> {
+        Coverage.supported?(1)
+      }.should raise_error(TypeError, "wrong argument type Integer (expected Symbol)")
+    end
+  end
+end


### PR DESCRIPTION
#1016 
[[Feature #19026](https://bugs.ruby-lang.org/issues/19026)]
> Coverage.supported?(mode) enables detection of what coverage modes are
supported.