### PR TITLE
Move specs for OpenSSL::X509::Store#verify to correct location

### DIFF
--- a/library/openssl/x509/store/verify_spec.rb
+++ b/library/openssl/x509/store/verify_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../../../spec_helper'
 require 'openssl'
 
-describe "OpenSSL::X509::Name.verify" do
+describe "OpenSSL::X509::Store#verify" do
   it "returns true for valid certificate" do
     key = OpenSSL::PKey::RSA.new 2048
     cert = OpenSSL::X509::Certificate.new


### PR DESCRIPTION
The eventual check (after tons of setup) is this:
```ruby
store = OpenSSL::X509::Store.new
store.add_cert(cert)
[store.verify(cert), store.error, store.error_string].should == [true, 0, "ok"]
```
The description and the location of this file were incorrect.