### PR TITLE
Add tests for warnings when passing block to creation of new IO object

### DIFF
--- a/core/file/new_spec.rb
+++ b/core/file/new_spec.rb
@@ -188,6 +188,12 @@ describe "File.new" do
     }.should raise_error(Errno::EEXIST, /File exists/)
   end
 
+  it "does not use the given block and warns to use File::open" do
+    -> {
+      @fh = File.new(@file) { raise }
+    }.should complain(/warning: File::new\(\) does not take block; use File::open\(\) instead/)
+  end
+
   it "raises a TypeError if the first parameter can't be coerced to a string" do
     -> { File.new(true) }.should raise_error(TypeError)
     -> { File.new(false) }.should raise_error(TypeError)

--- a/core/io/new_spec.rb
+++ b/core/io/new_spec.rb
@@ -5,6 +5,12 @@ require_relative 'shared/new'
 
 describe "IO.new" do
   it_behaves_like :io_new, :new
+
+  it "does not use the given block and warns to use IO::open" do
+    -> {
+      @io = IO.send(@method, @fd) { raise }
+    }.should complain(/warning: IO::new\(\) does not take block; use IO::open\(\) instead/)
+  end
 end
 
 describe "IO.new" do

--- a/library/socket/tcpserver/new_spec.rb
+++ b/library/socket/tcpserver/new_spec.rb
@@ -97,6 +97,12 @@ describe "TCPServer.new" do
     addr[1].should be_kind_of(Integer)
   end
 
+  it "does not use the given block and warns to use TCPServer::open" do
+    -> {
+      @server = TCPServer.new(0) { raise }
+    }.should complain(/warning: TCPServer::new\(\) does not take block; use TCPServer::open\(\) instead/)
+  end
+
   it "raises Errno::EADDRNOTAVAIL when the address is unknown" do
     -> { TCPServer.new("1.2.3.4", 0) }.should raise_error(Errno::EADDRNOTAVAIL)
   end

--- a/library/socket/tcpsocket/initialize_spec.rb
+++ b/library/socket/tcpsocket/initialize_spec.rb
@@ -4,6 +4,27 @@ require_relative 'shared/new'
 
 describe 'TCPSocket#initialize' do
   it_behaves_like :tcpsocket_new, :new
+
+  describe "with a running server" do
+    before :each do
+      @server = SocketSpecs::SpecTCPServer.new
+      @hostname = @server.hostname
+    end
+
+    after :each do
+      if @socket
+        @socket.write "QUIT"
+        @socket.close
+      end
+      @server.shutdown
+    end
+
+    it "does not use the given block and warns to use TCPSocket::open" do
+      -> {
+        @socket = TCPSocket.new(@hostname, @server.port, nil) { raise }
+      }.should complain(/warning: TCPSocket::new\(\) does not take block; use TCPSocket::open\(\) instead/)
+    end
+  end
 end
 
 describe 'TCPSocket#initialize' do

--- a/library/socket/udpsocket/new_spec.rb
+++ b/library/socket/udpsocket/new_spec.rb
@@ -26,6 +26,12 @@ describe 'UDPSocket.new' do
     @socket.should be_an_instance_of(UDPSocket)
   end
 
+  it "does not use the given block and warns to use UDPSocket::open" do
+    -> {
+      @socket = UDPSocket.new { raise }
+    }.should complain(/warning: UDPSocket::new\(\) does not take block; use UDPSocket::open\(\) instead/)
+  end
+
   it 'raises Errno::EAFNOSUPPORT or Errno::EPROTONOSUPPORT if unsupported family passed' do
     -> { UDPSocket.new(-1) }.should raise_error(SystemCallError) { |e|
       [Errno::EAFNOSUPPORT, Errno::EPROTONOSUPPORT].should include(e.class)

--- a/library/socket/unixserver/accept_nonblock_spec.rb
+++ b/library/socket/unixserver/accept_nonblock_spec.rb
@@ -1,9 +1,8 @@
 require_relative '../spec_helper'
 require_relative '../fixtures/classes'
 
-describe "UNIXServer#accept_nonblock" do
-
-  platform_is_not :windows do
+with_feature :unix_socket do
+  describe "UNIXServer#accept_nonblock" do
     before :each do
       @path = SocketSpecs.socket_path
       @server = UNIXServer.open(@path)
@@ -33,9 +32,7 @@ describe "UNIXServer#accept_nonblock" do
       @server.accept_nonblock(exception: false).should == :wait_readable
     end
   end
-end
 
-with_feature :unix_socket do
   describe 'UNIXServer#accept_nonblock' do
     before do
       @path   = SocketSpecs.socket_path

--- a/library/socket/unixserver/accept_spec.rb
+++ b/library/socket/unixserver/accept_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../spec_helper'
 require_relative '../fixtures/classes'
 
-platform_is_not :windows do
+with_feature :unix_socket do
   describe "UNIXServer#accept" do
     before :each do
       @path = SocketSpecs.socket_path

--- a/library/socket/unixserver/for_fd_spec.rb
+++ b/library/socket/unixserver/for_fd_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../spec_helper'
 require_relative '../fixtures/classes'
 
-platform_is_not :windows do
+with_feature :unix_socket do
   describe "UNIXServer#for_fd" do
     before :each do
       @unix_path = SocketSpecs.socket_path

--- a/library/socket/unixserver/new_spec.rb
+++ b/library/socket/unixserver/new_spec.rb
@@ -1,6 +1,8 @@
 require_relative '../spec_helper'
 require_relative 'shared/new'
 
-describe "UNIXServer.new" do
-  it_behaves_like :unixserver_new, :new
+with_feature :unix_socket do
+  describe "UNIXServer.new" do
+    it_behaves_like :unixserver_new, :new
+  end
 end

--- a/library/socket/unixserver/new_spec.rb
+++ b/library/socket/unixserver/new_spec.rb
@@ -4,5 +4,11 @@ require_relative 'shared/new'
 with_feature :unix_socket do
   describe "UNIXServer.new" do
     it_behaves_like :unixserver_new, :new
+
+    it "does not use the given block and warns to use UNIXServer::open" do
+      -> {
+        @server = UNIXServer.new(@path) { raise }
+      }.should complain(/warning: UNIXServer::new\(\) does not take block; use UNIXServer::open\(\) instead/)
+    end
   end
 end

--- a/library/socket/unixserver/open_spec.rb
+++ b/library/socket/unixserver/open_spec.rb
@@ -2,10 +2,10 @@ require_relative '../spec_helper'
 require_relative '../fixtures/classes'
 require_relative 'shared/new'
 
-describe "UNIXServer.open" do
-  it_behaves_like :unixserver_new, :open
+with_feature :unix_socket do
+  describe "UNIXServer.open" do
+    it_behaves_like :unixserver_new, :open
 
-  platform_is_not :windows do
     before :each do
       @path = SocketSpecs.socket_path
     end

--- a/library/socket/unixserver/shared/new.rb
+++ b/library/socket/unixserver/shared/new.rb
@@ -2,21 +2,19 @@ require_relative '../../spec_helper'
 require_relative '../../fixtures/classes'
 
 describe :unixserver_new, shared: true do
-  platform_is_not :windows do
-    before :each do
-      @path = SocketSpecs.socket_path
-    end
+  before :each do
+    @path = SocketSpecs.socket_path
+  end
 
-    after :each do
-      @server.close if @server
-      @server = nil
-      SocketSpecs.rm_socket @path
-    end
+  after :each do
+    @server.close if @server
+    @server = nil
+    SocketSpecs.rm_socket @path
+  end
 
-    it "creates a new UNIXServer" do
-      @server = UNIXServer.send(@method, @path)
-      @server.path.should == @path
-      @server.addr.should == ["AF_UNIX", @path]
-    end
+  it "creates a new UNIXServer" do
+    @server = UNIXServer.send(@method, @path)
+    @server.path.should == @path
+    @server.addr.should == ["AF_UNIX", @path]
   end
 end

--- a/library/socket/unixsocket/addr_spec.rb
+++ b/library/socket/unixsocket/addr_spec.rb
@@ -1,9 +1,8 @@
 require_relative '../spec_helper'
 require_relative '../fixtures/classes'
 
-describe "UNIXSocket#addr" do
-
-  platform_is_not :windows do
+with_feature :unix_socket do
+  describe "UNIXSocket#addr" do
     before :each do
       @path = SocketSpecs.socket_path
       @server = UNIXServer.open(@path)

--- a/library/socket/unixsocket/inspect_spec.rb
+++ b/library/socket/unixsocket/inspect_spec.rb
@@ -1,8 +1,8 @@
 require_relative '../spec_helper'
 require_relative '../fixtures/classes'
 
-describe "UNIXSocket#inspect" do
-  platform_is_not :windows do
+with_feature :unix_socket do
+  describe "UNIXSocket#inspect" do
     it "returns sockets fd for unnamed sockets" do
       begin
         s1, s2 = UNIXSocket.socketpair

--- a/library/socket/unixsocket/local_address_spec.rb
+++ b/library/socket/unixsocket/local_address_spec.rb
@@ -46,9 +46,7 @@ with_feature :unix_socket do
       end
     end
   end
-end
 
-with_feature :unix_socket do
   describe 'UNIXSocket#local_address with a UNIX socket pair' do
     before :each do
       @sock, @sock2 = Socket.pair(Socket::AF_UNIX, Socket::SOCK_STREAM)

--- a/library/socket/unixsocket/new_spec.rb
+++ b/library/socket/unixsocket/new_spec.rb
@@ -1,6 +1,8 @@
 require_relative '../spec_helper'
 require_relative 'shared/new'
 
-describe "UNIXSocket.new" do
-  it_behaves_like :unixsocket_new, :new
+with_feature :unix_socket do
+  describe "UNIXSocket.new" do
+    it_behaves_like :unixsocket_new, :new
+  end
 end

--- a/library/socket/unixsocket/new_spec.rb
+++ b/library/socket/unixsocket/new_spec.rb
@@ -4,5 +4,11 @@ require_relative 'shared/new'
 with_feature :unix_socket do
   describe "UNIXSocket.new" do
     it_behaves_like :unixsocket_new, :new
+
+    it "does not use the given block and warns to use UNIXSocket::open" do
+      -> {
+        @client = UNIXSocket.new(@path) { raise }
+      }.should complain(/warning: UNIXSocket::new\(\) does not take block; use UNIXSocket::open\(\) instead/)
+    end
   end
 end

--- a/library/socket/unixsocket/open_spec.rb
+++ b/library/socket/unixsocket/open_spec.rb
@@ -2,12 +2,12 @@ require_relative '../spec_helper'
 require_relative '../fixtures/classes'
 require_relative 'shared/new'
 
-describe "UNIXSocket.open" do
-  it_behaves_like :unixsocket_new, :open
-end
+with_feature :unix_socket do
+  describe "UNIXSocket.open" do
+    it_behaves_like :unixsocket_new, :open
+  end
 
-describe "UNIXSocket.open" do
-  platform_is_not :windows do
+  describe "UNIXSocket.open" do
     before :each do
       @path = SocketSpecs.socket_path
       @server = UNIXServer.open(@path)

--- a/library/socket/unixsocket/pair_spec.rb
+++ b/library/socket/unixsocket/pair_spec.rb
@@ -2,9 +2,8 @@ require_relative '../spec_helper'
 require_relative '../fixtures/classes'
 require_relative '../shared/partially_closable_sockets'
 
-describe "UNIXSocket#pair" do
-  platform_is_not :windows do
-
+with_feature :unix_socket do
+  describe "UNIXSocket#pair" do
     it_should_behave_like :partially_closable_sockets
 
     before :each do

--- a/library/socket/unixsocket/partially_closable_spec.rb
+++ b/library/socket/unixsocket/partially_closable_spec.rb
@@ -2,9 +2,8 @@ require_relative '../spec_helper'
 require_relative '../fixtures/classes'
 require_relative '../shared/partially_closable_sockets'
 
-platform_is_not :windows do
+with_feature :unix_socket do
   describe "UNIXSocket partial closability" do
-
     before :each do
       @path = SocketSpecs.socket_path
       @server = UNIXServer.open(@path)
@@ -20,6 +19,5 @@ platform_is_not :windows do
     end
 
     it_should_behave_like :partially_closable_sockets
-
   end
 end

--- a/library/socket/unixsocket/path_spec.rb
+++ b/library/socket/unixsocket/path_spec.rb
@@ -1,9 +1,8 @@
 require_relative '../spec_helper'
 require_relative '../fixtures/classes'
 
-describe "UNIXSocket#path" do
-
-  platform_is_not :windows do
+with_feature :unix_socket do
+  describe "UNIXSocket#path" do
     before :each do
       @path = SocketSpecs.socket_path
       @server = UNIXServer.open(@path)
@@ -24,5 +23,4 @@ describe "UNIXSocket#path" do
       @client.path.should == ""
     end
   end
-
 end

--- a/library/socket/unixsocket/peeraddr_spec.rb
+++ b/library/socket/unixsocket/peeraddr_spec.rb
@@ -1,9 +1,8 @@
 require_relative '../spec_helper'
 require_relative '../fixtures/classes'
 
-describe "UNIXSocket#peeraddr" do
-
-  platform_is_not :windows do
+with_feature :unix_socket do
+  describe "UNIXSocket#peeraddr" do
     before :each do
       @path = SocketSpecs.socket_path
       @server = UNIXServer.open(@path)
@@ -26,5 +25,4 @@ describe "UNIXSocket#peeraddr" do
       }.should raise_error(Errno::ENOTCONN)
     end
   end
-
 end

--- a/library/socket/unixsocket/recv_io_spec.rb
+++ b/library/socket/unixsocket/recv_io_spec.rb
@@ -1,9 +1,8 @@
 require_relative '../spec_helper'
 require_relative '../fixtures/classes'
 
-describe "UNIXSocket#recv_io" do
-
-  platform_is_not :windows do
+with_feature :unix_socket do
+  describe "UNIXSocket#recv_io" do
     before :each do
       @path = SocketSpecs.socket_path
       @server = UNIXServer.open(@path)
@@ -41,9 +40,7 @@ describe "UNIXSocket#recv_io" do
       @io.should be_an_instance_of(File)
     end
   end
-end
 
-with_feature :unix_socket do
   describe 'UNIXSocket#recv_io' do
     before do
       @file = File.open('/dev/null', 'w')

--- a/library/socket/unixsocket/recvfrom_spec.rb
+++ b/library/socket/unixsocket/recvfrom_spec.rb
@@ -1,8 +1,8 @@
 require_relative '../spec_helper'
 require_relative '../fixtures/classes'
 
-describe "UNIXSocket#recvfrom" do
-  platform_is_not :windows do
+with_feature :unix_socket do
+  describe "UNIXSocket#recvfrom" do
     before :each do
       @path = SocketSpecs.socket_path
       @server = UNIXServer.open(@path)
@@ -42,10 +42,7 @@ describe "UNIXSocket#recvfrom" do
       sock.close
     end
   end
-end
 
-
-with_feature :unix_socket do
   describe 'UNIXSocket#recvfrom' do
     describe 'using a socket pair' do
       before do

--- a/library/socket/unixsocket/send_io_spec.rb
+++ b/library/socket/unixsocket/send_io_spec.rb
@@ -1,9 +1,8 @@
 require_relative '../spec_helper'
 require_relative '../fixtures/classes'
 
-describe "UNIXSocket#send_io" do
-
-  platform_is_not :windows do
+with_feature :unix_socket do
+  describe "UNIXSocket#send_io" do
     before :each do
       @path = SocketSpecs.socket_path
       @server = UNIXServer.open(@path)
@@ -32,9 +31,7 @@ describe "UNIXSocket#send_io" do
       @io.read.should == File.read(@send_io_path)
     end
   end
-end
 
-with_feature :unix_socket do
   describe 'UNIXSocket#send_io' do
     before do
       @file = File.open('/dev/null', 'w')

--- a/library/socket/unixsocket/shared/new.rb
+++ b/library/socket/unixsocket/shared/new.rb
@@ -2,23 +2,21 @@ require_relative '../../spec_helper'
 require_relative '../../fixtures/classes'
 
 describe :unixsocket_new, shared: true do
-  platform_is_not :windows do
-    before :each do
-      @path = SocketSpecs.socket_path
-      @server = UNIXServer.open(@path)
-    end
+  before :each do
+    @path = SocketSpecs.socket_path
+    @server = UNIXServer.open(@path)
+  end
 
-    after :each do
-      @client.close if @client
-      @server.close
-      SocketSpecs.rm_socket @path
-    end
+  after :each do
+    @client.close if @client
+    @server.close
+    SocketSpecs.rm_socket @path
+  end
 
-    it "opens a unix socket on the specified file" do
-      @client = UNIXSocket.send(@method, @path)
+  it "opens a unix socket on the specified file" do
+    @client = UNIXSocket.send(@method, @path)
 
-      @client.addr[0].should == "AF_UNIX"
-      @client.should_not.closed?
-    end
+    @client.addr[0].should == "AF_UNIX"
+    @client.should_not.closed?
   end
 end

--- a/library/stringio/new_spec.rb
+++ b/library/stringio/new_spec.rb
@@ -2,7 +2,9 @@ require_relative '../../spec_helper'
 require 'stringio'
 
 describe "StringIO.new" do
-  it "warns when called with a block" do
-    -> { eval("StringIO.new {}") }.should complain(/StringIO::new\(\) does not take block; use StringIO::open\(\) instead/)
+  it "does not use the given block and warns to use StringIO::open" do
+    -> {
+      StringIO.new { raise }
+    }.should complain(/warning: StringIO::new\(\) does not take block; use StringIO::open\(\) instead/)
   end
 end


### PR DESCRIPTION
I think these were all `IO` subclasses, which means I probably missed half of them.
I used the syntax `IO::open` instead of `IO.open` in the descriptions of the tests, since that is what the warnings say.