### PR TITLE
Remove guards for Ruby version 2.7.2 and 2.7.3

### DIFF
--- a/core/method/super_method_spec.rb
+++ b/core/method/super_method_spec.rb
@@ -55,12 +55,10 @@ describe "Method#super_method" do
     end
   end
 
-  ruby_version_is "2.7.3" do
-    context "after aliasing an inherited method" do
-      it "returns the expected super_method" do
-        method = MethodSpecs::InheritedMethods::C.new.method(:meow)
-        method.super_method.owner.should == MethodSpecs::InheritedMethods::A
-      end
+  context "after aliasing an inherited method" do
+    it "returns the expected super_method" do
+      method = MethodSpecs::InheritedMethods::C.new.method(:meow)
+      method.super_method.owner.should == MethodSpecs::InheritedMethods::A
     end
   end
 end

--- a/core/unboundmethod/super_method_spec.rb
+++ b/core/unboundmethod/super_method_spec.rb
@@ -40,12 +40,10 @@ describe "UnboundMethod#super_method" do
     end
   end
 
-  ruby_version_is "2.7.3" do
-    context "after aliasing an inherited method" do
-      it "returns the expected super_method" do
-        method = MethodSpecs::InheritedMethods::C.instance_method(:meow)
-        method.super_method.owner.should == MethodSpecs::InheritedMethods::A
-      end
+  context "after aliasing an inherited method" do
+    it "returns the expected super_method" do
+      method = MethodSpecs::InheritedMethods::C.instance_method(:meow)
+      method.super_method.owner.should == MethodSpecs::InheritedMethods::A
     end
   end
 end

--- a/core/warning/element_reference_spec.rb
+++ b/core/warning/element_reference_spec.rb
@@ -1,11 +1,9 @@
 require_relative '../../spec_helper'
 
 describe "Warning.[]" do
-  ruby_version_is '2.7.2' do
-    it "returns default values for categories :deprecated and :experimental" do
-      ruby_exe('p [Warning[:deprecated], Warning[:experimental]]').chomp.should == "[false, true]"
-      ruby_exe('p [Warning[:deprecated], Warning[:experimental]]', options: "-w").chomp.should == "[true, true]"
-    end
+  it "returns default values for categories :deprecated and :experimental" do
+    ruby_exe('p [Warning[:deprecated], Warning[:experimental]]').chomp.should == "[false, true]"
+    ruby_exe('p [Warning[:deprecated], Warning[:experimental]]', options: "-w").chomp.should == "[true, true]"
   end
 
   ruby_version_is '3.3' do

--- a/language/delegation_spec.rb
+++ b/language/delegation_spec.rb
@@ -38,28 +38,26 @@ describe "delegation with def(...)" do
   end
 end
 
-ruby_version_is "2.7.3" do
-  describe "delegation with def(x, ...)" do
-    it "delegates rest and kwargs" do
-      a = Class.new(DelegationSpecs::Target)
-      a.class_eval(<<-RUBY)
-        def delegate(x, ...)
-          target(...)
-        end
-      RUBY
+describe "delegation with def(x, ...)" do
+  it "delegates rest and kwargs" do
+    a = Class.new(DelegationSpecs::Target)
+    a.class_eval(<<-RUBY)
+      def delegate(x, ...)
+        target(...)
+      end
+    RUBY
 
-      a.new.delegate(0, 1, b: 2).should == [[1], {b: 2}]
-    end
+    a.new.delegate(0, 1, b: 2).should == [[1], {b: 2}]
+  end
 
-    it "delegates block" do
-      a = Class.new(DelegationSpecs::Target)
-      a.class_eval(<<-RUBY)
-        def delegate_block(x, ...)
-          target_block(...)
-        end
-      RUBY
+  it "delegates block" do
+    a = Class.new(DelegationSpecs::Target)
+    a.class_eval(<<-RUBY)
+      def delegate_block(x, ...)
+        target_block(...)
+      end
+    RUBY
 
-      a.new.delegate_block(0, 1, b: 2) { |x| x }.should == [{b: 2}, [1]]
-    end
+    a.new.delegate_block(0, 1, b: 2) { |x| x }.should == [{b: 2}, [1]]
   end
 end


### PR DESCRIPTION
Since those are no longer supported.

I guess those have been missed in commit f0525c95d6b901f6b2aa64c58ae408884be261ac.