### PR TITLE
Fix shared test digest_instance_update

### DIFF
--- a/library/digest/instance/shared/update.rb
+++ b/library/digest/instance/shared/update.rb
@@ -3,6 +3,6 @@ describe :digest_instance_update, shared: true do
     c = Class.new do
       include Digest::Instance
     end
-    -> { c.new.update("test") }.should raise_error(RuntimeError)
+    -> { c.new.send(@method, "test") }.should raise_error(RuntimeError)
   end
 end


### PR DESCRIPTION
Use the provided method instead. This fixes the `Digest::Instance#<<` spec, it now does what it says it does.