### PR TITLE
Fix description of specs of UNIXSocket.pair

### DIFF
--- a/library/socket/unixsocket/pair_spec.rb
+++ b/library/socket/unixsocket/pair_spec.rb
@@ -3,7 +3,7 @@ require_relative '../fixtures/classes'
 require_relative '../shared/partially_closable_sockets'
 
 with_feature :unix_socket do
-  describe "UNIXSocket#pair" do
+  describe "UNIXSocket.pair" do
     it_should_behave_like :partially_closable_sockets
 
     before :each do


### PR DESCRIPTION
This is a class method, not an instance method.