### PR TITLE
Extend specs of Set#divide

### DIFF
--- a/library/set/divide_spec.rb
+++ b/library/set/divide_spec.rb
@@ -13,11 +13,11 @@ describe "Set#divide" do
     ret.sort.should == ["five", "four", "one", "three", "two"]
   end
 
-  # BUG: Does not raise a LocalJumpError, but a NoMethodError
-  #
-  # it "raises a LocalJumpError when not passed a block" do
-  #   lambda { Set[1].divide }.should raise_error(LocalJumpError)
-  # end
+  it "returns an enumerator when not passed a block" do
+    ret = Set[1, 2, 3, 4].divide
+    ret.should be_kind_of(Enumerator)
+    ret.each(&:even?).should == Set[Set[1, 3], Set[2, 4]]
+  end
 end
 
 describe "Set#divide when passed a block with an arity of 2" do
@@ -30,5 +30,11 @@ describe "Set#divide when passed a block with an arity of 2" do
     ret = []
     Set[1, 2].divide { |x, y| ret << [x, y] }
     ret.sort.should == [[1, 1], [1, 2], [2, 1], [2, 2]]
+  end
+
+  it "returns an enumerator when not passed a block" do
+    ret = Set[1, 2, 3, 4].divide
+    ret.should be_kind_of(Enumerator)
+    ret.each { |a, b| (a + b).even? }.should == Set[Set[1, 3], Set[2, 4]]
   end
 end

--- a/library/set/divide_spec.rb
+++ b/library/set/divide_spec.rb
@@ -38,3 +38,22 @@ describe "Set#divide when passed a block with an arity of 2" do
     ret.each { |a, b| (a + b).even? }.should == Set[Set[1, 3], Set[2, 4]]
   end
 end
+
+describe "Set#divide when passed a block with an arity of > 2" do
+  it "only uses the first element if the arity > 2" do
+    set = Set["one", "two", "three", "four", "five"].divide do |x, y, z|
+      y.should be_nil
+      z.should be_nil
+      x.length
+    end
+    set.map { |x| x.to_a.sort }.sort.should == [["five", "four"], ["one", "two"], ["three"]]
+  end
+
+  it "only uses the first element if the arity = -1" do
+    set = Set["one", "two", "three", "four", "five"].divide do |*xs|
+      xs.size.should == 1
+      xs.first.length
+    end
+    set.map { |x| x.to_a.sort }.sort.should == [["five", "four"], ["one", "two"], ["three"]]
+  end
+end


### PR DESCRIPTION
This contains two commits:

1. Add test for calling `Set#divide` without a block. There was a commented piece of code that expected an exception, but since Ruby 2.4 the documentation states it should return an Enumerator
2. Add test for calling the block with an undefined arity. The docs describe the behaviour for blocks with arity 1 and 2, but not what happens when call the method with a block with a different arity. This is technically undefined behaviour, so I'm not sure whether this spec should be added.