### PR TITLE
Use remove_const after specs which set constants

### DIFF
--- a/core/basicobject/singleton_method_added_spec.rb
+++ b/core/basicobject/singleton_method_added_spec.rb
@@ -96,6 +96,8 @@ describe "BasicObject#singleton_method_added" do
           end
         }.should raise_error(NoMethodError, /undefined method [`']singleton_method_added' for/)
       end
+    ensure
+      BasicObjectSpecs.send(:remove_const, :NoSingletonMethodAdded)
     end
 
     it "raises NoMethodError for a singleton instance" do

--- a/core/class/dup_spec.rb
+++ b/core/class/dup_spec.rb
@@ -59,6 +59,8 @@ describe "Class#dup" do
   it "stores the new name if assigned to a constant" do
     CoreClassSpecs::RecordCopy = CoreClassSpecs::Record.dup
     CoreClassSpecs::RecordCopy.name.should == "CoreClassSpecs::RecordCopy"
+  ensure
+    CoreClassSpecs.send(:remove_const, :RecordCopy)
   end
 
   it "raises TypeError if called on BasicObject" do

--- a/core/class/new_spec.rb
+++ b/core/class/new_spec.rb
@@ -83,6 +83,8 @@ describe "Class.new" do
     a = Class.new
     MyClass::NestedClass = a
     MyClass::NestedClass.name.should == "MyClass::NestedClass"
+  ensure
+    Object.send(:remove_const, :MyClass)
   end
 
   it "sets the new class' superclass to the given class" do

--- a/core/exception/errno_spec.rb
+++ b/core/exception/errno_spec.rb
@@ -29,6 +29,8 @@ describe "Errno::EMFILE" do
     ExceptionSpecs::EMFILESub = Class.new(Errno::EMFILE)
     exc = ExceptionSpecs::EMFILESub.new
     exc.should be_an_instance_of(ExceptionSpecs::EMFILESub)
+  ensure
+    ExceptionSpecs.send(:remove_const, :EMFILESub)
   end
 end
 

--- a/core/exception/system_call_error_spec.rb
+++ b/core/exception/system_call_error_spec.rb
@@ -16,6 +16,8 @@ describe "SystemCallError" do
     exc = ExceptionSpecs::SCESub.new
     ScratchPad.recorded.should equal(:initialize)
     exc.should be_an_instance_of(ExceptionSpecs::SCESub)
+  ensure
+    ExceptionSpecs.send(:remove_const, :SCESub)
   end
 end
 

--- a/core/kernel/eval_spec.rb
+++ b/core/kernel/eval_spec.rb
@@ -313,6 +313,8 @@ CODE
       eval(code)
       EvalSpecs.constants(false).should include(:"Vπ")
       EvalSpecs::Vπ.should == 3.14
+    ensure
+      EvalSpecs.send(:remove_const, :Vπ)
     end
 
     it "allows an emacs-style magic comment encoding" do
@@ -326,6 +328,8 @@ CODE
       eval(code)
       EvalSpecs.constants(false).should include(:"Vπemacs")
       EvalSpecs::Vπemacs.should == 3.14
+    ensure
+      EvalSpecs.send(:remove_const, :Vπemacs)
     end
 
     it "allows spaces before the magic encoding comment" do
@@ -339,6 +343,8 @@ CODE
       eval(code)
       EvalSpecs.constants(false).should include(:"Vπspaces")
       EvalSpecs::Vπspaces.should == 3.14
+    ensure
+      EvalSpecs.send(:remove_const, :Vπspaces)
     end
 
     it "allows a shebang line before the magic encoding comment" do
@@ -353,6 +359,8 @@ CODE
       eval(code)
       EvalSpecs.constants(false).should include(:"Vπshebang")
       EvalSpecs::Vπshebang.should == 3.14
+    ensure
+      EvalSpecs.send(:remove_const, :Vπshebang)
     end
 
     it "allows a shebang line and some spaces before the magic encoding comment" do
@@ -367,6 +375,8 @@ CODE
       eval(code)
       EvalSpecs.constants(false).should include(:"Vπshebang_spaces")
       EvalSpecs::Vπshebang_spaces.should == 3.14
+    ensure
+      EvalSpecs.send(:remove_const, :Vπshebang_spaces)
     end
 
     it "allows a magic encoding comment and a subsequent frozen_string_literal magic comment" do
@@ -385,6 +395,8 @@ CODE
       EvalSpecs::Vπstring.should == "frozen"
       EvalSpecs::Vπstring.encoding.should == Encoding::UTF_8
       EvalSpecs::Vπstring.frozen?.should == !frozen_string_default
+    ensure
+      EvalSpecs.send(:remove_const, :Vπstring)
     end
 
     it "allows a magic encoding comment and a frozen_string_literal magic comment on the same line in emacs style" do
@@ -400,6 +412,8 @@ CODE
       EvalSpecs::Vπsame_line.should == "frozen"
       EvalSpecs::Vπsame_line.encoding.should == Encoding::UTF_8
       EvalSpecs::Vπsame_line.frozen?.should be_true
+    ensure
+      EvalSpecs.send(:remove_const, :Vπsame_line)
     end
 
     it "ignores the magic encoding comment if it is after a frozen_string_literal magic comment" do
@@ -420,6 +434,8 @@ CODE
       value.should == "frozen"
       value.encoding.should == Encoding::BINARY
       value.frozen?.should == !frozen_string_default
+    ensure
+      EvalSpecs.send(:remove_const, binary_constant)
     end
 
     it "ignores the frozen_string_literal magic comment if it appears after a token and warns if $VERBOSE is true" do

--- a/core/module/const_defined_spec.rb
+++ b/core/module/const_defined_spec.rb
@@ -65,6 +65,8 @@ describe "Module#const_defined?" do
     str = "CS_CONSTλ".encode("euc-jp")
     ConstantSpecs.const_set str, 1
     ConstantSpecs.const_defined?(str).should be_true
+  ensure
+    ConstantSpecs.send(:remove_const, str)
   end
 
   it "returns false if the constant is not defined in the receiver, its superclass, or any included modules" do

--- a/core/module/const_get_spec.rb
+++ b/core/module/const_get_spec.rb
@@ -202,40 +202,60 @@ describe "Module#const_get" do
 
       ConstantSpecs::ContainerA::ChildA::CS_CONST301 = :const301_5
       ConstantSpecs::ContainerA::ChildA.const_get(:CS_CONST301).should == :const301_5
+    ensure
+      ConstantSpecs::ClassA.send(:remove_const, :CS_CONST301)
+      ConstantSpecs::ModuleA.send(:remove_const, :CS_CONST301)
+      ConstantSpecs::ParentA.send(:remove_const, :CS_CONST301)
+      ConstantSpecs::ContainerA::ChildA.send(:remove_const, :CS_CONST301)
     end
 
     it "searches a module included in the immediate class before the superclass" do
       ConstantSpecs::ParentB::CS_CONST302 = :const302_1
       ConstantSpecs::ModuleF::CS_CONST302 = :const302_2
       ConstantSpecs::ContainerB::ChildB.const_get(:CS_CONST302).should == :const302_2
+    ensure
+      ConstantSpecs::ParentB.send(:remove_const, :CS_CONST302)
+      ConstantSpecs::ModuleF.send(:remove_const, :CS_CONST302)
     end
 
     it "searches the superclass before a module included in the superclass" do
       ConstantSpecs::ModuleE::CS_CONST303 = :const303_1
       ConstantSpecs::ParentB::CS_CONST303 = :const303_2
       ConstantSpecs::ContainerB::ChildB.const_get(:CS_CONST303).should == :const303_2
+    ensure
+      ConstantSpecs::ModuleE.send(:remove_const, :CS_CONST303)
+      ConstantSpecs::ParentB.send(:remove_const, :CS_CONST303)
     end
 
     it "searches a module included in the superclass" do
       ConstantSpecs::ModuleA::CS_CONST304 = :const304_1
       ConstantSpecs::ModuleE::CS_CONST304 = :const304_2
       ConstantSpecs::ContainerB::ChildB.const_get(:CS_CONST304).should == :const304_2
+    ensure
+      ConstantSpecs::ModuleA.send(:remove_const, :CS_CONST304)
+      ConstantSpecs::ModuleE.send(:remove_const, :CS_CONST304)
     end
 
     it "searches the superclass chain" do
       ConstantSpecs::ModuleA::CS_CONST305 = :const305
       ConstantSpecs::ContainerB::ChildB.const_get(:CS_CONST305).should == :const305
+    ensure
+      ConstantSpecs::ModuleA.send(:remove_const, :CS_CONST305)
     end
 
     it "returns a toplevel constant when the receiver is a Class" do
       Object::CS_CONST306 = :const306
       ConstantSpecs::ContainerB::ChildB.const_get(:CS_CONST306).should == :const306
+    ensure
+      Object.send(:remove_const, :CS_CONST306)
     end
 
     it "returns a toplevel constant when the receiver is a Module" do
       Object::CS_CONST308 = :const308
       ConstantSpecs.const_get(:CS_CONST308).should == :const308
       ConstantSpecs::ModuleA.const_get(:CS_CONST308).should == :const308
+    ensure
+      Object.send(:remove_const, :CS_CONST308)
     end
 
     it "returns the updated value of a constant" do
@@ -246,6 +266,8 @@ describe "Module#const_get" do
         ConstantSpecs::ClassB::CS_CONST309 = :const309_2
       }.should complain(/already initialized constant/)
       ConstantSpecs::ClassB.const_get(:CS_CONST309).should == :const309_2
+    ensure
+      ConstantSpecs::ClassB.send(:remove_const, :CS_CONST309)
     end
   end
 end

--- a/core/module/const_set_spec.rb
+++ b/core/module/const_set_spec.rb
@@ -8,16 +8,23 @@ describe "Module#const_set" do
 
     ConstantSpecs.const_set "CS_CONST402", :const402
     ConstantSpecs.const_get(:CS_CONST402).should == :const402
+  ensure
+    ConstantSpecs.send(:remove_const, :CS_CONST401)
+    ConstantSpecs.send(:remove_const, :CS_CONST402)
   end
 
   it "returns the value set" do
     ConstantSpecs.const_set(:CS_CONST403, :const403).should == :const403
+  ensure
+    ConstantSpecs.send(:remove_const, :CS_CONST403)
   end
 
   it "sets the name of an anonymous module" do
     m = Module.new
     ConstantSpecs.const_set(:CS_CONST1000, m)
     m.name.should == "ConstantSpecs::CS_CONST1000"
+  ensure
+    ConstantSpecs.send(:remove_const, :CS_CONST1000)
   end
 
   it "sets the name of a module scoped by an anonymous module" do
@@ -38,6 +45,8 @@ describe "Module#const_set" do
     b.name.should == "ModuleSpecs_CS3::B"
     c.name.should == "ModuleSpecs_CS3::B::C"
     d.name.should == "ModuleSpecs_CS3::D"
+  ensure
+    Object.send(:remove_const, :ModuleSpecs_CS3)
   end
 
   it "raises a NameError if the name does not start with a capital letter" do
@@ -55,6 +64,8 @@ describe "Module#const_set" do
     ConstantSpecs.const_set("CS_CONST404", :const404).should == :const404
     -> { ConstantSpecs.const_set "Name=", 1 }.should raise_error(NameError)
     -> { ConstantSpecs.const_set "Name?", 1 }.should raise_error(NameError)
+  ensure
+    ConstantSpecs.send(:remove_const, :CS_CONST404)
   end
 
   it "calls #to_str to convert the given name to a String" do
@@ -62,6 +73,8 @@ describe "Module#const_set" do
     name.should_receive(:to_str).and_return("CS_CONST405")
     ConstantSpecs.const_set(name, :const405).should == :const405
     ConstantSpecs::CS_CONST405.should == :const405
+  ensure
+    ConstantSpecs.send(:remove_const, :CS_CONST405)
   end
 
   it "raises a TypeError if conversion to a String by calling #to_str fails" do

--- a/core/module/const_source_location_spec.rb
+++ b/core/module/const_source_location_spec.rb
@@ -19,40 +19,60 @@ describe "Module#const_source_location" do
 
       ConstantSpecs::ContainerA::ChildA::CSL_CONST301 = :const301_5
       ConstantSpecs::ContainerA::ChildA.const_source_location(:CSL_CONST301).should == [__FILE__, __LINE__ - 1]
+    ensure
+      ConstantSpecs::ClassA.send(:remove_const, :CSL_CONST301)
+      ConstantSpecs::ModuleA.send(:remove_const, :CSL_CONST301)
+      ConstantSpecs::ParentA.send(:remove_const, :CSL_CONST301)
+      ConstantSpecs::ContainerA::ChildA.send(:remove_const, :CSL_CONST301)
     end
 
     it "searches a path in a module included in the immediate class before the superclass" do
       ConstantSpecs::ParentB::CSL_CONST302 = :const302_1
       ConstantSpecs::ModuleF::CSL_CONST302 = :const302_2
       ConstantSpecs::ContainerB::ChildB.const_source_location(:CSL_CONST302).should == [__FILE__, __LINE__ - 1]
+    ensure
+      ConstantSpecs::ParentB.send(:remove_const, :CSL_CONST302)
+      ConstantSpecs::ModuleF.send(:remove_const, :CSL_CONST302)
     end
 
     it "searches a path in the superclass before a module included in the superclass" do
       ConstantSpecs::ModuleE::CSL_CONST303 = :const303_1
       ConstantSpecs::ParentB::CSL_CONST303 = :const303_2
       ConstantSpecs::ContainerB::ChildB.const_source_location(:CSL_CONST303).should == [__FILE__, __LINE__ - 1]
+    ensure
+      ConstantSpecs::ModuleE.send(:remove_const, :CSL_CONST303)
+      ConstantSpecs::ParentB.send(:remove_const, :CSL_CONST303)
     end
 
     it "searches a path in a module included in the superclass" do
       ConstantSpecs::ModuleA::CSL_CONST304 = :const304_1
       ConstantSpecs::ModuleE::CSL_CONST304 = :const304_2
       ConstantSpecs::ContainerB::ChildB.const_source_location(:CSL_CONST304).should == [__FILE__, __LINE__ - 1]
+    ensure
+      ConstantSpecs::ModuleA.send(:remove_const, :CSL_CONST304)
+      ConstantSpecs::ModuleE.send(:remove_const, :CSL_CONST304)
     end
 
     it "searches a path in the superclass chain" do
       ConstantSpecs::ModuleA::CSL_CONST305 = :const305
       ConstantSpecs::ContainerB::ChildB.const_source_location(:CSL_CONST305).should == [__FILE__, __LINE__ - 1]
+    ensure
+      ConstantSpecs::ModuleA.send(:remove_const, :CSL_CONST305)
     end
 
     it "returns path to a toplevel constant when the receiver is a Class" do
       Object::CSL_CONST306 = :const306
       ConstantSpecs::ContainerB::ChildB.const_source_location(:CSL_CONST306).should == [__FILE__, __LINE__ - 1]
+    ensure
+      Object.send(:remove_const, :CSL_CONST306)
     end
 
     it "returns path to a toplevel constant when the receiver is a Module" do
       Object::CSL_CONST308 = :const308
       ConstantSpecs.const_source_location(:CSL_CONST308).should == [__FILE__, __LINE__ - 1]
       ConstantSpecs::ModuleA.const_source_location(:CSL_CONST308).should == [__FILE__, __LINE__ - 2]
+    ensure
+      Object.send(:remove_const, :CSL_CONST308)
     end
 
     it "returns path to the updated value of a constant" do
@@ -63,6 +83,8 @@ describe "Module#const_source_location" do
         ConstantSpecs::ClassB::CSL_CONST309 = :const309_2
       }.should complain(/already initialized constant/)
       ConstantSpecs::ClassB.const_source_location(:CSL_CONST309).should == [__FILE__, __LINE__ - 2]
+    ensure
+      ConstantSpecs::ClassB.send(:remove_const, :CSL_CONST309)
     end
   end
 

--- a/core/module/define_method_spec.rb
+++ b/core/module/define_method_spec.rb
@@ -476,6 +476,9 @@ describe "Module#define_method" do
       ChildClass = Class.new(ParentClass) { define_method(:foo) { :baz } }
       ParentClass.send :define_method, :foo, ChildClass.instance_method(:foo)
     }.should raise_error(TypeError, /bind argument must be a subclass of ChildClass/)
+  ensure
+    Object.send(:remove_const, :ParentClass)
+    Object.send(:remove_const, :ChildClass)
   end
 
   it "raises a TypeError when an UnboundMethod from one class is defined on an unrelated class" do

--- a/core/module/include_spec.rb
+++ b/core/module/include_spec.rb
@@ -44,7 +44,11 @@ describe "Module#include" do
   end
 
   it "does not raise a TypeError when the argument is an instance of a subclass of Module" do
-    -> { ModuleSpecs::SubclassSpec.include(ModuleSpecs::Subclass.new) }.should_not raise_error(TypeError)
+    class ModuleSpecs::SubclassSpec::AClass
+    end
+    -> { ModuleSpecs::SubclassSpec::AClass.include(ModuleSpecs::Subclass.new) }.should_not raise_error(TypeError)
+  ensure
+    ModuleSpecs::SubclassSpec.send(:remove_const, :AClass)
   end
 
   ruby_version_is ""..."3.2" do
@@ -427,6 +431,8 @@ describe "Module#include" do
       M.const_set(:FOO, 'm')
       B.foo.should == 'm'
     end
+  ensure
+    ModuleSpecs.send(:remove_const, :ConstUpdated)
   end
 
   it "updates the constant when a module included after a call is later updated" do
@@ -453,6 +459,8 @@ describe "Module#include" do
       M.const_set(:FOO, 'm')
       B.foo.should == 'm'
     end
+  ensure
+    ModuleSpecs.send(:remove_const, :ConstLaterUpdated)
   end
 
   it "updates the constant when a module included in another module after a call is later updated" do
@@ -479,6 +487,8 @@ describe "Module#include" do
       M.const_set(:FOO, 'm')
       B.foo.should == 'm'
     end
+  ensure
+    ModuleSpecs.send(:remove_const, :ConstModuleLaterUpdated)
   end
 
   it "updates the constant when a nested included module is updated" do
@@ -507,6 +517,8 @@ describe "Module#include" do
       N.const_set(:FOO, 'n')
       B.foo.should == 'n'
     end
+  ensure
+    ModuleSpecs.send(:remove_const, :ConstUpdatedNestedIncludeUpdated)
   end
 
   it "updates the constant when a new module is included" do
@@ -531,6 +543,8 @@ describe "Module#include" do
       B.include(M)
       B.foo.should == 'm'
     end
+  ensure
+    ModuleSpecs.send(:remove_const, :ConstUpdatedNewInclude)
   end
 
   it "updates the constant when a new module with nested module is included" do
@@ -559,6 +573,8 @@ describe "Module#include" do
       B.include M
       B.foo.should == 'n'
     end
+  ensure
+    ModuleSpecs.send(:remove_const, :ConstUpdatedNestedIncluded)
   end
 
   it "overrides a previous super method call" do

--- a/core/module/name_spec.rb
+++ b/core/module/name_spec.rb
@@ -30,6 +30,8 @@ describe "Module#name" do
     m::N.name.should =~ /\A#<Module:0x\h+>::N\z/
     ModuleSpecs::Anonymous::WasAnnon = m::N
     m::N.name.should == "ModuleSpecs::Anonymous::WasAnnon"
+  ensure
+    ModuleSpecs::Anonymous.send(:remove_const, :WasAnnon)
   end
 
   it "may be the repeated in different module objects" do
@@ -76,12 +78,16 @@ describe "Module#name" do
     m = Module.new
     ModuleSpecs::Anonymous::A = m
     m.name.should == "ModuleSpecs::Anonymous::A"
+  ensure
+    ModuleSpecs::Anonymous.send(:remove_const, :A)
   end
 
   it "is set when assigning to a constant (constant path does not match outer module name)" do
     m = Module.new
     ModuleSpecs::Anonymous::SameChild::A = m
     m.name.should == "ModuleSpecs::Anonymous::Child::A"
+  ensure
+    ModuleSpecs::Anonymous::SameChild.send(:remove_const, :A)
   end
 
   it "is not modified when assigning to a new constant after it has been accessed" do
@@ -90,6 +96,9 @@ describe "Module#name" do
     m.name.should == "ModuleSpecs::Anonymous::B"
     ModuleSpecs::Anonymous::C = m
     m.name.should == "ModuleSpecs::Anonymous::B"
+  ensure
+    ModuleSpecs::Anonymous.send(:remove_const, :B)
+    ModuleSpecs::Anonymous.send(:remove_const, :C)
   end
 
   it "is not modified when assigned to a different anonymous module" do
@@ -125,6 +134,8 @@ describe "Module#name" do
     m::N = Module.new
     ModuleSpecs::Anonymous::E = m
     m::N.name.should == "ModuleSpecs::Anonymous::E::N"
+  ensure
+    ModuleSpecs::Anonymous.send(:remove_const, :E)
   end
 
   # https://bugs.ruby-lang.org/issues/19681
@@ -138,6 +149,8 @@ describe "Module#name" do
       "ModuleSpecs::Anonymous::StoredInMultiplePlaces::O"
     ]
     valid_names.should include(m::N.name) # You get one of the two, but you don't know which one.
+  ensure
+    ModuleSpecs::Anonymous.send(:remove_const, :StoredInMultiplePlaces)
   end
 
   ruby_version_is "3.2" do

--- a/core/module/prepend_spec.rb
+++ b/core/module/prepend_spec.rb
@@ -261,6 +261,8 @@ describe "Module#prepend" do
       B.prepend M
       B.foo.should == 'm'
     end
+  ensure
+    ModuleSpecs.send(:remove_const, :ConstUpdatePrepended)
   end
 
   it "updates the constant when a prepended module is updated" do
@@ -281,6 +283,8 @@ describe "Module#prepend" do
       M.const_set(:FOO, 'm')
       B.foo.should == 'm'
     end
+  ensure
+    ModuleSpecs.send(:remove_const, :ConstPrependedUpdated)
   end
 
   it "updates the constant when there is a base included constant and the prepended module overrides it" do
@@ -302,6 +306,8 @@ describe "Module#prepend" do
       A.prepend M
       A.foo.should == 'm'
     end
+  ensure
+    ModuleSpecs.send(:remove_const, :ConstIncludedPrependedOverride)
   end
 
   it "updates the constant when there is a base included constant and the prepended module is later updated" do
@@ -325,6 +331,8 @@ describe "Module#prepend" do
       M.const_set(:FOO, 'm')
       A.foo.should == 'm'
     end
+  ensure
+    ModuleSpecs.send(:remove_const, :ConstIncludedPrependedLaterUpdated)
   end
 
   it "updates the constant when a module prepended after a constant is later updated" do
@@ -348,6 +356,8 @@ describe "Module#prepend" do
       M.const_set(:FOO, 'm')
       B.foo.should == 'm'
     end
+  ensure
+    ModuleSpecs.send(:remove_const, :ConstUpdatedPrependedAfterLaterUpdated)
   end
 
   it "updates the constant when a module is prepended after another and the constant is defined later on that module" do
@@ -372,6 +382,8 @@ describe "Module#prepend" do
       N.const_set(:FOO, 'n')
       A.foo.should == 'n'
     end
+  ensure
+    ModuleSpecs.send(:remove_const, :ConstUpdatedPrependedAfterConstDefined)
   end
 
   it "updates the constant when a module is included in a prepended module and the constant is defined later" do
@@ -399,6 +411,8 @@ describe "Module#prepend" do
       N.const_set(:FOO, 'n')
       A.foo.should == 'n'
     end
+  ensure
+    ModuleSpecs.send(:remove_const, :ConstUpdatedIncludedInPrependedConstDefinedLater)
   end
 
   it "updates the constant when a new module with an included module is prepended" do
@@ -425,6 +439,8 @@ describe "Module#prepend" do
       B.prepend M
       B.foo.should == 'n'
     end
+  ensure
+    ModuleSpecs.send(:remove_const, :ConstUpdatedNewModuleIncludedPrepended)
   end
 
   it "raises a TypeError when the argument is not a Module" do
@@ -432,7 +448,11 @@ describe "Module#prepend" do
   end
 
   it "does not raise a TypeError when the argument is an instance of a subclass of Module" do
-    -> { ModuleSpecs::SubclassSpec.prepend(ModuleSpecs::Subclass.new) }.should_not raise_error(TypeError)
+    class ModuleSpecs::SubclassSpec::AClass
+    end
+    -> { ModuleSpecs::SubclassSpec::AClass.prepend(ModuleSpecs::Subclass.new) }.should_not raise_error(TypeError)
+  ensure
+    ModuleSpecs::SubclassSpec.send(:remove_const, :AClass)
   end
 
   ruby_version_is ""..."3.2" do

--- a/core/module/remove_const_spec.rb
+++ b/core/module/remove_const_spec.rb
@@ -101,5 +101,7 @@ describe "Module#remove_const" do
       A.send(:remove_const,:FOO)
       A.foo.should == 'm'
     end
+  ensure
+    ConstantSpecs.send(:remove_const, :RemovedConstantUpdate)
   end
 end

--- a/core/module/to_s_spec.rb
+++ b/core/module/to_s_spec.rb
@@ -51,6 +51,8 @@ describe "Module#to_s" do
 
     ModuleSpecs::RefinementInspect::R.name.should == 'ModuleSpecs::RefinementInspect::R'
     ModuleSpecs::RefinementInspect::R.to_s.should == '#<refinement:String@ModuleSpecs::RefinementInspect>'
+  ensure
+    ModuleSpecs.send(:remove_const, :RefinementInspect)
   end
 
   it 'does not call #inspect or #to_s for singleton classes' do

--- a/core/struct/new_spec.rb
+++ b/core/struct/new_spec.rb
@@ -6,6 +6,8 @@ describe "Struct.new" do
     struct = Struct.new('Animal', :name, :legs, :eyeballs)
     struct.should == Struct::Animal
     struct.name.should == "Struct::Animal"
+  ensure
+    Struct.send(:remove_const, :Animal)
   end
 
   it "overwrites previously defined constants with string as first argument" do
@@ -19,6 +21,8 @@ describe "Struct.new" do
     second.should == Struct::Person
 
     first.members.should_not == second.members
+  ensure
+    Struct.send(:remove_const, :Person)
   end
 
   it "calls to_str on its first argument (constant name)" do
@@ -27,6 +31,8 @@ describe "Struct.new" do
     struct = Struct.new(obj)
     struct.should == Struct::Foo
     struct.name.should == "Struct::Foo"
+  ensure
+    Struct.send(:remove_const, :Foo)
   end
 
   it "creates a new anonymous class with nil first argument" do
@@ -138,6 +144,8 @@ describe "Struct.new" do
     it "creates a constant in subclass' namespace" do
       struct = StructClasses::Apple.new('Computer', :size)
       struct.should == StructClasses::Apple::Computer
+    ensure
+      StructClasses::Apple.send(:remove_const, :Computer)
     end
 
     it "creates an instance" do

--- a/language/class_spec.rb
+++ b/language/class_spec.rb
@@ -271,6 +271,8 @@ describe "A class definition" do
 
       AnonWithConstant.name.should == 'AnonWithConstant'
       klass.get_class_name.should == 'AnonWithConstant'
+    ensure
+      Object.send(:remove_const, :AnonWithConstant)
     end
   end
 end

--- a/language/constants_spec.rb
+++ b/language/constants_spec.rb
@@ -72,39 +72,60 @@ describe "Literal (A::X) constant resolution" do
 
       ConstantSpecs::ModuleA::CS_CONST101 = :const101_5
       ConstantSpecs::ModuleA::CS_CONST101.should == :const101_5
+    ensure
+      ConstantSpecs::ClassB.send(:remove_const, :CS_CONST101)
+      ConstantSpecs::ParentB.send(:remove_const, :CS_CONST101)
+      ConstantSpecs::ContainerB.send(:remove_const, :CS_CONST101)
+      ConstantSpecs::ContainerB::ChildB.send(:remove_const, :CS_CONST101)
+      ConstantSpecs::ModuleA.send(:remove_const, :CS_CONST101)
     end
 
     it "searches a module included in the immediate class before the superclass" do
       ConstantSpecs::ParentB::CS_CONST102 = :const102_1
       ConstantSpecs::ModuleF::CS_CONST102 = :const102_2
       ConstantSpecs::ContainerB::ChildB::CS_CONST102.should == :const102_2
+    ensure
+      ConstantSpecs::ParentB.send(:remove_const, :CS_CONST102)
+      ConstantSpecs::ModuleF.send(:remove_const, :CS_CONST102)
     end
 
     it "searches the superclass before a module included in the superclass" do
       ConstantSpecs::ModuleE::CS_CONST103 = :const103_1
       ConstantSpecs::ParentB::CS_CONST103 = :const103_2
       ConstantSpecs::ContainerB::ChildB::CS_CONST103.should == :const103_2
+    ensure
+      ConstantSpecs::ModuleE.send(:remove_const, :CS_CONST103)
+      ConstantSpecs::ParentB.send(:remove_const, :CS_CONST103)
     end
 
     it "searches a module included in the superclass" do
       ConstantSpecs::ModuleA::CS_CONST104 = :const104_1
       ConstantSpecs::ModuleE::CS_CONST104 = :const104_2
       ConstantSpecs::ContainerB::ChildB::CS_CONST104.should == :const104_2
+    ensure
+      ConstantSpecs::ModuleA.send(:remove_const, :CS_CONST104)
+      ConstantSpecs::ModuleE.send(:remove_const, :CS_CONST104)
     end
 
     it "searches the superclass chain" do
       ConstantSpecs::ModuleA::CS_CONST105 = :const105
       ConstantSpecs::ContainerB::ChildB::CS_CONST105.should == :const105
+    ensure
+      ConstantSpecs::ModuleA.send(:remove_const, :CS_CONST105)
     end
 
     it "searches Object if no class or module qualifier is given" do
       CS_CONST106 = :const106
       CS_CONST106.should == :const106
+    ensure
+      Object.send(:remove_const, :CS_CONST106)
     end
 
     it "searches Object if a toplevel qualifier (::X) is given" do
       ::CS_CONST107 = :const107
       ::CS_CONST107.should == :const107
+    ensure
+      Object.send(:remove_const, :CS_CONST107)
     end
 
     it "does not search the singleton class of the class or module" do
@@ -123,6 +144,9 @@ describe "Literal (A::X) constant resolution" do
       end
 
       -> { ConstantSpecs::CS_CONST108 }.should raise_error(NameError)
+    ensure
+      ConstantSpecs::ContainerB::ChildB.singleton_class.send(:remove_const, :CS_CONST108)
+      ConstantSpecs.singleton_class.send(:remove_const, :CS_CONST108)
     end
 
     it "returns the updated value when a constant is reassigned" do
@@ -133,6 +157,8 @@ describe "Literal (A::X) constant resolution" do
         ConstantSpecs::ClassB::CS_CONST109 = :const109_2
       }.should complain(/already initialized constant/)
       ConstantSpecs::ClassB::CS_CONST109.should == :const109_2
+    ensure
+      ConstantSpecs::ClassB.send(:remove_const, :CS_CONST109)
     end
 
     ruby_version_is "3.2" do
@@ -292,6 +318,12 @@ describe "Constant resolution within methods" do
       ConstantSpecs::ClassB.new.const201.should == :const201_2
       ConstantSpecs::ParentB.new.const201.should == :const201_3
       ConstantSpecs::ContainerB::ChildB.new.const201.should == :const201_5
+    ensure
+      ConstantSpecs::ModuleA.send(:remove_const, :CS_CONST201)
+      ConstantSpecs::ClassB.send(:remove_const, :CS_CONST201)
+      ConstantSpecs::ParentB.send(:remove_const, :CS_CONST201)
+      ConstantSpecs::ContainerB.send(:remove_const, :CS_CONST201)
+      ConstantSpecs::ContainerB::ChildB.send(:remove_const, :CS_CONST201)
     end
 
     it "searches a module included in the immediate class before the superclass" do
@@ -300,6 +332,9 @@ describe "Constant resolution within methods" do
 
       ConstantSpecs::ContainerB::ChildB.const202.should == :const202_1
       ConstantSpecs::ContainerB::ChildB.new.const202.should == :const202_1
+    ensure
+      ConstantSpecs::ParentB.send(:remove_const, :CS_CONST202)
+      ConstantSpecs::ContainerB::ChildB.send(:remove_const, :CS_CONST202)
     end
 
     it "searches the superclass before a module included in the superclass" do
@@ -308,6 +343,9 @@ describe "Constant resolution within methods" do
 
       ConstantSpecs::ContainerB::ChildB.const203.should == :const203_1
       ConstantSpecs::ContainerB::ChildB.new.const203.should == :const203_1
+    ensure
+      ConstantSpecs::ParentB.send(:remove_const, :CS_CONST203)
+      ConstantSpecs::ModuleE.send(:remove_const, :CS_CONST203)
     end
 
     it "searches a module included in the superclass" do
@@ -316,6 +354,9 @@ describe "Constant resolution within methods" do
 
       ConstantSpecs::ContainerB::ChildB.const204.should == :const204_1
       ConstantSpecs::ContainerB::ChildB.new.const204.should == :const204_1
+    ensure
+      ConstantSpecs::ModuleA.send(:remove_const, :CS_CONST204)
+      ConstantSpecs::ModuleE.send(:remove_const, :CS_CONST204)
     end
 
     it "searches the superclass chain" do
@@ -323,6 +364,8 @@ describe "Constant resolution within methods" do
 
       ConstantSpecs::ContainerB::ChildB.const205.should == :const205
       ConstantSpecs::ContainerB::ChildB.new.const205.should == :const205
+    ensure
+      ConstantSpecs::ModuleA.send(:remove_const, :CS_CONST205)
     end
 
     it "searches the lexical scope of the method not the receiver's immediate class" do
@@ -334,6 +377,9 @@ describe "Constant resolution within methods" do
       end
 
       ConstantSpecs::ContainerB::ChildB.const206.should == :const206_1
+    ensure
+      ConstantSpecs::ContainerB::ChildB.send(:remove_const, :CS_CONST206)
+      ConstantSpecs::ContainerB::ChildB.singleton_class.send(:remove_const, :CS_CONST206)
     end
 
     it "searches the lexical scope of a singleton method" do
@@ -341,12 +387,17 @@ describe "Constant resolution within methods" do
       ConstantSpecs::ClassB::CS_CONST207 = :const207_2
 
       ConstantSpecs::CS_CONST208.const207.should == :const207_1
+    ensure
+      ConstantSpecs.send(:remove_const, :CS_CONST207)
+      ConstantSpecs::ClassB.send(:remove_const, :CS_CONST207)
     end
 
     it "does not search the lexical scope of the caller" do
       ConstantSpecs::ClassB::CS_CONST209 = :const209
 
       -> { ConstantSpecs::ClassB.const209 }.should raise_error(NameError)
+    ensure
+      ConstantSpecs::ClassB.send(:remove_const, :CS_CONST209)
     end
 
     it "searches the lexical scope of a block" do
@@ -354,6 +405,9 @@ describe "Constant resolution within methods" do
       ConstantSpecs::ParentB::CS_CONST210 = :const210_2
 
       ConstantSpecs::ClassB.const210.should == :const210_1
+    ensure
+      ConstantSpecs::ClassB.send(:remove_const, :CS_CONST210)
+      ConstantSpecs::ParentB.send(:remove_const, :CS_CONST210)
     end
 
     it "searches Object as a lexical scope only if Object is explicitly opened" do
@@ -364,6 +418,11 @@ describe "Constant resolution within methods" do
       Object::CS_CONST212 = :const212_2
       ConstantSpecs::ParentB::CS_CONST212 = :const212_1
       ConstantSpecs::ContainerB::ChildB.const212.should == :const212_1
+    ensure
+      Object.send(:remove_const, :CS_CONST211)
+      ConstantSpecs::ParentB.send(:remove_const, :CS_CONST211)
+      Object.send(:remove_const, :CS_CONST212)
+      ConstantSpecs::ParentB.send(:remove_const, :CS_CONST212)
     end
 
     it "returns the updated value when a constant is reassigned" do
@@ -376,6 +435,8 @@ describe "Constant resolution within methods" do
       }.should complain(/already initialized constant/)
       ConstantSpecs::ContainerB::ChildB.const213.should == :const213_2
       ConstantSpecs::ContainerB::ChildB.new.const213.should == :const213_2
+    ensure
+      ConstantSpecs::ParentB.send(:remove_const, :CS_CONST213)
     end
 
     it "does not search the lexical scope of qualifying modules" do
@@ -384,6 +445,8 @@ describe "Constant resolution within methods" do
       -> do
         ConstantSpecs::ContainerB::ChildB.const214
       end.should raise_error(NameError)
+    ensure
+      ConstantSpecs::ContainerB.send(:remove_const, :CS_CONST214)
     end
   end
 
@@ -484,6 +547,10 @@ describe "Module#private_constant marked constants" do
 
         PrivateModule::X.should == 1
       end
+    ensure
+      module ::ConstantVisibility::ModuleContainer
+        PrivateModule.send(:remove_const, :X)
+      end
     end
 
     it "can be reopened as a class where constant is not private" do
@@ -493,6 +560,10 @@ describe "Module#private_constant marked constants" do
         end
 
         PrivateClass::X.should == 1
+      end
+    ensure
+      module ::ConstantVisibility::ModuleContainer
+        PrivateClass.send(:remove_const, :X)
       end
     end
 
@@ -565,6 +636,10 @@ describe "Module#private_constant marked constants" do
 
         PrivateModule::X.should == 1
       end
+    ensure
+      class ::ConstantVisibility::ClassContainer
+        PrivateModule.send(:remove_const, :X)
+      end
     end
 
     it "can be reopened as a class where constant is not private" do
@@ -574,6 +649,10 @@ describe "Module#private_constant marked constants" do
         end
 
         PrivateClass::X.should == 1
+      end
+    ensure
+      class ::ConstantVisibility::ClassContainer
+        PrivateClass.send(:remove_const, :X)
       end
     end
 

--- a/language/def_spec.rb
+++ b/language/def_spec.rb
@@ -524,6 +524,8 @@ describe "A nested method definition" do
 
     obj = DefSpecNested.new
     obj.inherited_method.should == obj
+  ensure
+    DefSpecNested.send(:remove_const, :TARGET)
   end
 
   # See http://yugui.jp/articles/846#label-3
@@ -545,6 +547,8 @@ describe "A nested method definition" do
 
     DefSpecNested.should_not have_instance_method :arg_method
     DefSpecNested.should_not have_instance_method :body_method
+  ensure
+    DefSpecNested.send(:remove_const, :OBJ)
   end
 
   it "creates an instance method inside Class.new" do

--- a/language/module_spec.rb
+++ b/language/module_spec.rb
@@ -26,12 +26,16 @@ describe "The module keyword" do
   it "reopens an existing module" do
     module ModuleSpecs; Reopened = true; end
     ModuleSpecs::Reopened.should be_true
+  ensure
+    ModuleSpecs.send(:remove_const, :Reopened)
   end
 
   ruby_version_is '3.2' do
     it "does not reopen a module included in Object" do
       module IncludedModuleSpecs; Reopened = true; end
       ModuleSpecs::IncludedInObject::IncludedModuleSpecs.should_not == Object::IncludedModuleSpecs
+    ensure
+      IncludedModuleSpecs.send(:remove_const, :Reopened)
     end
   end
 
@@ -76,6 +80,8 @@ describe "Assigning an anonymous module to a constant" do
 
     ::ModuleSpecs_CS1 = mod
     mod.name.should == "ModuleSpecs_CS1"
+  ensure
+    Object.send(:remove_const, :ModuleSpecs_CS1)
   end
 
   it "sets the name of a module scoped by an anonymous module" do
@@ -96,5 +102,7 @@ describe "Assigning an anonymous module to a constant" do
     b.name.should == "ModuleSpecs_CS2::B"
     c.name.should == "ModuleSpecs_CS2::B::C"
     d.name.should == "ModuleSpecs_CS2::D"
+  ensure
+    Object.send(:remove_const, :ModuleSpecs_CS2)
   end
 end

--- a/language/optional_assignments_spec.rb
+++ b/language/optional_assignments_spec.rb
@@ -698,6 +698,8 @@ describe 'Optional constant assignment' do
       x.should == 1
       y.should == 0
       ConstantSpecs::ClassA::NIL_OR_ASSIGNED_CONSTANT3.should == nil
+    ensure
+      ConstantSpecs::ClassA.send(:remove_const, :NIL_OR_ASSIGNED_CONSTANT3)
     end
   end
 

--- a/language/variables_spec.rb
+++ b/language/variables_spec.rb
@@ -346,6 +346,9 @@ describe "Multiple assignment" do
         SINGLE_RHS_1, SINGLE_RHS_2 = 1
         [SINGLE_RHS_1, SINGLE_RHS_2].should == [1, nil]
       end
+    ensure
+      VariableSpecs.send(:remove_const, :SINGLE_RHS_1)
+      VariableSpecs.send(:remove_const, :SINGLE_RHS_2)
     end
   end
 
@@ -584,6 +587,8 @@ describe "Multiple assignment" do
         (*SINGLE_SPLATTED_RHS) = *1
         SINGLE_SPLATTED_RHS.should == [1]
       end
+    ensure
+      VariableSpecs.send(:remove_const, :SINGLE_SPLATTED_RHS)
     end
   end
 
@@ -783,6 +788,9 @@ describe "Multiple assignment" do
         MRHS_VALUES_1.should == 1
         MRHS_VALUES_2.should == 2
       end
+    ensure
+      VariableSpecs.send(:remove_const, :MRHS_VALUES_1)
+      VariableSpecs.send(:remove_const, :MRHS_VALUES_2)
     end
 
     it "assigns all RHS values as an array to a single LHS constant" do
@@ -790,6 +798,8 @@ describe "Multiple assignment" do
         MRHS_VALUES = 1, 2, 3
         MRHS_VALUES.should == [1, 2, 3]
       end
+    ensure
+      VariableSpecs.send(:remove_const, :MRHS_VALUES)
     end
   end
 

--- a/library/erb/def_class_spec.rb
+++ b/library/erb/def_class_spec.rb
@@ -24,6 +24,8 @@ END
     MyClass1ForErb = erb.def_class(MyClass1ForErb_, 'render()')
     MyClass1ForErb.method_defined?(:render).should == true
     MyClass1ForErb.new('foo', 123).render().should == expected
+  ensure
+    Object.send(:remove_const, :MyClass1ForErb)
   end
 
 end

--- a/library/erb/def_module_spec.rb
+++ b/library/erb/def_module_spec.rb
@@ -22,6 +22,9 @@ END
       include MyModule2ForErb
     end
     MyClass2ForErb.new.render('foo', 123).should == expected
+  ensure
+    Object.send(:remove_const, :MyClass2ForErb)
+    Object.send(:remove_const, :MyModule2ForErb)
   end
 
 end

--- a/library/erb/defmethod/def_erb_method_spec.rb
+++ b/library/erb/defmethod/def_erb_method_spec.rb
@@ -58,6 +58,8 @@ END
       end
     end
     MyClass4ForErb.new([10,20,30]).render().should == expected
+  ensure
+    Object.send(:remove_const, :MY_INPUT4_FOR_ERB)
   end
 
 

--- a/library/yaml/to_yaml_spec.rb
+++ b/library/yaml/to_yaml_spec.rb
@@ -65,6 +65,8 @@ describe "Object#to_yaml" do
   it "returns the YAML representation of a Struct object" do
     Person = Struct.new(:name, :gender)
     Person.new("Jane", "female").to_yaml.should match_yaml("--- !ruby/struct:Person\nname: Jane\ngender: female\n")
+  ensure
+    Object.send(:remove_const, :Person)
   end
 
   it "returns the YAML representation of an unnamed Struct object" do

--- a/optional/capi/class_spec.rb
+++ b/optional/capi/class_spec.rb
@@ -365,6 +365,8 @@ describe "C-API Class function" do
                                         "ClassUnder6",
                                         Class.new)
       }.should raise_error(TypeError)
+    ensure
+      CApiClassSpecs.send(:remove_const, :ClassUnder6)
     end
 
     it "defines a class for an existing Autoload" do

--- a/optional/capi/module_spec.rb
+++ b/optional/capi/module_spec.rb
@@ -22,6 +22,8 @@ describe "CApiModule" do
     it "sets a new constant on a module" do
       @m.rb_const_set(CApiModuleSpecs::C, :W, 7)
       CApiModuleSpecs::C::W.should == 7
+    ensure
+      CApiModuleSpecs::C.send(:remove_const, :W)
     end
 
     it "sets an existing constant's value" do
@@ -93,6 +95,8 @@ describe "CApiModule" do
     it "defines a new constant on a module" do
       @m.rb_define_const(CApiModuleSpecs::C, "V", 7)
       CApiModuleSpecs::C::V.should == 7
+    ensure
+      CApiModuleSpecs::C.send(:remove_const, :V)
     end
 
     it "sets an existing constant's value" do


### PR DESCRIPTION
So I'm making a tool which runs specs many times, and specs that set consts seems to often not cleanup after themselves. This makes the repeat have annoying warnings about already defined consts.

Those constants existing between specs also seems like something that could create an interaction between them.

So I added the remove_const calls that make sense to avoid all of these warnings. Good news, no tests relied on that!