### PR TITLE
Add extra test for IO.new with internal_encoding keyword

### DIFF
--- a/core/io/shared/new.rb
+++ b/core/io/shared/new.rb
@@ -325,6 +325,9 @@ describe :io_new_errors, shared: true do
       @io = IO.send(@method, @fd, 'w:ISO-8859-1', external_encoding: 'ISO-8859-1')
     }.should raise_error(ArgumentError)
     -> {
+      @io = IO.send(@method, @fd, 'w:ISO-8859-1', internal_encoding: 'ISO-8859-1')
+    }.should raise_error(ArgumentError)
+    -> {
       @io = IO.send(@method, @fd, 'w:ISO-8859-1:UTF-8', internal_encoding: 'ISO-8859-1')
     }.should raise_error(ArgumentError)
   end


### PR DESCRIPTION
When providing a single encoding in the mode argument, the external encoding of the IO object is set to that encoding, the internal encoding is left blank. The ArgumentError in this case is a rather specific behaviour.

I'm marking this one as Draft for now, I'm not exactly sure if this is the intended behaviour.