### PR TITLE
Add specs for IO#autoclose? and IO#autoclose=

### DIFF
--- a/core/io/autoclose_spec.rb
+++ b/core/io/autoclose_spec.rb
@@ -11,19 +11,36 @@ describe "IO#autoclose" do
     @io.close unless @io.closed?
   end
 
+  it "is set to true by default" do
+    @io.should.autoclose?
+  end
+
   it "can be set to true" do
+    @io.autoclose = false
     @io.autoclose = true
     @io.should.autoclose?
   end
 
   it "can be set to false" do
+    @io.autoclose = true
     @io.autoclose = false
     @io.should_not.autoclose?
   end
 
   it "can be set to any truthy value" do
+    @io.autoclose = false
     @io.autoclose = 42
     @io.should.autoclose?
+
+    @io.autoclose = false
+    @io.autoclose = Object.new
+    @io.should.autoclose?
+  end
+
+  it "can be set to any falsy value" do
+    @io.autoclose = true
+    @io.autoclose = nil
+    @io.should_not.autoclose?
   end
 
   it "can be set multple times" do

--- a/core/io/autoclose_spec.rb
+++ b/core/io/autoclose_spec.rb
@@ -1,0 +1,49 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "IO#autoclose" do
+  before :each do
+    @io = IOSpecs.io_fixture "lines.txt"
+  end
+
+  after :each do
+    @io.autoclose = true unless @io.closed?
+    @io.close unless @io.closed?
+  end
+
+  it "can be set to true" do
+    @io.autoclose = true
+    @io.should.autoclose?
+  end
+
+  it "can be set to false" do
+    @io.autoclose = false
+    @io.should_not.autoclose?
+  end
+
+  it "can be set to any truthy value" do
+    @io.autoclose = 42
+    @io.should.autoclose?
+  end
+
+  it "can be set multple times" do
+    @io.autoclose = true
+    @io.should.autoclose?
+
+    @io.autoclose = false
+    @io.should_not.autoclose?
+
+    @io.autoclose = true
+    @io.should.autoclose?
+  end
+
+  it "cannot be queried on a closed IO object" do
+    @io.close
+    -> { @io.autoclose? }.should raise_error(IOError, /closed stream/)
+  end
+
+  it "cannot be set on a closed IO object" do
+    @io.close
+    -> { @io.autoclose = false }.should raise_error(IOError, /closed stream/)
+  end
+end


### PR DESCRIPTION
These are the very basic specs, set a value, get a value. The actual behaviour change is not tested, I tried the example of https://ruby-doc.org/3.2.2/IO.html#method-i-autoclose-3D and a couple of variations, and I could not get them to work.