### PR TITLE
Move mismatch of Range#cover? and Range#include? out of shared folder

### DIFF
--- a/core/range/cover_spec.rb
+++ b/core/range/cover_spec.rb
@@ -7,4 +7,8 @@ describe "Range#cover?" do
   it_behaves_like :range_cover_and_include, :cover?
   it_behaves_like :range_cover, :cover?
   it_behaves_like :range_cover_subrange, :cover?
+
+  it "covers U+9995 in the range U+0999..U+9999" do
+    ("\u{999}".."\u{9999}").cover?("\u{9995}").should be_true
+  end
 end

--- a/core/range/include_spec.rb
+++ b/core/range/include_spec.rb
@@ -7,4 +7,8 @@ require_relative 'shared/cover'
 describe "Range#include?" do
   it_behaves_like :range_cover_and_include, :include?
   it_behaves_like :range_include, :include?
+
+  it "does not include U+9995 in the range U+0999..U+9999" do
+    ("\u{999}".."\u{9999}").include?("\u{9995}").should be_false
+  end
 end

--- a/core/range/shared/cover_and_include.rb
+++ b/core/range/shared/cover_and_include.rb
@@ -57,7 +57,6 @@ describe :range_cover_and_include, shared: true do
   it "returns true if argument is less than the last value of the range and greater than the first value" do
     (20..30).send(@method, 28).should be_true
     ('e'..'h').send(@method, 'g').should be_true
-    ("\u{999}".."\u{9999}").send @method, "\u{9995}"
   end
 
   it "returns true if argument is sole element in the range" do


### PR DESCRIPTION
This is based on an observation made by @richardboehme in the Natalie project, split over these two commits:

https://github.com/natalie-lang/natalie/commit/a263a4d961f630b447d0431c73a4bbf1485627a4#diff-269d1f98177fca45189f918bb4282631ff1dcaaac8f1d793c3fea82b3034b73f
https://github.com/natalie-lang/natalie/commit/00ccd22a239aee0a52c27542b87a1a78eb425c83

It turns out `cover?` and `include?` do not behave the same for this query, so I moved this one out of the shared folder and into the two separate specs.
I had to guess what the spec was actually testing, so the descriptions for the test are probably up for improvement.