### PR TITLE
Add more specs for method calls with a space

### DIFF
--- a/language/method_spec.rb
+++ b/language/method_spec.rb
@@ -1193,14 +1193,42 @@ describe "A method call with a space between method name and parentheses" do
     end
   end
 
-  context "when a single argument provided" do
-    it "assigns it" do
+  context "when a single argument is provided" do
+    it "assigns a simple expression" do
+      args = m (1)
+      args.should == [1]
+    end
+
+    it "assigns an expression consisting of multiple statements" do
+      args = m ((0; 1))
+      args.should == [1]
+    end
+
+    it "assigns one single statement, without the need of parentheses" do
       args = m (1 == 1 ? true : false)
       args.should == [true]
     end
+
+    it "raises a syntax error if there are multiple statements" do
+      -> {
+        eval("m (1; 2)")
+      }.should raise_error(SyntaxError)
+    end
   end
 
-  context "when 2+ arguments provided" do
+  context "when multiple arguments are provided" do
+    it "assigns simple expressions" do
+      args = m (1), (2)
+      args.should == [1, 2]
+    end
+
+    it "assigns expressions consisting of multiple statements" do
+      args = m ((0; 1)), ((2; 3))
+      args.should == [1, 3]
+    end
+  end
+
+  context "when the argument looks like an argument list" do
     it "raises a syntax error" do
       -> {
         eval("m (1, 2)")


### PR DESCRIPTION
This is a question disguised as optimistic patch :).

Looks like

```
foo (...)
```

(note the space after `foo`) is special-cased to turn single statements into expressions without the need of extra parentheses, but mulitple statements don't have this automation.

Assuming this is intentional, this patch adds coverage for it, and a few related specs since I was on it.