### PR TITLE
Remove ScratchPad reset from specs for Mutex#lock

### DIFF
--- a/core/mutex/lock_spec.rb
+++ b/core/mutex/lock_spec.rb
@@ -1,10 +1,6 @@
 require_relative '../../spec_helper'
 
 describe "Mutex#lock" do
-  before :each do
-    ScratchPad.clear
-  end
-
   it "returns self" do
     m = Mutex.new
     m.lock.should == m


### PR DESCRIPTION
The ScratchPad is not used in this file. This is probably a leftover from a previous version.