### PR TITLE
Remove fixtures/classes from core/kernel/sleep_spec

### DIFF
--- a/core/kernel/sleep_spec.rb
+++ b/core/kernel/sleep_spec.rb
@@ -1,5 +1,4 @@
 require_relative '../../spec_helper'
-require_relative 'fixtures/classes'
 
 describe "Kernel#sleep" do
   it "is a private method" do


### PR DESCRIPTION
Very minor cleanup, the spec does not use any of these classes.