### PR TITLE
Extend specs for Date.iso8601

### DIFF
--- a/library/date/iso8601_spec.rb
+++ b/library/date/iso8601_spec.rb
@@ -22,6 +22,18 @@ describe "Date.iso8601" do
     d.should == Date.civil(-4712, 1, 1)
   end
 
+  it "raises a Date::Error if the argument is a invalid Date" do
+    -> {
+      Date.iso8601('invalid')
+    }.should raise_error(Date::Error, "invalid date")
+  end
+
+  it "raises a Date::Error when passed a nil" do
+    -> {
+      Date.iso8601(nil)
+    }.should raise_error(Date::Error, "invalid date")
+  end
+
   it "raises a TypeError when passed an Object" do
     -> { Date.iso8601(Object.new) }.should raise_error(TypeError)
   end
@@ -31,5 +43,14 @@ describe "Date._iso8601" do
   it "returns an empty hash if the argument is a invalid Date" do
     h = Date._iso8601('invalid')
     h.should == {}
+  end
+
+  it "returns an empty hash if the argument is nil" do
+    h = Date._iso8601(nil)
+    h.should == {}
+  end
+
+  it "raises a TypeError when passed an Object" do
+    -> { Date._iso8601(Object.new) }.should raise_error(TypeError)
   end
 end


### PR DESCRIPTION
Include a few invalid inputs, mostly to illustrate the difference between `Date.iso8601` and `Date._iso8601`