### PR TITLE
Remove require fiber from fiber_storage tests

### DIFF
--- a/core/fiber/storage_spec.rb
+++ b/core/fiber/storage_spec.rb
@@ -1,7 +1,5 @@
 require_relative '../../spec_helper'
 
-require 'fiber'
-
 describe "Fiber.new(storage:)" do
   ruby_version_is "3.2" do
     it "creates a Fiber with the given storage" do


### PR DESCRIPTION
These tests only run on Ruby 3.2 and higher, where Fiber is available by default.