### PR TITLE
Add tests for special values of maxlen in IO#read

### DIFF
--- a/core/io/read_spec.rb
+++ b/core/io/read_spec.rb
@@ -113,6 +113,10 @@ describe "IO.read" do
     IO.read(@fname, 1, 10).should == nil
   end
 
+  it "returns an empty string when reading zero bytes" do
+    IO.read(@fname, 0).should == ''
+  end
+
   it "raises an Errno::ENOENT when the requested file does not exist" do
     rm_r @fname
     -> { IO.read @fname }.should raise_error(Errno::ENOENT)

--- a/core/io/read_spec.rb
+++ b/core/io/read_spec.rb
@@ -250,6 +250,14 @@ describe "IO#read" do
     @io.read(4).should == '7890'
   end
 
+  it "treats first nil argument as no length limit" do
+    @io.read(nil).should == @contents
+  end
+
+  it "raises an ArgumentError when not passed a valid length" do
+    -> { @io.read(-1) }.should raise_error(ArgumentError)
+  end
+
   it "clears the output buffer if there is nothing to read" do
     @io.pos = 10
 

--- a/core/io/read_spec.rb
+++ b/core/io/read_spec.rb
@@ -117,6 +117,11 @@ describe "IO.read" do
     IO.read(@fname, 0).should == ''
   end
 
+  it "returns a String in BINARY when passed a size" do
+    IO.read(@fname, 1).encoding.should == Encoding::BINARY
+    IO.read(@fname, 0).encoding.should == Encoding::BINARY
+  end
+
   it "raises an Errno::ENOENT when the requested file does not exist" do
     rm_r @fname
     -> { IO.read @fname }.should raise_error(Errno::ENOENT)
@@ -553,6 +558,7 @@ describe :io_read_size_internal_encoding, shared: true do
 
   it "returns a String in BINARY when passed a size" do
     @io.read(4).encoding.should equal(Encoding::BINARY)
+    @io.read(0).encoding.should equal(Encoding::BINARY)
   end
 
   it "does not change the buffer's encoding when passed a limit" do


### PR DESCRIPTION
* nil should be handled as no maxlen argument
* Negative values raise an ArgumentError

These cases were tested in IO.read, but missing in IO#read

* Reading with a length of 0 should return an empty String
* Reading with a length should return a binary String

These cases were tested in IO#read, but missing in IO.read