### PR TITLE
Improve irb_spec's home setup

### DIFF
--- a/core/binding/irb_spec.rb
+++ b/core/binding/irb_spec.rb
@@ -1,11 +1,19 @@
 require_relative '../../spec_helper'
 
 describe "Binding#irb" do
+  before :each do
+    @env_home = ENV["HOME"]
+    ENV["HOME"] = CODE_LOADING_DIR
+  end
+
+  after :each do
+    ENV["HOME"] = @env_home
+  end
+
   it "creates an IRB session with the binding in scope" do
     irb_fixture = fixture __FILE__, "irb.rb"
-    irbrc_fixture = fixture __FILE__, "irbrc"
 
-    out = IO.popen([{"IRBRC"=>irbrc_fixture}, *ruby_exe, irb_fixture], "r+") do |pipe|
+    out = IO.popen([*ruby_exe, irb_fixture], "r+") do |pipe|
       pipe.puts "a ** 2"
       pipe.puts "exit"
       pipe.readlines.map(&:chomp)


### PR DESCRIPTION
Before v1.12, IRB avoids loading `~/.irbrc` if the project folder has a `.irbrc` file. So to avoid loading dev's `~/.irbrc`, cfe908c added an empty irbrc fixture as a workaround.

However, because IRB v1.12 starts loading `~/.irbrc` even if the project folder has a `.irbrc` file, the workaround no longer works.

This commit removes the workaround and uses altering `HOME` environment variable to avoid loading `.irbrc` from devs' home directory instead.