### PR TITLE
Copy-paste fix in specs of MatchData#values_at

### DIFF
--- a/core/matchdata/values_at_spec.rb
+++ b/core/matchdata/values_at_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
 
-describe "Struct#values_at" do
+describe "MatchData#values_at" do
   # Should be synchronized with core/array/values_at_spec.rb and core/struct/values_at_spec.rb
   #
   # /(.)(.)(\d+)(\d)/.match("THX1138: The Movie").to_a # => ["HX1138", "H", "X", "113", "8"]


### PR DESCRIPTION
I know it says that it should be synchronized with struct/values_at_spec, but this might be a bit too synchronized.