### PR TITLE
Add tests for to_str conversion in Kernel.(s)printf

### DIFF
--- a/core/kernel/printf_spec.rb
+++ b/core/kernel/printf_spec.rb
@@ -31,6 +31,13 @@ describe "Kernel.printf" do
     object.should_receive(:write).with("string")
     Kernel.printf(object, "%s", "string")
   end
+
+  it "calls #to_str to convert the format object to a String" do
+    object = mock('format string')
+    object.should_receive(:to_str).and_return("to_str: %i")
+    $stdout.should_receive(:write).with("to_str: 42")
+    Kernel.printf($stdout, object, 42)
+  end
 end
 
 describe "Kernel.printf" do

--- a/core/kernel/sprintf_spec.rb
+++ b/core/kernel/sprintf_spec.rb
@@ -3,12 +3,24 @@ require_relative 'fixtures/classes'
 require_relative 'shared/sprintf'
 require_relative 'shared/sprintf_encoding'
 
+describe :kernel_sprintf_to_str, shared: true do
+  it "calls #to_str to convert the format object to a String" do
+    obj = mock('format string')
+    obj.should_receive(:to_str).and_return("to_str: %i")
+    @method.call(obj, 42).should == "to_str: 42"
+  end
+end
+
 describe "Kernel#sprintf" do
   it_behaves_like :kernel_sprintf, -> format, *args {
     sprintf(format, *args)
   }
 
   it_behaves_like :kernel_sprintf_encoding, -> format, *args {
+    sprintf(format, *args)
+  }
+
+  it_behaves_like :kernel_sprintf_to_str, -> format, *args {
     sprintf(format, *args)
   }
 end
@@ -19,6 +31,10 @@ describe "Kernel.sprintf" do
   }
 
   it_behaves_like :kernel_sprintf_encoding, -> format, *args {
+    Kernel.sprintf(format, *args)
+  }
+
+  it_behaves_like :kernel_sprintf_to_str, -> format, *args {
     Kernel.sprintf(format, *args)
   }
 end


### PR DESCRIPTION
There is a similar test for IO#printf, but this tests the more generic case.