### PR TITLE
Remove "require 'thread'" statements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,9 +43,6 @@ Lint/InterpolationCheck:
 Lint/LiteralAsCondition:
   Enabled: false
 
-Lint/RedundantRequireStatement:
-  Enabled: false
-
 Lint/RedundantSplatExpansion:
   Enabled: false
 

--- a/core/conditionvariable/broadcast_spec.rb
+++ b/core/conditionvariable/broadcast_spec.rb
@@ -1,5 +1,4 @@
 require_relative '../../spec_helper'
-require 'thread'
 
 describe "ConditionVariable#broadcast" do
   it "releases all threads waiting in line for this resource" do

--- a/core/conditionvariable/marshal_dump_spec.rb
+++ b/core/conditionvariable/marshal_dump_spec.rb
@@ -1,5 +1,4 @@
 require_relative '../../spec_helper'
-require 'thread'
 
 describe "ConditionVariable#marshal_dump" do
   it "raises a TypeError" do

--- a/core/conditionvariable/signal_spec.rb
+++ b/core/conditionvariable/signal_spec.rb
@@ -1,5 +1,4 @@
 require_relative '../../spec_helper'
-require 'thread'
 
 describe "ConditionVariable#signal" do
   it "releases the first thread waiting in line for this resource" do

--- a/core/conditionvariable/wait_spec.rb
+++ b/core/conditionvariable/wait_spec.rb
@@ -1,5 +1,4 @@
 require_relative '../../spec_helper'
-require 'thread'
 
 describe "ConditionVariable#wait" do
   it "calls #sleep on the given object" do

--- a/core/module/autoload_spec.rb
+++ b/core/module/autoload_spec.rb
@@ -1,7 +1,6 @@
 require_relative '../../spec_helper'
 require_relative '../../fixtures/code_loading'
 require_relative 'fixtures/classes'
-require 'thread'
 
 describe "Module#autoload?" do
   it "returns the name of the file that will be autoloaded" do

--- a/core/process/fixtures/kill.rb
+++ b/core/process/fixtures/kill.rb
@@ -1,5 +1,3 @@
-require 'thread'
-
 pid_file = ARGV.shift
 scenario = ARGV.shift
 

--- a/library/objectspace/reachable_objects_from_spec.rb
+++ b/library/objectspace/reachable_objects_from_spec.rb
@@ -38,7 +38,6 @@ describe "ObjectSpace.reachable_objects_from" do
   end
 
   it "finds an object stored in a Queue" do
-    require 'thread'
     o = Object.new
     q = Queue.new
     q << o
@@ -49,7 +48,6 @@ describe "ObjectSpace.reachable_objects_from" do
   end
 
   it "finds an object stored in a SizedQueue" do
-    require 'thread'
     o = Object.new
     q = SizedQueue.new(3)
     q << o


### PR DESCRIPTION
These are no longer required in the supported Ruby versions.