### PR TITLE
Replace someone's domain fallingsnow.net with our domain ruby-lang.org.

### DIFF
--- a/library/socket/ipsocket/getaddress_spec.rb
+++ b/library/socket/ipsocket/getaddress_spec.rb
@@ -19,7 +19,7 @@ describe "Socket::IPSocket#getaddress" do
   # traditionally invalidly named ones.
   it "raises an error on unknown hostnames" do
     -> {
-      IPSocket.getaddress("rubyspecdoesntexist.fallingsnow.net")
+      IPSocket.getaddress("rubyspecdoesntexist.ruby-lang.org")
     }.should raise_error(SocketError)
   end
 end


### PR DESCRIPTION
This improvement was suggested at https://github.com/ruby/spec/issues/1095#issuecomment-1765134800.

---

Because we want to predict the behavior of the domain in the spec test.
