### PR TITLE
Add specs for compare methods of OpenSSL

### DIFF
--- a/library/openssl/fixed_length_secure_compare_spec.rb
+++ b/library/openssl/fixed_length_secure_compare_spec.rb
@@ -1,0 +1,42 @@
+require_relative '../../spec_helper'
+require 'openssl'
+
+describe "OpenSSL.fixed_length_secure_compare" do
+  it "returns true for two strings with the same content" do
+    input1 = "the quick brown fox jumps over the lazy dog"
+    input2 = "the quick brown fox jumps over the lazy dog"
+    OpenSSL.fixed_length_secure_compare(input1, input2).should be_true
+  end
+
+  it "returns false for two strings of equal size with different content" do
+    input1 = "the quick brown fox jumps over the lazy dog"
+    input2 = "the lazy dog jumps over the quick brown fox"
+    OpenSSL.fixed_length_secure_compare(input1, input2).should be_false
+  end
+
+  it "converts both arguments to strings using #to_str" do
+    input1 = mock("input1")
+    input1.should_receive(:to_str).and_return("the quick brown fox jumps over the lazy dog")
+    input2 = mock("input2")
+    input2.should_receive(:to_str).and_return("the quick brown fox jumps over the lazy dog")
+    OpenSSL.fixed_length_secure_compare(input1, input2).should be_true
+  end
+
+  it "does not accept arguments that are not string and cannot be coerced into strings" do
+    -> {
+      OpenSSL.fixed_length_secure_compare("input1", :input2)
+    }.should raise_error(TypeError, 'no implicit conversion of Symbol into String')
+
+    -> {
+      OpenSSL.fixed_length_secure_compare(Object.new, "input2")
+    }.should raise_error(TypeError, 'no implicit conversion of Object into String')
+  end
+
+  it "raises an ArgumentError for two strings of different size" do
+    input1 = "the quick brown fox jumps over the lazy dog"
+    input2 = "the quick brown fox"
+    -> {
+      OpenSSL.fixed_length_secure_compare(input1, input2)
+    }.should raise_error(ArgumentError, 'inputs must be of equal length')
+  end
+end

--- a/library/openssl/secure_compare_spec.rb
+++ b/library/openssl/secure_compare_spec.rb
@@ -1,0 +1,38 @@
+require_relative '../../spec_helper'
+require 'openssl'
+
+describe "OpenSSL.secure_compare" do
+  it "returns true for two strings with the same content" do
+    input1 = "the quick brown fox jumps over the lazy dog"
+    input2 = "the quick brown fox jumps over the lazy dog"
+    OpenSSL.secure_compare(input1, input2).should be_true
+  end
+
+  it "returns false for two strings with different content" do
+    input1 = "the quick brown fox jumps over the lazy dog"
+    input2 = "the lazy dog jumps over the quick brown fox"
+    OpenSSL.secure_compare(input1, input2).should be_false
+  end
+
+  it "converts both arguments to strings using #to_str, but adds equality check for the original objects" do
+    input1 = mock("input1")
+    input1.should_receive(:to_str).and_return("the quick brown fox jumps over the lazy dog")
+    input2 = mock("input2")
+    input2.should_receive(:to_str).and_return("the quick brown fox jumps over the lazy dog")
+    OpenSSL.secure_compare(input1, input2).should be_false
+
+    input = mock("input")
+    input.should_receive(:to_str).twice.and_return("the quick brown fox jumps over the lazy dog")
+    OpenSSL.secure_compare(input, input).should be_true
+  end
+
+  it "does not accept arguments that are not string and cannot be coerced into strings" do
+    -> {
+      OpenSSL.secure_compare("input1", :input2)
+    }.should raise_error(TypeError, 'no implicit conversion of Symbol into String')
+
+    -> {
+      OpenSSL.secure_compare(Object.new, "input2")
+    }.should raise_error(TypeError, 'no implicit conversion of Object into String')
+  end
+end


### PR DESCRIPTION
This is a very crude spec that just checks to see if the results are correct. These methods have the guarantee to run in constant time regardless of the input, which is not under test.