### PR TITLE
Cleanup of IO#getc usage in specs of IO#read

### DIFF
--- a/core/io/read_spec.rb
+++ b/core/io/read_spec.rb
@@ -331,7 +331,7 @@ describe "IO#read" do
     @io.read(0).should == ''
     @io.pos.should == 0
 
-    @io.getc.chr.should == '1'
+    @io.getc.should == '1'
   end
 
   it "is at end-of-file when everything has been read" do


### PR DESCRIPTION
`IO#getc` returns a character string, there is no need to call `#chr` on the result. It looks like it got confused with `IO#getbyte`.