### PR TITLE
Update spec for cyclic references in Set#inspect / Set#to_s

### DIFF
--- a/library/set/shared/inspect.rb
+++ b/library/set/shared/inspect.rb
@@ -15,9 +15,11 @@ describe :set_inspect, shared: true do
     Set["1", "2"].send(@method).should include('", "')
   end
 
-  it "correctly handles self-references" do
-    (set = Set[]) << set
-    set.send(@method).should be_kind_of(String)
-    set.send(@method).should include("#<Set: {...}>")
+  it "correctly handles cyclic-references" do
+    set1 = Set[]
+    set2 = Set[set1]
+    set1 << set2
+    set1.send(@method).should be_kind_of(String)
+    set1.send(@method).should include("#<Set: {...}>")
   end
 end


### PR DESCRIPTION
The old version did only check a depth of 1. The following pseudocode would pass that test (if the head and tail of the inspect string were added to it):
```ruby
map { |item| item == self ? "#<Set: {...}>" : item.inspect }
```
Any deeper level of cyclic references would cause an infinite loop in this code.
This changes explicitly adds the deeper cycles to the spec.