### PR TITLE
Convert specs for OpenSSL::Digest to shared specs with Digest

### DIFF
--- a/library/digest/sha512/length_spec.rb
+++ b/library/digest/sha512/length_spec.rb
@@ -1,7 +1,6 @@
 require_relative '../../../spec_helper'
-require_relative 'shared/constants'
 require_relative 'shared/length'
 
 describe "Digest::SHA512#length" do
-  it_behaves_like :sha512_length, :length
+  it_behaves_like :sha512_length, :length, Digest::SHA512.new
 end

--- a/library/digest/sha512/shared/length.rb
+++ b/library/digest/sha512/shared/length.rb
@@ -1,8 +1,9 @@
+require_relative 'constants'
+
 describe :sha512_length, shared: true do
   it "returns the length of the digest" do
-    cur_digest = Digest::SHA512.new
-    cur_digest.send(@method).should == SHA512Constants::BlankDigest.size
-    cur_digest << SHA512Constants::Contents
-    cur_digest.send(@method).should == SHA512Constants::Digest.size
+    @object.send(@method).should == SHA512Constants::BlankDigest.size
+    @object << SHA512Constants::Contents
+    @object.send(@method).should == SHA512Constants::Digest.size
   end
 end

--- a/library/digest/sha512/size_spec.rb
+++ b/library/digest/sha512/size_spec.rb
@@ -1,7 +1,6 @@
 require_relative '../../../spec_helper'
-require_relative 'shared/constants'
 require_relative 'shared/length'
 
 describe "Digest::SHA512#size" do
-  it_behaves_like :sha512_length, :size
+  it_behaves_like :sha512_length, :size, Digest::SHA512.new
 end

--- a/library/openssl/digest/digest_length_spec.rb
+++ b/library/openssl/digest/digest_length_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../../spec_helper'
 require_relative '../../../library/digest/sha1/shared/constants'
 require_relative '../../../library/digest/sha256/shared/constants'
 require_relative '../../../library/digest/sha384/shared/constants'
-require_relative '../../../library/digest/sha512/shared/constants'
+require_relative '../../digest/sha512/shared/length'
 require 'openssl'
 
 describe "OpenSSL::Digest#digest_length" do
@@ -19,9 +19,7 @@ describe "OpenSSL::Digest#digest_length" do
       OpenSSL::Digest.new('sha384').digest_length.should == SHA384Constants::DigestLength
     end
 
-    it "returns a SHA512 digest length" do
-      OpenSSL::Digest.new('sha512').digest_length.should == SHA512Constants::DigestLength
-    end
+    it_behaves_like :sha512_length, :digest_length, OpenSSL::Digest.new('sha512')
   end
 
   context "when the digest object is created via a subclass" do
@@ -37,8 +35,6 @@ describe "OpenSSL::Digest#digest_length" do
       OpenSSL::Digest::SHA384.new.digest_length.should == SHA384Constants::DigestLength
     end
 
-    it "returns a SHA512 digest length" do
-      OpenSSL::Digest::SHA512.new.digest_length.should == SHA512Constants::DigestLength
-    end
+    it_behaves_like :sha512_length, :digest_length, OpenSSL::Digest::SHA512.new
   end
 end


### PR DESCRIPTION
This is going to take a bit of time, so I would like to have an approval for the idea before I actually spend a few hours on this.

Ruby has two libraries to calculate digests: `digest` and `openssl` (or the classes `Digest` en `OpenSSL::Digest`). The tests for openssl-digest currently use a lot of the constants of the digest, but they could use the specs as well. The current pull request is a little proof of concept for a single spec.

That brings us to the next point: the documentation of the OpenSSL::Digest class is weird. When I look at https://www.rubydoc.info/stdlib/openssl/OpenSSL/Digest, the only documented method is `digest`. https://docs.ruby-lang.org/en/3.2/OpenSSL/Digest.html describes a few more methods. But it turns out that the OpenSSL::Digest object had methods `size` and `length` too, similar to the Digest object. Or the OpenSSL::Digest object has a `file` method too, similar to Digest, but this is not documented. Should these undocumented methods be added to the specs too?