### PR TITLE
Don't assume that Qfalse is 0 in rb_special_const_p

### DIFF
--- a/optional/capi/ext/object_spec.c
+++ b/optional/capi/ext/object_spec.c
@@ -179,11 +179,7 @@ static VALUE object_spec_rb_method_boundp(VALUE self, VALUE obj, VALUE method, V
 }
 
 static VALUE object_spec_rb_special_const_p(VALUE self, VALUE value) {
-  if (rb_special_const_p(value)) {
-    return Qtrue;
-  } else {
-    return Qfalse;
-  }
+  return rb_special_const_p(value);
 }
 
 static VALUE so_to_id(VALUE self, VALUE obj) {


### PR DESCRIPTION
rb_special_const_p returns a VALUE (Qtrue or Qfalse), so can directly return the value and we shouldn't assume that Qfalse is 0.