### PR TITLE
Extend tests for Fiber storage

### DIFF
--- a/core/fiber/storage_spec.rb
+++ b/core/fiber/storage_spec.rb
@@ -119,6 +119,19 @@ describe "Fiber.[]=" do
     it "sets the value of the given key in the storage of the current fiber" do
       Fiber.new { Fiber[:life] = 43; Fiber[:life] }.resume.should == 43
     end
+
+    it "does not overwrite the storage of the parent fiber" do
+      f = Fiber.new(storage: {life: 42}) do
+        Fiber.yield Fiber.new { Fiber[:life] = 43; Fiber[:life] }.resume
+        Fiber[:life]
+      end
+      f.resume.should == 43 # Value of the inner fiber
+      f.resume.should == 42 # Value of the outer fiber
+    end
+
+    it "can't access the storage of the fiber with non-symbol keys" do
+      -> { Fiber[Object.new] = 44 }.should raise_error(TypeError)
+    end
   end
 
   ruby_version_is "3.3" do

--- a/core/fiber/storage_spec.rb
+++ b/core/fiber/storage_spec.rb
@@ -24,6 +24,14 @@ describe "Fiber.new(storage:)" do
     it "cannot create a fiber with non-hash storage" do
       -> { Fiber.new(storage: 42) {} }.should raise_error(TypeError)
     end
+
+    it "cannot create a fiber with a frozen hash as storage" do
+      -> { Fiber.new(storage: {life: 43}.freeze) {} }.should raise_error(FrozenError)
+    end
+
+    it "cannot create a fiber with a storage hash with non-symbol keys" do
+      -> { Fiber.new(storage: {life: 43, Object.new => 44}) {} }.should raise_error(TypeError)
+    end
   end
 end
 

--- a/core/fiber/storage_spec.rb
+++ b/core/fiber/storage_spec.rb
@@ -35,6 +35,17 @@ describe "Fiber.new(storage:)" do
   end
 end
 
+describe "Fiber#storage" do
+  ruby_version_is "3.2" do
+    it "cannot be accessed from a different fiber" do
+      f = Fiber.new(storage: {life: 42}) { nil }
+      -> {
+        f.storage
+      }.should raise_error(ArgumentError, /Fiber storage can only be accessed from the Fiber it belongs to/)
+    end
+  end
+end
+
 describe "Fiber#storage=" do
   ruby_version_is "3.2" do
     it "can clear the storage of the fiber" do

--- a/core/fiber/storage_spec.rb
+++ b/core/fiber/storage_spec.rb
@@ -92,6 +92,17 @@ describe "Fiber.[]" do
     it "returns nil if the current fiber has no storage" do
       Fiber.new { Fiber[:life] }.resume.should be_nil
     end
+
+    it "can access the storage of the parent fiber" do
+      f = Fiber.new(storage: {life: 42}) do
+        Fiber.new { Fiber[:life] }.resume
+      end
+      f.resume.should == 42
+    end
+
+    it "can't access the storage of the fiber with non-symbol keys" do
+      -> { Fiber[Object.new] }.should raise_error(TypeError)
+    end
   end
 end
 


### PR DESCRIPTION
Most of these tests were performed on some methods, but not on all:

* Keys of a type other than Symbol raise an error
* Storage access may look into the storage of the parent fiber
* Storage is only accessible in the current fiber.