### PR TITLE
Fix beginningless Range in MatchData#values_at

### DIFF
--- a/core/matchdata/values_at_spec.rb
+++ b/core/matchdata/values_at_spec.rb
@@ -34,7 +34,7 @@ describe "Struct#values_at" do
     end
 
     it "supports beginningless Range" do
-      /(.)(.)(\d+)(\d)/.match("THX1138: The Movie").values_at(0..2).should == ["HX1138", "H", "X"]
+      /(.)(.)(\d+)(\d)/.match("THX1138: The Movie").values_at(..2).should == ["HX1138", "H", "X"]
     end
 
     it "returns an empty Array when Range is empty" do


### PR DESCRIPTION
The file contains the following comment:
```ruby
# Should be synchronized with core/array/values_at_spec.rb and core/struct/values_at_spec.rb
```
These two files look fine, it's just this one that accidentally had a range with a beginning.