### PR TITLE
Add specs for Fiber.scheduler and Fiber.set_scheduler

### DIFF
--- a/core/fiber/scheduler_spec.rb
+++ b/core/fiber/scheduler_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../spec_helper'
+require_relative 'shared/scheduler'
+
+require "fiber"
+
+describe "Fiber.scheduler" do
+  it_behaves_like :scheduler, :scheduler
+end

--- a/core/fiber/set_scheduler_spec.rb
+++ b/core/fiber/set_scheduler_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../spec_helper'
+require_relative 'shared/scheduler'
+
+require "fiber"
+
+describe "Fiber.scheduler" do
+  it_behaves_like :scheduler, :set_scheduler
+end

--- a/core/fiber/shared/scheduler.rb
+++ b/core/fiber/shared/scheduler.rb
@@ -1,0 +1,49 @@
+describe :scheduler, shared: true do
+  it "validates the scheduler for required methods" do
+    required_methods = [:block, :unblock, :kernel_sleep, :io_wait]
+    required_methods.each do |missing_method|
+      scheduler = Object.new
+      required_methods.difference([missing_method]).each do |method|
+        scheduler.define_singleton_method(method) {}
+      end
+      -> { Fiber.set_scheduler(scheduler) }.should raise_error(ArgumentError, /Scheduler must implement ##{missing_method}/)
+    end
+  end
+
+  it "can set and get the scheduler" do
+    required_methods = [:block, :unblock, :kernel_sleep, :io_wait]
+    scheduler = Object.new
+    required_methods.each do |method|
+      scheduler.define_singleton_method(method) {}
+    end
+    Fiber.set_scheduler(scheduler)
+    Fiber.scheduler.should == scheduler
+  end
+
+  it "returns the scheduler after setting it" do
+    required_methods = [:block, :unblock, :kernel_sleep, :io_wait]
+    scheduler = Object.new
+    required_methods.each do |method|
+      scheduler.define_singleton_method(method) {}
+    end
+    result = Fiber.set_scheduler(scheduler)
+    result.should == scheduler
+  end
+
+  it "can remove the scheduler" do
+    required_methods = [:block, :unblock, :kernel_sleep, :io_wait]
+    scheduler = Object.new
+    required_methods.each do |method|
+      scheduler.define_singleton_method(method) {}
+    end
+    Fiber.set_scheduler(scheduler)
+    Fiber.set_scheduler(nil)
+    Fiber.scheduler.should be_nil
+  end
+
+  it "can assign a nil scheduler multiple times" do
+    Fiber.set_scheduler(nil)
+    Fiber.set_scheduler(nil)
+    Fiber.scheduler.should be_nil
+  end
+end


### PR DESCRIPTION
With a few remarks, since I'm not sure about some best practices here.

* The feature is mentioned in #823 and assigned to @aardvark179 (at least, I guess that's what the username in front of the item means). I'm not trying to step in line or step on anybody's toes, but this is what I'm currently working on for Natalie, so I kind of needed the specs anyway.
* I didn't see much use in testing these two methods separately, since you can only set if you've set a scheduler by requesting the scheduler and vice versa (unless you count actually using the scheduler, but that makes it even more complex). I've used a shared spec that combines the tests for them, which passes on the methods that we don't use in the specs. This is totally different from other shared specs (like `Hash#include?` and `Hash#key?`) I couldn't really find an example of other intertwined methods, so there might be a more idiomatic way of doing this.

