### PR TITLE
Add missing checks for to_str calls in ENV specs

### DIFF
--- a/core/env/delete_spec.rb
+++ b/core/env/delete_spec.rb
@@ -41,6 +41,14 @@ describe "ENV.delete" do
     ENV["foo"].should == nil
   end
 
+  it "removes the variable coerced with #to_str" do
+    ENV["foo"] = "bar"
+    k = mock('key')
+    k.should_receive(:to_str).and_return("foo")
+    ENV.delete(k)
+    ENV["foo"].should == nil
+  end
+
   it "raises TypeError if the argument is not a String and does not respond to #to_str" do
     -> { ENV.delete(Object.new) }.should raise_error(TypeError, "no implicit conversion of Object into String")
   end

--- a/core/env/shared/include.rb
+++ b/core/env/shared/include.rb
@@ -17,6 +17,13 @@ describe :env_include, shared: true do
     ENV.send(@method, "foo").should == false
   end
 
+  it "coerces the key with #to_str" do
+    ENV["foo"] = "bar"
+    k = mock('key')
+    k.should_receive(:to_str).and_return("foo")
+    ENV.send(@method, k).should == true
+  end
+
   it "raises TypeError if the argument is not a String and does not respond to #to_str" do
     -> { ENV.send(@method, Object.new) }.should raise_error(TypeError, "no implicit conversion of Object into String")
   end

--- a/core/env/shared/key.rb
+++ b/core/env/shared/key.rb
@@ -21,6 +21,15 @@ describe :env_key, shared: true do
     }
   end
 
+  it "coerces the key element with #to_str" do
+    ENV["foo"] = "bar"
+    k = mock('key')
+    k.should_receive(:to_str).and_return("bar")
+    suppress_warning {
+      ENV.send(@method, k).should == "foo"
+    }
+  end
+
   it "raises TypeError if the argument is not a String and does not respond to #to_str" do
     -> {
       suppress_warning {

--- a/core/env/shared/value.rb
+++ b/core/env/shared/value.rb
@@ -16,6 +16,13 @@ describe :env_value, shared: true do
     ENV.send(@method, "foo").should == false
   end
 
+  it "coerces the value element with #to_str" do
+    ENV["foo"] = "bar"
+    v = mock('value')
+    v.should_receive(:to_str).and_return("bar")
+    ENV.send(@method, v).should == true
+  end
+
   it "returns nil if the argument is not a String and does not respond to #to_str" do
     ENV.send(@method, Object.new).should == nil
   end

--- a/core/env/slice_spec.rb
+++ b/core/env/slice_spec.rb
@@ -21,6 +21,16 @@ describe "ENV.slice" do
     ENV.slice("foo", "boo", "bar").should == {"foo" => "0", "bar" => "1"}
   end
 
+  it "returns the values for the keys coerced with #to_str, but keeps the original objects as result keys" do
+    foo = mock('key 1')
+    foo.should_receive(:to_str).and_return("foo")
+    boo = mock('key 2')
+    boo.should_receive(:to_str).and_return("boo")
+    bar = mock('key 3')
+    bar.should_receive(:to_str).and_return("bar")
+    ENV.slice(foo, boo, bar).should == {foo => "0", bar => "1"}
+  end
+
   it "raises TypeError if any argument is not a String and does not respond to #to_str" do
     -> { ENV.slice(Object.new) }.should raise_error(TypeError, "no implicit conversion of Object into String")
   end


### PR DESCRIPTION
A number of specs did mention the calls to to_str, but did not test the full path.