### PR TITLE
Workaround: Fix library zlib test failures on Ubuntu jammy s390x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: ruby
+arch: s390x
+dist: jammy
+before_install:
+  # Print the used zlib deb package version.
+  - |
+    dpkg -s "$(dpkg -S /usr/include/zlib.h | cut -d ":" -f 1)"
+  - git clone https://github.com/ruby/mspec.git ../mspec
+script:
+  - CHECK_LEAKS=true ../mspec/bin/mspec -j --timeout 30

--- a/library/zlib/deflate/set_dictionary_spec.rb
+++ b/library/zlib/deflate/set_dictionary_spec.rb
@@ -1,14 +1,20 @@
 require_relative '../../../spec_helper'
+require_relative '../spec_helper'
 require 'zlib'
 
 describe "Zlib::Deflate#set_dictionary" do
   it "sets the dictionary" do
-    d = Zlib::Deflate.new
-    d.set_dictionary 'aaaaaaaaaa'
-    d << 'abcdefghij'
+    stdout = ruby_exe(<<~'RUBY', options: '-rzlib', env: Zlib::CHILD_ENV)
+      d = Zlib::Deflate.new
+      d.set_dictionary 'aaaaaaaaaa'
+      d << 'abcdefghij'
 
-    d.finish.should == [120, 187, 20, 225, 3, 203, 75, 76,
+      puts d.finish == [120, 187, 20, 225, 3, 203, 75, 76,
                         74, 78, 73, 77, 75, 207, 200, 204,
                         2, 0, 21, 134, 3, 248].pack('C*')
+
+    RUBY
+
+    stdout.should == "true\n"
   end
 end

--- a/library/zlib/deflate_spec.rb
+++ b/library/zlib/deflate_spec.rb
@@ -1,8 +1,13 @@
 require_relative '../../spec_helper'
+require_relative 'spec_helper'
 require "zlib"
 
 describe "Zlib.deflate" do
   it "deflates some data" do
-    Zlib.deflate("1" * 10).should == [120, 156, 51, 52, 132, 1, 0, 10, 145, 1, 235].pack('C*')
+    stdout = ruby_exe(<<~'RUBY', options: '-rzlib', env: Zlib::CHILD_ENV)
+      puts Zlib.deflate("1" * 10) == [120, 156, 51, 52, 132, 1, 0, 10, 145, 1, 235].pack('C*')
+    RUBY
+
+    stdout.should == "true\n"
   end
 end

--- a/library/zlib/gzip_spec.rb
+++ b/library/zlib/gzip_spec.rb
@@ -9,7 +9,15 @@ describe "Zlib.gzip" do
   end
 
   it "gzips the given string" do
-    # skip gzip header for now
-    Zlib.gzip(@data)[10..-1].should == @zip[10..-1]
+    stdout = ruby_exe(<<~'RUBY', options: '-rzlib', env: Zlib::CHILD_ENV)
+      @data = '12345abcde'
+      @zip = [31, 139, 8, 0, 44, 220, 209, 71, 0, 3, 51, 52, 50, 54, 49, 77,
+              76, 74, 78, 73, 5, 0, 157, 5, 0, 36, 10, 0, 0, 0].pack('C*')
+
+      # skip gzip header for now
+      puts Zlib.gzip(@data)[10..-1] == @zip[10..-1]
+    RUBY
+
+    stdout.should == "true\n"
   end
 end

--- a/library/zlib/spec_helper.rb
+++ b/library/zlib/spec_helper.rb
@@ -1,0 +1,7 @@
+require 'zlib'
+
+begin
+  child_env = {}
+  child_env['DFLTCC'] = '0' if RUBY_PLATFORM =~ /s390x/
+  Zlib::CHILD_ENV = child_env.freeze
+end


### PR DESCRIPTION
This PR fixes #1083, and ruby/ruby's tests on Ubuntu jammy s390x server on RubyCI. The log is [here](http://rubyci.s3.amazonaws.com/s390x/ruby-master/log/20230927T120004Z.fail.html.gz).

The ruby/spec fails on the s390x jammy s390x where the zlib deb package is configured by `./configure --dfltcc`. 

It produces a different (but still valid) compressed byte stream, and causes the test failures in ruby/zlib. As a workaround, we need to set the environment variable `DFLTCC=0` disabling the implementation in zlib on s390x to the failing tests.

Note we need to test in a child Ruby process with `ruby_exe` to test on the `DFLTCC=0` set by the parent Ruby process.

See <https://github.com/ruby/zlib/commit/9f3b9c470c> for details.

This PR has 2 commits. The 1st commit is to add Travis CI s390x. As far as I know, Travis CI is only the choice to test on naive s390x on pull-request.

Travis CI log before the commit.
https://app.travis-ci.com/github/junaruga/ruby-spec/jobs/610640347
> 3715 files, 32206 examples, 181145 expectations, 12 failures, 0 errors, 0 tagged

Travis CI log after the commit.
https://app.travis-ci.com/github/junaruga/ruby-spec/builds/266237275
> 3715 files, 32206 examples, 158515 expectations, 0 failures, 0 errors, 0 tagged


It seems that right now Travis CI is enabled for only ruby/ruby. I am asking @hsbt to enable Travis CI for ruby/*, all the repositories under Ruby projects.
 