### PR TITLE
Merge specs of UNIXSocket.pair and UNIXSocket.socketpair into a shared spec

### DIFF
--- a/library/socket/unixsocket/pair_spec.rb
+++ b/library/socket/unixsocket/pair_spec.rb
@@ -15,22 +15,27 @@ with_feature :unix_socket do
       @s2.close
     end
 
+    it "returns two UNIXSockets" do
+      @s1.should be_an_instance_of(UNIXSocket)
+      @s2.should be_an_instance_of(UNIXSocket)
+    end
+
     it "returns a pair of connected sockets" do
       @s1.puts "foo"
       @s2.gets.should == "foo\n"
     end
 
-    it "returns sockets with no name" do
-      @s1.path.should == @s2.path
+    it "sets the socket paths to empty Strings" do
       @s1.path.should == ""
+      @s2.path.should == ""
     end
 
-    it "returns sockets with no address" do
+    it "sets the socket addresses to empty Strings" do
       @s1.addr.should == ["AF_UNIX", ""]
       @s2.addr.should == ["AF_UNIX", ""]
     end
 
-    it "returns sockets with no peeraddr" do
+    it "sets the socket peer addresses to empty Strings" do
       @s1.peeraddr.should == ["AF_UNIX", ""]
       @s2.peeraddr.should == ["AF_UNIX", ""]
     end

--- a/library/socket/unixsocket/pair_spec.rb
+++ b/library/socket/unixsocket/pair_spec.rb
@@ -1,9 +1,11 @@
 require_relative '../spec_helper'
 require_relative '../fixtures/classes'
 require_relative '../shared/partially_closable_sockets'
+require_relative 'shared/pair'
 
 with_feature :unix_socket do
   describe "UNIXSocket.pair" do
+    it_should_behave_like :unixsocket_pair
     it_should_behave_like :partially_closable_sockets
 
     before :each do
@@ -13,31 +15,6 @@ with_feature :unix_socket do
     after :each do
       @s1.close
       @s2.close
-    end
-
-    it "returns two UNIXSockets" do
-      @s1.should be_an_instance_of(UNIXSocket)
-      @s2.should be_an_instance_of(UNIXSocket)
-    end
-
-    it "returns a pair of connected sockets" do
-      @s1.puts "foo"
-      @s2.gets.should == "foo\n"
-    end
-
-    it "sets the socket paths to empty Strings" do
-      @s1.path.should == ""
-      @s2.path.should == ""
-    end
-
-    it "sets the socket addresses to empty Strings" do
-      @s1.addr.should == ["AF_UNIX", ""]
-      @s2.addr.should == ["AF_UNIX", ""]
-    end
-
-    it "sets the socket peer addresses to empty Strings" do
-      @s1.peeraddr.should == ["AF_UNIX", ""]
-      @s2.peeraddr.should == ["AF_UNIX", ""]
     end
   end
 end

--- a/library/socket/unixsocket/shared/pair.rb
+++ b/library/socket/unixsocket/shared/pair.rb
@@ -1,0 +1,29 @@
+require_relative '../../spec_helper'
+require_relative '../../fixtures/classes'
+
+describe :unixsocket_pair, shared: true do
+    it "returns two UNIXSockets" do
+      @s1.should be_an_instance_of(UNIXSocket)
+      @s2.should be_an_instance_of(UNIXSocket)
+    end
+
+    it "returns a pair of connected sockets" do
+      @s1.puts "foo"
+      @s2.gets.should == "foo\n"
+    end
+
+    it "sets the socket paths to empty Strings" do
+      @s1.path.should == ""
+      @s2.path.should == ""
+    end
+
+    it "sets the socket addresses to empty Strings" do
+      @s1.addr.should == ["AF_UNIX", ""]
+      @s2.addr.should == ["AF_UNIX", ""]
+    end
+
+    it "sets the socket peer addresses to empty Strings" do
+      @s1.peeraddr.should == ["AF_UNIX", ""]
+      @s2.peeraddr.should == ["AF_UNIX", ""]
+    end
+end

--- a/library/socket/unixsocket/socketpair_spec.rb
+++ b/library/socket/unixsocket/socketpair_spec.rb
@@ -1,9 +1,11 @@
 require_relative '../spec_helper'
 require_relative '../fixtures/classes'
 require_relative '../shared/partially_closable_sockets'
+require_relative 'shared/pair'
 
 with_feature :unix_socket do
   describe "UNIXSocket.socketpair" do
+    it_should_behave_like :unixsocket_pair
     it_should_behave_like :partially_closable_sockets
 
     before :each do
@@ -13,31 +15,6 @@ with_feature :unix_socket do
     after :each do
       @s1.close
       @s2.close
-    end
-
-    it "returns two UNIXSockets" do
-      @s1.should be_an_instance_of(UNIXSocket)
-      @s2.should be_an_instance_of(UNIXSocket)
-    end
-
-    it "returns a pair of connected sockets" do
-      @s1.puts "foo"
-      @s2.gets.should == "foo\n"
-    end
-
-    it "sets the socket paths to empty Strings" do
-      @s1.path.should == ""
-      @s2.path.should == ""
-    end
-
-    it "sets the socket addresses to empty Strings" do
-      @s1.addr.should == ["AF_UNIX", ""]
-      @s2.addr.should == ["AF_UNIX", ""]
-    end
-
-    it "sets the socket peer addresses to empty Strings" do
-      @s1.peeraddr.should == ["AF_UNIX", ""]
-      @s2.peeraddr.should == ["AF_UNIX", ""]
     end
   end
 end

--- a/library/socket/unixsocket/socketpair_spec.rb
+++ b/library/socket/unixsocket/socketpair_spec.rb
@@ -1,40 +1,43 @@
 require_relative '../spec_helper'
+require_relative '../fixtures/classes'
+require_relative '../shared/partially_closable_sockets'
 
 with_feature :unix_socket do
-  describe 'UNIXSocket.socketpair' do
-    before do
+  describe "UNIXSocket.socketpair" do
+    it_should_behave_like :partially_closable_sockets
+
+    before :each do
       @s1, @s2 = UNIXSocket.socketpair
     end
 
-    after do
+    after :each do
       @s1.close
       @s2.close
     end
 
-    it 'returns two UNIXSockets' do
+    it "returns two UNIXSockets" do
       @s1.should be_an_instance_of(UNIXSocket)
       @s2.should be_an_instance_of(UNIXSocket)
     end
 
-    it 'connects the sockets to each other' do
-      @s1.write('hello')
-
-      @s2.recv(5).should == 'hello'
+    it "returns a pair of connected sockets" do
+      @s1.puts "foo"
+      @s2.gets.should == "foo\n"
     end
 
-    it 'sets the socket paths to empty Strings' do
-      @s1.path.should == ''
-      @s2.path.should == ''
+    it "sets the socket paths to empty Strings" do
+      @s1.path.should == ""
+      @s2.path.should == ""
     end
 
-    it 'sets the socket addresses to empty Strings' do
-      @s1.addr.should == ['AF_UNIX', '']
-      @s2.addr.should == ['AF_UNIX', '']
+    it "sets the socket addresses to empty Strings" do
+      @s1.addr.should == ["AF_UNIX", ""]
+      @s2.addr.should == ["AF_UNIX", ""]
     end
 
-    it 'sets the socket peer addresses to empty Strings' do
-      @s1.peeraddr.should == ['AF_UNIX', '']
-      @s2.peeraddr.should == ['AF_UNIX', '']
+    it "sets the socket peer addresses to empty Strings" do
+      @s1.peeraddr.should == ["AF_UNIX", ""]
+      @s2.peeraddr.should == ["AF_UNIX", ""]
     end
   end
 end


### PR DESCRIPTION
The methods are aliases, so we probably shouldn't have two separate specs hanging around.