### PR TITLE
Remove senseless spec.

### DIFF
--- a/core/enumerator/product/size_spec.rb
+++ b/core/enumerator/product/size_spec.rb
@@ -23,14 +23,6 @@ ruby_version_is "3.2" do
       product.size.should == Float::INFINITY
     end
 
-    it "returns -Float::INFINITY if any enumerable reports its size as -Float::INFINITY" do
-      enum = Object.new
-      def enum.size; -Float::INFINITY; end
-
-      product = Enumerator::Product.new(1..2, enum)
-      product.size.should == -Float::INFINITY
-    end
-
     it "returns nil if any enumerable reports its size as Float::NAN" do
       enum = Object.new
       def enum.size; Float::NAN; end


### PR DESCRIPTION
A negative `size` makes no sense at all, -infinity even less so. It is indeed the case that Ruby currently returns `-infinity` (even if you take the product of two of these senseless enumerables), but that doesn't make it a _valid spec_. Ruby does this because it is simpler to test for ±infinity than it is to test for +infinity... 

Other alternative implementations should _not_ attempt to mimick such behaviour.

One could argue it is a bug (and `nil` should be returned maybe, but that would be the case for any negative `size`), or that the current result is acceptable because  "garbage in garbage out", but nobody in their right mind would rely on this behavior and clearly returning `nil` or raising an exception are better results than returning - infinity.

This PR leaves this uninteresting and ill-defined corner case as implementation dependent.

Ref: https://github.com/marcandre/backports/pull/192