### PR TITLE
Fix description of specs of Socket.pair and Socket.socketpair

### DIFF
--- a/library/socket/socket/pair_spec.rb
+++ b/library/socket/socket/pair_spec.rb
@@ -2,6 +2,6 @@ require_relative '../spec_helper'
 require_relative '../fixtures/classes'
 require_relative '../shared/socketpair'
 
-describe "Socket#pair" do
+describe "Socket.pair" do
   it_behaves_like :socket_socketpair, :pair
 end

--- a/library/socket/socket/socketpair_spec.rb
+++ b/library/socket/socket/socketpair_spec.rb
@@ -2,6 +2,6 @@ require_relative '../spec_helper'
 require_relative '../fixtures/classes'
 require_relative '../shared/socketpair'
 
-describe "Socket#socketpair" do
+describe "Socket.socketpair" do
   it_behaves_like :socket_socketpair, :socketpair
 end


### PR DESCRIPTION
These are class methods, not instance methods.