### PR TITLE
Add more specs for Kernel#caller with a Range argument

### DIFF
--- a/core/kernel/caller_spec.rb
+++ b/core/kernel/caller_spec.rb
@@ -44,16 +44,44 @@ describe 'Kernel#caller' do
     ]
   end
 
+  it "can be called with a range" do
+    locations1 = caller(0)
+    locations2 = caller(2..4)
+    locations1[2..4].should == locations2
+  end
+
   it "works with endless ranges" do
     locations1 = KernelSpecs::CallerTest.locations(0)
     locations2 = KernelSpecs::CallerTest.locations(eval("(2..)"))
-    locations2.map(&:to_s).should == locations1[2..-1].map(&:to_s)
+    locations2.should == locations1[2..-1]
   end
 
   it "works with beginless ranges" do
     locations1 = KernelSpecs::CallerTest.locations(0)
     locations2 = KernelSpecs::CallerTest.locations((..5))
-    locations2.map(&:to_s)[eval("(2..)")].should == locations1[(..5)].map(&:to_s)[eval("(2..)")]
+    locations2[eval("(2..)")].should == locations1[(..5)][eval("(2..)")]
+  end
+
+  it "can be called with a range whose end is negative" do
+    locations1 = caller(0)
+    locations2 = caller(2..-1)
+    locations3 = caller(2..-2)
+    locations1[2..-1].should == locations2
+    locations1[2..-2].should == locations3
+  end
+
+  it "must return nil if omitting more locations than available" do
+    caller(100).should == nil
+    caller(100..-1).should == nil
+  end
+
+  it "must return [] if omitting exactly the number of locations available" do
+    omit = caller(0).length
+    caller(omit).should == []
+  end
+
+  it "must return the same locations when called with 1..-1 and when called with no arguments" do
+    caller.should == caller(1..-1)
   end
 
   guard -> { Kernel.instance_method(:tap).source_location } do


### PR DESCRIPTION
These have been copied from the specs of Kernel#caller_locations