### PR TITLE
Add test for File.realpath for going one level up from a filename to get a directory

### DIFF
--- a/core/file/realpath_spec.rb
+++ b/core/file/realpath_spec.rb
@@ -54,6 +54,10 @@ platform_is_not :windows do
       File.realpath(@relative_symlink).should == @file
     end
 
+    it "removes the file element when going one level up" do
+      File.realpath('../', @file).should == @real_dir
+    end
+
     it "raises an Errno::ELOOP if the symlink points to itself" do
       File.unlink @link
       File.symlink(@link, @link)

--- a/core/method/source_location_spec.rb
+++ b/core/method/source_location_spec.rb
@@ -13,7 +13,7 @@ describe "Method#source_location" do
   it "sets the first value to the path of the file in which the method was defined" do
     file = @method.source_location.first
     file.should be_an_instance_of(String)
-    file.should == File.realpath('../fixtures/classes.rb', __FILE__)
+    file.should == File.realpath('fixtures/classes.rb', __dir__)
   end
 
   it "sets the last value to an Integer representing the line on which the method was defined" do

--- a/core/proc/source_location_spec.rb
+++ b/core/proc/source_location_spec.rb
@@ -19,19 +19,19 @@ describe "Proc#source_location" do
   it "sets the first value to the path of the file in which the proc was defined" do
     file = @proc.source_location.first
     file.should be_an_instance_of(String)
-    file.should == File.realpath('../fixtures/source_location.rb', __FILE__)
+    file.should == File.realpath('fixtures/source_location.rb', __dir__)
 
     file = @proc_new.source_location.first
     file.should be_an_instance_of(String)
-    file.should == File.realpath('../fixtures/source_location.rb', __FILE__)
+    file.should == File.realpath('fixtures/source_location.rb', __dir__)
 
     file = @lambda.source_location.first
     file.should be_an_instance_of(String)
-    file.should == File.realpath('../fixtures/source_location.rb', __FILE__)
+    file.should == File.realpath('fixtures/source_location.rb', __dir__)
 
     file = @method.source_location.first
     file.should be_an_instance_of(String)
-    file.should == File.realpath('../fixtures/source_location.rb', __FILE__)
+    file.should == File.realpath('fixtures/source_location.rb', __dir__)
   end
 
   it "sets the last value to an Integer representing the line on which the proc was defined" do

--- a/core/unboundmethod/source_location_spec.rb
+++ b/core/unboundmethod/source_location_spec.rb
@@ -9,7 +9,7 @@ describe "UnboundMethod#source_location" do
   it "sets the first value to the path of the file in which the method was defined" do
     file = @method.source_location.first
     file.should be_an_instance_of(String)
-    file.should == File.realpath('../fixtures/classes.rb', __FILE__)
+    file.should == File.realpath('fixtures/classes.rb', __dir__)
   end
 
   it "sets the last value to an Integer representing the line on which the method was defined" do


### PR DESCRIPTION
And clean up the checks for source locations to use `__dir__` instead of `__FILE__`, since it's the directory we're looking for.