### PR TITLE
Add specs for invalid base argument in Kernel.Integer

### DIFF
--- a/core/kernel/Integer_spec.rb
+++ b/core/kernel/Integer_spec.rb
@@ -586,6 +586,21 @@ describe :kernel_integer_string_base, shared: true do
     Integer("777", obj).should == 0777
   end
 
+  # https://bugs.ruby-lang.org/issues/19349
+  ruby_version_is ''...'3.3' do
+    it "ignores the base if it is not an integer and does not respond to #to_i" do
+      Integer("777", "8").should == 777
+    end
+  end
+
+  ruby_version_is '3.3' do
+    it "raises a TypeError if it is not an integer and does not respond to #to_i" do
+      -> {
+        Integer("777", "8")
+      }.should raise_error(TypeError, "no implicit conversion of String into Integer")
+    end
+  end
+
   describe "when passed exception: false" do
     describe "and valid argument" do
       it "returns an Integer number" do


### PR DESCRIPTION
I'm not sure if we're doing 3.3 changes already? Especially since it's not running in the CI yet