### PR TITLE
Add tests for combination of {bin,text}mode and external_encoding in ...

### DIFF
--- a/core/io/shared/new.rb
+++ b/core/io/shared/new.rb
@@ -208,6 +208,26 @@ describe :io_new, shared: true do
     @io.internal_encoding.to_s.should == 'IBM866'
   end
 
+  it "does not use binmode argument when mode encoding is specified" do
+    @io = IO.send(@method, @fd, 'w:iso-8859-1', binmode: true)
+    @io.external_encoding.to_s.should == 'ISO-8859-1'
+  end
+
+  it "does not use textmode argument when mode encoding is specified" do
+    @io = IO.send(@method, @fd, 'w:ascii-8bit', textmode: true)
+    @io.external_encoding.to_s.should == 'ASCII-8BIT'
+  end
+
+  it "does not use binmode argument when external encoding is specified via the :external_encoding option" do
+    @io = IO.send(@method, @fd, 'w', binmode: true, external_encoding: 'iso-8859-1')
+    @io.external_encoding.to_s.should == 'ISO-8859-1'
+  end
+
+  it "does not use textmode argument when external encoding is specified via the :external_encoding option" do
+    @io = IO.send(@method, @fd, 'w', textmode: true, external_encoding: 'ascii-8bit')
+    @io.external_encoding.to_s.should == 'ASCII-8BIT'
+  end
+
   it "raises ArgumentError for nil options" do
     -> {
       IO.send(@method, @fd, 'w', nil)


### PR DESCRIPTION
…IO.new

The encoding option takes precedence over the binmode/textmode options. There are similar tests for passing the binmode argument in the mode argument.