### PR TITLE
Add spec for Process::RLIMIT_NPTS

### DIFF
--- a/core/process/constants_spec.rb
+++ b/core/process/constants_spec.rb
@@ -56,9 +56,15 @@ describe "Process::Constants" do
   end
 
   platform_is :netbsd, :freebsd do
-    it "Process::RLIMIT_SBSIZE" do
+    it "has the correct constant values on NetBSD and FreeBSD" do
       Process::RLIMIT_SBSIZE.should == 9 # FIXME: what's it equal?
       Process::RLIMIT_AS.should == 10
+    end
+  end
+
+  platform_is :freebsd do
+    it "has the correct constant values on FreeBSD" do
+      Process::RLIMIT_NPTS.should == 11
     end
   end
 


### PR DESCRIPTION
Full disclosure: I have not tested this due to the lack of a FreeBSD system. The expected value has been copied from https://github.com/lattera/freebsd/blob/master/sys/sys/resource.h