### PR TITLE
Remove dependency on Date.parse from YAML specs

### DIFF
--- a/library/yaml/to_yaml_spec.rb
+++ b/library/yaml/to_yaml_spec.rb
@@ -19,7 +19,7 @@ describe "Object#to_yaml" do
 
   it "returns the YAML representation of a Date object" do
     require 'date'
-    Date.parse('1997/12/30').to_yaml.should match_yaml("--- 1997-12-30\n")
+    Date.new(1997, 12, 30).to_yaml.should match_yaml("--- 1997-12-30\n")
   end
 
   it "returns the YAML representation of a FalseClass" do


### PR DESCRIPTION
Writing it as `Date.new` is just as clear, has one less dependency and matches the Date statements in `library/yaml/shared/load.rb`