### PR TITLE
Remove should_not raise_error from core/array/fill_spec.rb

### DIFF
--- a/core/array/fill_spec.rb
+++ b/core/array/fill_spec.rb
@@ -52,11 +52,9 @@ describe "Array#fill" do
   end
 
   it "raises an ArgumentError if 4 or more arguments are passed when no block given" do
-    -> { [].fill('a') }.should_not raise_error(ArgumentError)
-
-    -> { [].fill('a', 1) }.should_not raise_error(ArgumentError)
-
-    -> { [].fill('a', 1, 2) }.should_not raise_error(ArgumentError)
+    [].fill('a').should == []
+    [].fill('a', 1).should == []
+    [].fill('a', 1, 2).should == [nil, 'a', 'a']
     -> { [].fill('a', 1, 2, true) }.should raise_error(ArgumentError)
   end
 
@@ -65,11 +63,9 @@ describe "Array#fill" do
   end
 
   it "raises an ArgumentError if 3 or more arguments are passed when a block given" do
-    -> { [].fill() {|i|} }.should_not raise_error(ArgumentError)
-
-    -> { [].fill(1) {|i|} }.should_not raise_error(ArgumentError)
-
-    -> { [].fill(1, 2) {|i|} }.should_not raise_error(ArgumentError)
+    [].fill() {|i|}.should == []
+    [].fill(1) {|i|}.should == []
+    [].fill(1, 2) {|i|}.should == [nil, nil, nil]
     -> { [].fill(1, 2, true) {|i|} }.should raise_error(ArgumentError)
   end
 
@@ -213,23 +209,23 @@ describe "Array#fill with (filler, index, length)" do
 
   # See: https://blade.ruby-lang.org/ruby-core/17481
   it "does not raise an exception if the given length is negative and its absolute value does not exceed the index" do
-    -> { [1, 2, 3, 4].fill('a', 3, -1)}.should_not raise_error(ArgumentError)
-    -> { [1, 2, 3, 4].fill('a', 3, -2)}.should_not raise_error(ArgumentError)
-    -> { [1, 2, 3, 4].fill('a', 3, -3)}.should_not raise_error(ArgumentError)
+    [1, 2, 3, 4].fill('a', 3, -1).should == [1, 2, 3, 4]
+    [1, 2, 3, 4].fill('a', 3, -2).should == [1, 2, 3, 4]
+    [1, 2, 3, 4].fill('a', 3, -3).should == [1, 2, 3, 4]
 
-    -> { [1, 2, 3, 4].fill(3, -1, &@never_passed)}.should_not raise_error(ArgumentError)
-    -> { [1, 2, 3, 4].fill(3, -2, &@never_passed)}.should_not raise_error(ArgumentError)
-    -> { [1, 2, 3, 4].fill(3, -3, &@never_passed)}.should_not raise_error(ArgumentError)
+    [1, 2, 3, 4].fill(3, -1, &@never_passed).should == [1, 2, 3, 4]
+    [1, 2, 3, 4].fill(3, -2, &@never_passed).should == [1, 2, 3, 4]
+    [1, 2, 3, 4].fill(3, -3, &@never_passed).should == [1, 2, 3, 4]
   end
 
   it "does not raise an exception even if the given length is negative and its absolute value exceeds the index" do
-    -> { [1, 2, 3, 4].fill('a', 3, -4)}.should_not raise_error(ArgumentError)
-    -> { [1, 2, 3, 4].fill('a', 3, -5)}.should_not raise_error(ArgumentError)
-    -> { [1, 2, 3, 4].fill('a', 3, -10000)}.should_not raise_error(ArgumentError)
+    [1, 2, 3, 4].fill('a', 3, -4).should == [1, 2, 3, 4]
+    [1, 2, 3, 4].fill('a', 3, -5).should == [1, 2, 3, 4]
+    [1, 2, 3, 4].fill('a', 3, -10000).should == [1, 2, 3, 4]
 
-    -> { [1, 2, 3, 4].fill(3, -4, &@never_passed)}.should_not raise_error(ArgumentError)
-    -> { [1, 2, 3, 4].fill(3, -5, &@never_passed)}.should_not raise_error(ArgumentError)
-    -> { [1, 2, 3, 4].fill(3, -10000, &@never_passed)}.should_not raise_error(ArgumentError)
+    [1, 2, 3, 4].fill(3, -4, &@never_passed).should == [1, 2, 3, 4]
+    [1, 2, 3, 4].fill(3, -5, &@never_passed).should == [1, 2, 3, 4]
+    [1, 2, 3, 4].fill(3, -10000, &@never_passed).should == [1, 2, 3, 4]
   end
 
   it "tries to convert the second and third arguments to Integers using #to_int" do


### PR DESCRIPTION
#754 

Removed `should_not raise_error` from `core/array/fill_spec.rb` and replaced it with asserting the value inside lambda.

```
$ grep "should_not raise_error" core/array/fill_spec.rb | wc -l
       0
```