### PR TITLE
Add #to_ary specs for Array's assoc and rassoc

### DIFF
--- a/core/array/assoc_spec.rb
+++ b/core/array/assoc_spec.rb
@@ -37,4 +37,16 @@ describe "Array#assoc" do
     a.assoc(s1.first).should equal(s1)
     a.assoc(s2.first).should equal(s2)
   end
+
+  it "calls to_ary on non-array elements" do
+    s1 = [1, 2]
+    s2 = ArraySpecs::ArrayConvertible.new(2, 3)
+    a = [s1, s2]
+
+    s1.should_not_receive(:to_ary)
+    a.assoc(s1.first).should equal(s1)
+
+    a.assoc(2).should == [2, 3]
+    s2.called.should equal(:to_ary)
+  end
 end

--- a/core/array/rassoc_spec.rb
+++ b/core/array/rassoc_spec.rb
@@ -35,4 +35,16 @@ describe "Array#rassoc" do
 
     [[1, :foobar, o], [2, o, 1], [3, mock('foo')]].rassoc(key).should == [2, o, 1]
   end
+
+  it "does not call to_ary on non-array elements" do
+    s1 = [1, 2]
+    s2 = ArraySpecs::ArrayConvertible.new(2, 3)
+    a = [s1, s2]
+
+    s1.should_not_receive(:to_ary)
+    a.rassoc(2).should equal(s1)
+
+    s2.should_not_receive(:to_ary)
+    a.rassoc(3).should equal(nil)
+  end
 end


### PR DESCRIPTION
Add specs specifying `Array#assoc` and `Array#rassoc` behaviour regarding implicit conversion 