### PR TITLE
Remove unstable behaviour of Thread.to_enum(:each_caller_location).next

### DIFF
--- a/core/thread/each_caller_location_spec.rb
+++ b/core/thread/each_caller_location_spec.rb
@@ -34,12 +34,6 @@ describe "Thread.each_caller_location" do
       Thread.each_caller_location {}.should == nil
     end
 
-    it "cannot be iterated with an external iterator" do
-      -> {
-        Thread.to_enum(:each_caller_location).next
-      }.should raise_error(StopIteration, "iteration reached an end")
-    end
-
     it "raises LocalJumpError when called without a block" do
       -> {
         Thread.each_caller_location


### PR DESCRIPTION
This PR removes a test on `Thread.to_enum(:each_caller_location).next` (expecting to raise `StopIteration`) as it's deemed to be unstable and a not-recommended use case.

Discussions on this:
- https://github.com/oracle/truffleruby/pull/3050#discussion_r1233032509
- https://github.com/oracle/truffleruby/pull/3050#discussion_r1235322064