### PR TITLE
Make the spec suite compatible with `--enable-frozen-string-literal`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ jobs:
       matrix:
         os: [ ubuntu, macos, windows ]
         ruby: [ 3.0.6, 3.1.4, 3.2.2, 3.3.0 ]
+        rubyopt: [""]
+        include:
+          - os: ubuntu
+            ruby: 3.3.0
+            rubyopt: "--enable-frozen-string-literal"
+
     runs-on: ${{ matrix.os }}-latest
     steps:
     - name: git config autocrlf
@@ -28,6 +34,7 @@ jobs:
       if: matrix.os == 'ubuntu'
       env:
         CHECK_LEAKS: true
+        RUBYOPT: "${{ matrix.rubyopt }}"
       run: ../mspec/bin/mspec -j --timeout 30
 
     - name: Run specs (macOS)

--- a/core/argf/readpartial_spec.rb
+++ b/core/argf/readpartial_spec.rb
@@ -29,7 +29,7 @@ describe "ARGF.readpartial" do
 
   it "clears output buffer even if EOFError is raised because @argf is at end" do
     begin
-      output = "to be cleared"
+      output = +"to be cleared"
 
       argf [@file1_name] do
         @argf.read

--- a/core/argf/shared/getc.rb
+++ b/core/argf/shared/getc.rb
@@ -9,7 +9,7 @@ describe :argf_getc, shared: true do
 
   it "reads each char of files" do
     argf [@file1, @file2] do
-      chars = ""
+      chars = +""
       @chars.size.times { chars << @argf.send(@method) }
       chars.should == @chars
     end

--- a/core/argf/shared/read.rb
+++ b/core/argf/shared/read.rb
@@ -15,7 +15,7 @@ describe :argf_read, shared: true do
 
   it "treats second argument as an output buffer" do
     argf [@file1_name] do
-      buffer = ""
+      buffer = +""
       @argf.send(@method, @file1.size, buffer)
       buffer.should == @file1
     end
@@ -23,7 +23,7 @@ describe :argf_read, shared: true do
 
   it "clears output buffer before appending to it" do
     argf [@file1_name] do
-      buffer = "to be cleared"
+      buffer = +"to be cleared"
       @argf.send(@method, @file1.size, buffer)
       buffer.should == @file1
     end

--- a/core/array/fill_spec.rb
+++ b/core/array/fill_spec.rb
@@ -21,7 +21,7 @@ describe "Array#fill" do
 
   it "does not replicate the filler" do
     ary = [1, 2, 3, 4]
-    str = "x"
+    str = +"x"
     ary.fill(str).should == [str, str, str, str]
     str << "y"
     ary.should == [str, str, str, str]

--- a/core/array/fixtures/encoded_strings.rb
+++ b/core/array/fixtures/encoded_strings.rb
@@ -2,14 +2,14 @@
 module ArraySpecs
   def self.array_with_usascii_and_7bit_utf8_strings
     [
-      'foo'.force_encoding('US-ASCII'),
+      'foo'.dup.force_encoding('US-ASCII'),
       'bar'
     ]
   end
 
   def self.array_with_usascii_and_utf8_strings
     [
-      'foo'.force_encoding('US-ASCII'),
+      'foo'.dup.force_encoding('US-ASCII'),
       'báz'
     ]
   end
@@ -17,7 +17,7 @@ module ArraySpecs
   def self.array_with_7bit_utf8_and_usascii_strings
     [
       'bar',
-      'foo'.force_encoding('US-ASCII')
+      'foo'.dup.force_encoding('US-ASCII')
     ]
   end
 
@@ -25,13 +25,13 @@ module ArraySpecs
     [
       'báz',
       'bar',
-      'foo'.force_encoding('US-ASCII')
+      'foo'.dup.force_encoding('US-ASCII')
     ]
   end
 
   def self.array_with_usascii_and_utf8_strings
     [
-      'foo'.force_encoding('US-ASCII'),
+      'foo'.dup.force_encoding('US-ASCII'),
       'bar',
       'báz'
     ]
@@ -41,7 +41,7 @@ module ArraySpecs
     [
       'bar',
       'báz',
-      'foo'.force_encoding('BINARY')
+      'foo'.dup.force_encoding('BINARY')
     ]
   end
 
@@ -55,14 +55,14 @@ module ArraySpecs
 
   def self.array_with_usascii_and_7bit_binary_strings
     [
-      'bar'.force_encoding('US-ASCII'),
-      'foo'.force_encoding('BINARY')
+      'bar'.dup.force_encoding('US-ASCII'),
+      'foo'.dup.force_encoding('BINARY')
     ]
   end
 
   def self.array_with_usascii_and_binary_strings
     [
-      'bar'.force_encoding('US-ASCII'),
+      'bar'.dup.force_encoding('US-ASCII'),
       [255].pack('C').force_encoding('BINARY')
     ]
   end

--- a/core/array/pack/buffer_spec.rb
+++ b/core/array/pack/buffer_spec.rb
@@ -13,13 +13,13 @@ describe "Array#pack with :buffer option" do
   it "adds result at the end of buffer content" do
     n = [ 65, 66, 67 ] # result without buffer is "ABC"
 
-    buffer = ""
+    buffer = +""
     n.pack("ccc", buffer: buffer).should == "ABC"
 
-    buffer = "123"
+    buffer = +"123"
     n.pack("ccc", buffer: buffer).should == "123ABC"
 
-    buffer = "12345"
+    buffer = +"12345"
     n.pack("ccc", buffer: buffer).should == "12345ABC"
   end
 
@@ -31,19 +31,19 @@ describe "Array#pack with :buffer option" do
   context "offset (@) is specified" do
     it 'keeps buffer content if it is longer than offset' do
       n = [ 65, 66, 67 ]
-      buffer = "123456"
+      buffer = +"123456"
       n.pack("@3ccc", buffer: buffer).should == "123ABC"
     end
 
     it "fills the gap with \\0 if buffer content is shorter than offset" do
       n = [ 65, 66, 67 ]
-      buffer = "123"
+      buffer = +"123"
       n.pack("@6ccc", buffer: buffer).should == "123\0\0\0ABC"
     end
 
     it 'does not keep buffer content if it is longer than offset + result' do
       n = [ 65, 66, 67 ]
-      buffer = "1234567890"
+      buffer = +"1234567890"
       n.pack("@3ccc", buffer: buffer).should == "123ABC"
     end
   end

--- a/core/array/pack/shared/string.rb
+++ b/core/array/pack/shared/string.rb
@@ -40,7 +40,7 @@ describe :array_pack_string, shared: true do
     f = pack_format("*")
     [ [["\u{3042 3044 3046 3048}", 0x2000B].pack(f+"U"),       Encoding::BINARY],
       [["abcde\xd1", "\xFF\xFe\x81\x82"].pack(f+"u"),          Encoding::BINARY],
-      [["a".force_encoding("ascii"), "\xFF\xFe\x81\x82"].pack(f+"u"), Encoding::BINARY],
+      [["a".dup.force_encoding("ascii"), "\xFF\xFe\x81\x82"].pack(f+"u"), Encoding::BINARY],
       # under discussion [ruby-dev:37294]
       [["\u{3042 3044 3046 3048}", 1].pack(f+"N"),             Encoding::BINARY]
     ].should be_computed_by(:encoding)

--- a/core/array/shared/inspect.rb
+++ b/core/array/shared/inspect.rb
@@ -19,7 +19,7 @@ describe :array_inspect, shared: true do
   end
 
   it "does not call #to_s on a String returned from #inspect" do
-    str = "abc"
+    str = +"abc"
     str.should_not_receive(:to_s)
 
     [str].send(@method).should == '["abc"]'
@@ -98,8 +98,8 @@ describe :array_inspect, shared: true do
     end
 
     it "does not raise if inspected result is not default external encoding" do
-      utf_16be = mock("utf_16be")
-      utf_16be.should_receive(:inspect).and_return(%<"utf_16be \u3042">.encode!(Encoding::UTF_16BE))
+      utf_16be = mock(+"utf_16be")
+      utf_16be.should_receive(:inspect).and_return(%<"utf_16be \u3042">.encode(Encoding::UTF_16BE))
 
       [utf_16be].send(@method).should == '["utf_16be \u3042"]'
     end

--- a/core/complex/inspect_spec.rb
+++ b/core/complex/inspect_spec.rb
@@ -17,7 +17,8 @@ describe "Complex#inspect" do
 
   it "calls #inspect on real and imaginary" do
     real = NumericSpecs::Subclass.new
-    real.should_receive(:inspect).and_return("1")
+    # + because of https://bugs.ruby-lang.org/issues/20337
+    real.should_receive(:inspect).and_return(+"1")
     imaginary = NumericSpecs::Subclass.new
     imaginary.should_receive(:inspect).and_return("2")
     imaginary.should_receive(:<).any_number_of_times.and_return(false)
@@ -26,7 +27,8 @@ describe "Complex#inspect" do
 
   it "adds an `*' before the `i' if the last character of the imaginary part is not numeric" do
     real = NumericSpecs::Subclass.new
-    real.should_receive(:inspect).and_return("(1)")
+    # + because of https://bugs.ruby-lang.org/issues/20337
+    real.should_receive(:inspect).and_return(+"(1)")
     imaginary = NumericSpecs::Subclass.new
     imaginary.should_receive(:inspect).and_return("(2)")
     imaginary.should_receive(:<).any_number_of_times.and_return(false)

--- a/core/complex/to_s_spec.rb
+++ b/core/complex/to_s_spec.rb
@@ -45,7 +45,8 @@ describe "Complex#to_s" do
 
   it "treats real and imaginary parts as strings" do
     real = NumericSpecs::Subclass.new
-    real.should_receive(:to_s).and_return("1")
+    # + because of https://bugs.ruby-lang.org/issues/20337
+    real.should_receive(:to_s).and_return(+"1")
     imaginary = NumericSpecs::Subclass.new
     imaginary.should_receive(:to_s).and_return("2")
     imaginary.should_receive(:<).any_number_of_times.and_return(false)

--- a/core/dir/children_spec.rb
+++ b/core/dir/children_spec.rb
@@ -47,7 +47,7 @@ describe "Dir.children" do
     encoding = Encoding.find("filesystem")
     encoding = Encoding::BINARY if encoding == Encoding::US_ASCII
     platform_is_not :windows do
-      children.should include("こんにちは.txt".force_encoding(encoding))
+      children.should include("こんにちは.txt".dup.force_encoding(encoding))
     end
     children.first.encoding.should equal(Encoding.find("filesystem"))
   end
@@ -113,7 +113,7 @@ describe "Dir#children" do
     encoding = Encoding.find("filesystem")
     encoding = Encoding::BINARY if encoding == Encoding::US_ASCII
     platform_is_not :windows do
-      children.should include("こんにちは.txt".force_encoding(encoding))
+      children.should include("こんにちは.txt".dup.force_encoding(encoding))
     end
     children.first.encoding.should equal(Encoding.find("filesystem"))
   end

--- a/core/dir/entries_spec.rb
+++ b/core/dir/entries_spec.rb
@@ -47,7 +47,7 @@ describe "Dir.entries" do
     encoding = Encoding.find("filesystem")
     encoding = Encoding::BINARY if encoding == Encoding::US_ASCII
     platform_is_not :windows do
-      entries.should include("こんにちは.txt".force_encoding(encoding))
+      entries.should include("こんにちは.txt".dup.force_encoding(encoding))
     end
     entries.first.encoding.should equal(Encoding.find("filesystem"))
   end

--- a/core/dir/shared/glob.rb
+++ b/core/dir/shared/glob.rb
@@ -12,7 +12,7 @@ describe :dir_glob, shared: true do
   end
 
   it "raises an Encoding::CompatibilityError if the argument encoding is not compatible with US-ASCII" do
-    pattern = "file*".force_encoding Encoding::UTF_16BE
+    pattern = "file*".dup.force_encoding Encoding::UTF_16BE
     -> { Dir.send(@method, pattern) }.should raise_error(Encoding::CompatibilityError)
   end
 

--- a/core/encoding/compatible_spec.rb
+++ b/core/encoding/compatible_spec.rb
@@ -7,7 +7,7 @@ require_relative '../../spec_helper'
 describe "Encoding.compatible? String, String" do
   describe "when the first's Encoding is valid US-ASCII" do
     before :each do
-      @str = "abc".force_encoding Encoding::US_ASCII
+      @str = "abc".dup.force_encoding Encoding::US_ASCII
     end
 
     it "returns US-ASCII when the second's is US-ASCII" do
@@ -33,28 +33,28 @@ describe "Encoding.compatible? String, String" do
 
   describe "when the first's Encoding is ASCII compatible and ASCII only" do
     it "returns the first's Encoding if the second is ASCII compatible and ASCII only" do
-      [ [Encoding, "abc".force_encoding("UTF-8"), "123".force_encoding("Shift_JIS"), Encoding::UTF_8],
-        [Encoding, "123".force_encoding("Shift_JIS"), "abc".force_encoding("UTF-8"), Encoding::Shift_JIS]
+      [ [Encoding, "abc".dup.force_encoding("UTF-8"), "123".dup.force_encoding("Shift_JIS"), Encoding::UTF_8],
+        [Encoding, "123".dup.force_encoding("Shift_JIS"), "abc".dup.force_encoding("UTF-8"), Encoding::Shift_JIS]
       ].should be_computed_by(:compatible?)
     end
 
     it "returns the first's Encoding if the second is ASCII compatible and ASCII only" do
-      [ [Encoding, "abc".force_encoding("BINARY"), "123".force_encoding("US-ASCII"), Encoding::BINARY],
-        [Encoding, "123".force_encoding("US-ASCII"), "abc".force_encoding("BINARY"), Encoding::US_ASCII]
+      [ [Encoding, "abc".dup.force_encoding("BINARY"), "123".dup.force_encoding("US-ASCII"), Encoding::BINARY],
+        [Encoding, "123".dup.force_encoding("US-ASCII"), "abc".dup.force_encoding("BINARY"), Encoding::US_ASCII]
       ].should be_computed_by(:compatible?)
     end
 
     it "returns the second's Encoding if the second is ASCII compatible but not ASCII only" do
-      [ [Encoding, "abc".force_encoding("UTF-8"), "\xff".force_encoding("Shift_JIS"), Encoding::Shift_JIS],
-        [Encoding, "123".force_encoding("Shift_JIS"), "\xff".force_encoding("UTF-8"), Encoding::UTF_8],
-        [Encoding, "abc".force_encoding("BINARY"), "\xff".force_encoding("US-ASCII"), Encoding::US_ASCII],
-        [Encoding, "123".force_encoding("US-ASCII"), "\xff".force_encoding("BINARY"), Encoding::BINARY],
+      [ [Encoding, "abc".dup.force_encoding("UTF-8"), "\xff".dup.force_encoding("Shift_JIS"), Encoding::Shift_JIS],
+        [Encoding, "123".dup.force_encoding("Shift_JIS"), "\xff".dup.force_encoding("UTF-8"), Encoding::UTF_8],
+        [Encoding, "abc".dup.force_encoding("BINARY"), "\xff".dup.force_encoding("US-ASCII"), Encoding::US_ASCII],
+        [Encoding, "123".dup.force_encoding("US-ASCII"), "\xff".dup.force_encoding("BINARY"), Encoding::BINARY],
       ].should be_computed_by(:compatible?)
     end
 
     it "returns nil if the second's Encoding is not ASCII compatible" do
-      a = "abc".force_encoding("UTF-8")
-      b = "1234".force_encoding("UTF-16LE")
+      a = "abc".dup.force_encoding("UTF-8")
+      b = "1234".dup.force_encoding("UTF-16LE")
       Encoding.compatible?(a, b).should be_nil
     end
   end
@@ -75,7 +75,7 @@ describe "Encoding.compatible? String, String" do
 
   describe "when the first's Encoding is not ASCII compatible" do
     before :each do
-      @str = "abc".force_encoding Encoding::UTF_7
+      @str = "abc".dup.force_encoding Encoding::UTF_7
     end
 
     it "returns nil when the second String is US-ASCII" do
@@ -91,14 +91,14 @@ describe "Encoding.compatible? String, String" do
     end
 
     it "returns the Encoding when the second's Encoding is not ASCII compatible but the same as the first's Encoding" do
-      encoding = Encoding.compatible?(@str, "def".force_encoding("utf-7"))
+      encoding = Encoding.compatible?(@str, "def".dup.force_encoding("utf-7"))
       encoding.should == Encoding::UTF_7
     end
   end
 
   describe "when the first's Encoding is invalid" do
     before :each do
-      @str = "\xff".force_encoding Encoding::UTF_8
+      @str = "\xff".dup.force_encoding Encoding::UTF_8
     end
 
     it "returns the first's Encoding when the second's Encoding is US-ASCII" do
@@ -114,11 +114,11 @@ describe "Encoding.compatible? String, String" do
     end
 
     it "returns nil when the second's Encoding is invalid and ASCII only" do
-      Encoding.compatible?(@str, "\x7f".force_encoding("utf-16be")).should be_nil
+      Encoding.compatible?(@str, "\x7f".dup.force_encoding("utf-16be")).should be_nil
     end
 
     it "returns nil when the second's Encoding is invalid and not ASCII only" do
-      Encoding.compatible?(@str, "\xff".force_encoding("utf-16be")).should be_nil
+      Encoding.compatible?(@str, "\xff".dup.force_encoding("utf-16be")).should be_nil
     end
 
     it "returns the Encoding when the second's Encoding is invalid but the same as the first" do
@@ -129,7 +129,7 @@ describe "Encoding.compatible? String, String" do
   describe "when the first String is empty and the second is not" do
     describe "and the first's Encoding is ASCII compatible" do
       before :each do
-        @str = "".force_encoding("utf-8")
+        @str = "".dup.force_encoding("utf-8")
       end
 
       it "returns the first's encoding when the second String is ASCII only" do
@@ -143,7 +143,7 @@ describe "Encoding.compatible? String, String" do
 
     describe "when the first's Encoding is not ASCII compatible" do
       before :each do
-        @str = "".force_encoding Encoding::UTF_7
+        @str = "".dup.force_encoding Encoding::UTF_7
       end
 
       it "returns the second string's encoding" do
@@ -154,7 +154,7 @@ describe "Encoding.compatible? String, String" do
 
   describe "when the second String is empty" do
     before :each do
-      @str = "abc".force_encoding("utf-7")
+      @str = "abc".dup.force_encoding("utf-7")
     end
 
     it "returns the first Encoding" do
@@ -165,7 +165,7 @@ end
 
 describe "Encoding.compatible? String, Regexp" do
   it "returns US-ASCII if both are US-ASCII" do
-    str = "abc".force_encoding("us-ascii")
+    str = "abc".dup.force_encoding("us-ascii")
     Encoding.compatible?(str, /abc/).should == Encoding::US_ASCII
   end
 
@@ -180,15 +180,15 @@ describe "Encoding.compatible? String, Regexp" do
   it "returns the String's Encoding if the String is not ASCII only" do
     [ [Encoding, "\xff",                                  Encoding::BINARY],
       [Encoding, "\u3042".encode("utf-8"),                Encoding::UTF_8],
-      [Encoding, "\xa4\xa2".force_encoding("euc-jp"),     Encoding::EUC_JP],
-      [Encoding, "\x82\xa0".force_encoding("shift_jis"),  Encoding::Shift_JIS],
+      [Encoding, "\xa4\xa2".dup.force_encoding("euc-jp"),     Encoding::EUC_JP],
+      [Encoding, "\x82\xa0".dup.force_encoding("shift_jis"),  Encoding::Shift_JIS],
     ].should be_computed_by(:compatible?, /abc/)
   end
 end
 
 describe "Encoding.compatible? String, Symbol" do
   it "returns US-ASCII if both are ASCII only" do
-    str = "abc".force_encoding("us-ascii")
+    str = "abc".dup.force_encoding("us-ascii")
     Encoding.compatible?(str, :abc).should == Encoding::US_ASCII
   end
 
@@ -203,8 +203,8 @@ describe "Encoding.compatible? String, Symbol" do
   it "returns the String's Encoding if the String is not ASCII only" do
     [ [Encoding, "\xff",                                  Encoding::BINARY],
       [Encoding, "\u3042".encode("utf-8"),                Encoding::UTF_8],
-      [Encoding, "\xa4\xa2".force_encoding("euc-jp"),     Encoding::EUC_JP],
-      [Encoding, "\x82\xa0".force_encoding("shift_jis"),  Encoding::Shift_JIS],
+      [Encoding, "\xa4\xa2".dup.force_encoding("euc-jp"),     Encoding::EUC_JP],
+      [Encoding, "\x82\xa0".dup.force_encoding("shift_jis"),  Encoding::Shift_JIS],
     ].should be_computed_by(:compatible?, :abc)
   end
 end
@@ -221,8 +221,8 @@ describe "Encoding.compatible? String, Encoding" do
   it "returns the String's encoding if the Encoding is US-ASCII" do
     [ [Encoding, "\xff",                                  Encoding::BINARY],
       [Encoding, "\u3042".encode("utf-8"),                Encoding::UTF_8],
-      [Encoding, "\xa4\xa2".force_encoding("euc-jp"),     Encoding::EUC_JP],
-      [Encoding, "\x82\xa0".force_encoding("shift_jis"),  Encoding::Shift_JIS],
+      [Encoding, "\xa4\xa2".dup.force_encoding("euc-jp"),     Encoding::EUC_JP],
+      [Encoding, "\x82\xa0".dup.force_encoding("shift_jis"),  Encoding::Shift_JIS],
     ].should be_computed_by(:compatible?, Encoding::US_ASCII)
   end
 
@@ -242,7 +242,7 @@ end
 
 describe "Encoding.compatible? Regexp, String" do
   it "returns US-ASCII if both are US-ASCII" do
-    str = "abc".force_encoding("us-ascii")
+    str = "abc".dup.force_encoding("us-ascii")
     Encoding.compatible?(/abc/, str).should == Encoding::US_ASCII
   end
 
@@ -256,8 +256,8 @@ describe "Encoding.compatible? Regexp, Regexp" do
   it "returns the first's Encoding if it is not US-ASCII and not ASCII only" do
     [ [Encoding, Regexp.new("\xff"),                                  Encoding::BINARY],
       [Encoding, Regexp.new("\u3042".encode("utf-8")),                Encoding::UTF_8],
-      [Encoding, Regexp.new("\xa4\xa2".force_encoding("euc-jp")),     Encoding::EUC_JP],
-      [Encoding, Regexp.new("\x82\xa0".force_encoding("shift_jis")),  Encoding::Shift_JIS],
+      [Encoding, Regexp.new("\xa4\xa2".dup.force_encoding("euc-jp")),     Encoding::EUC_JP],
+      [Encoding, Regexp.new("\x82\xa0".dup.force_encoding("shift_jis")),  Encoding::Shift_JIS],
     ].should be_computed_by(:compatible?, /abc/)
   end
 end
@@ -270,15 +270,15 @@ describe "Encoding.compatible? Regexp, Symbol" do
   it "returns the first's Encoding if it is not US-ASCII and not ASCII only" do
     [ [Encoding, Regexp.new("\xff"),                                  Encoding::BINARY],
       [Encoding, Regexp.new("\u3042".encode("utf-8")),                Encoding::UTF_8],
-      [Encoding, Regexp.new("\xa4\xa2".force_encoding("euc-jp")),     Encoding::EUC_JP],
-      [Encoding, Regexp.new("\x82\xa0".force_encoding("shift_jis")),  Encoding::Shift_JIS],
+      [Encoding, Regexp.new("\xa4\xa2".dup.force_encoding("euc-jp")),     Encoding::EUC_JP],
+      [Encoding, Regexp.new("\x82\xa0".dup.force_encoding("shift_jis")),  Encoding::Shift_JIS],
     ].should be_computed_by(:compatible?, /abc/)
   end
 end
 
 describe "Encoding.compatible? Symbol, String" do
   it "returns US-ASCII if both are ASCII only" do
-    str = "abc".force_encoding("us-ascii")
+    str = "abc".dup.force_encoding("us-ascii")
     Encoding.compatible?(str, :abc).should == Encoding::US_ASCII
   end
 end
@@ -291,8 +291,8 @@ describe "Encoding.compatible? Symbol, Regexp" do
   it "returns the Regexp's Encoding if it is not US-ASCII and not ASCII only" do
     a = Regexp.new("\xff")
     b = Regexp.new("\u3042".encode("utf-8"))
-    c = Regexp.new("\xa4\xa2".force_encoding("euc-jp"))
-    d = Regexp.new("\x82\xa0".force_encoding("shift_jis"))
+    c = Regexp.new("\xa4\xa2".dup.force_encoding("euc-jp"))
+    d = Regexp.new("\x82\xa0".dup.force_encoding("shift_jis"))
 
     [ [Encoding, :abc, a, Encoding::BINARY],
       [Encoding, :abc, b, Encoding::UTF_8],
@@ -310,8 +310,8 @@ describe "Encoding.compatible? Symbol, Symbol" do
   it "returns the first's Encoding if it is not ASCII only" do
     [ [Encoding, "\xff".to_sym,                                  Encoding::BINARY],
       [Encoding, "\u3042".encode("utf-8").to_sym,                Encoding::UTF_8],
-      [Encoding, "\xa4\xa2".force_encoding("euc-jp").to_sym,     Encoding::EUC_JP],
-      [Encoding, "\x82\xa0".force_encoding("shift_jis").to_sym,  Encoding::Shift_JIS],
+      [Encoding, "\xa4\xa2".dup.force_encoding("euc-jp").to_sym,     Encoding::EUC_JP],
+      [Encoding, "\x82\xa0".dup.force_encoding("shift_jis").to_sym,  Encoding::Shift_JIS],
     ].should be_computed_by(:compatible?, :abc)
   end
 end

--- a/core/encoding/converter/convert_spec.rb
+++ b/core/encoding/converter/convert_spec.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 require_relative '../../../spec_helper'
 
 describe "Encoding::Converter#convert" do
@@ -9,31 +10,31 @@ describe "Encoding::Converter#convert" do
 
   it "sets the encoding of the result to the target encoding" do
     ec = Encoding::Converter.new('ascii', 'utf-8')
-    str = 'glark'.force_encoding('ascii')
+    str = 'glark'.dup.force_encoding('ascii')
     ec.convert(str).encoding.should == Encoding::UTF_8
   end
 
   it "transcodes the given String to the target encoding" do
     ec = Encoding::Converter.new("utf-8", "euc-jp")
-    ec.convert("\u3042".force_encoding('UTF-8')).should == \
-      "\xA4\xA2".force_encoding('EUC-JP')
+    ec.convert("\u3042".dup.force_encoding('UTF-8')).should == \
+      "\xA4\xA2".dup.force_encoding('EUC-JP')
   end
 
   it "allows Strings of different encodings to the source encoding" do
     ec = Encoding::Converter.new('ascii', 'utf-8')
-    str = 'glark'.force_encoding('SJIS')
+    str = 'glark'.dup.force_encoding('SJIS')
     ec.convert(str).encoding.should == Encoding::UTF_8
   end
 
   it "reuses the given encoding pair if called multiple times" do
     ec = Encoding::Converter.new('ascii', 'SJIS')
-    ec.convert('a'.force_encoding('ASCII')).should == 'a'.force_encoding('SJIS')
-    ec.convert('b'.force_encoding('ASCII')).should == 'b'.force_encoding('SJIS')
+    ec.convert('a'.dup.force_encoding('ASCII')).should == 'a'.dup.force_encoding('SJIS')
+    ec.convert('b'.dup.force_encoding('ASCII')).should == 'b'.dup.force_encoding('SJIS')
   end
 
   it "raises UndefinedConversionError if the String contains characters invalid for the target encoding" do
     ec = Encoding::Converter.new('UTF-8', Encoding.find('macCyrillic'))
-    -> { ec.convert("\u{6543}".force_encoding('UTF-8')) }.should \
+    -> { ec.convert("\u{6543}".dup.force_encoding('UTF-8')) }.should \
       raise_error(Encoding::UndefinedConversionError)
   end
 

--- a/core/encoding/converter/finish_spec.rb
+++ b/core/encoding/converter/finish_spec.rb
@@ -16,8 +16,8 @@ describe "Encoding::Converter#finish" do
   end
 
   it "returns the last part of the converted String if it hasn't already" do
-     @ec.convert("\u{9999}").should == "\e$B9a".force_encoding('iso-2022-jp')
-     @ec.finish.should == "\e(B".force_encoding('iso-2022-jp')
+     @ec.convert("\u{9999}").should == "\e$B9a".dup.force_encoding('iso-2022-jp')
+     @ec.finish.should == "\e(B".dup.force_encoding('iso-2022-jp')
   end
 
   it "returns a String in the destination encoding" do

--- a/core/encoding/converter/last_error_spec.rb
+++ b/core/encoding/converter/last_error_spec.rb
@@ -9,45 +9,45 @@ describe "Encoding::Converter#last_error" do
 
   it "returns nil when the last conversion did not produce an error" do
     ec = Encoding::Converter.new('ascii','utf-8')
-    ec.convert('a'.force_encoding('ascii'))
+    ec.convert('a'.dup.force_encoding('ascii'))
     ec.last_error.should be_nil
   end
 
   it "returns nil when #primitive_convert last returned :destination_buffer_full" do
     ec = Encoding::Converter.new("utf-8", "iso-2022-jp")
-    ec.primitive_convert("\u{9999}", "", 0, 0, partial_input: false) \
+    ec.primitive_convert(+"\u{9999}", +"", 0, 0, partial_input: false) \
       .should == :destination_buffer_full
     ec.last_error.should be_nil
   end
 
   it "returns nil when #primitive_convert last returned :finished" do
     ec = Encoding::Converter.new("utf-8", "iso-8859-1")
-    ec.primitive_convert("glark".force_encoding('utf-8'),"").should == :finished
+    ec.primitive_convert("glark".dup.force_encoding('utf-8'), +"").should == :finished
     ec.last_error.should be_nil
   end
 
   it "returns nil if the last conversion succeeded but the penultimate failed" do
     ec = Encoding::Converter.new("utf-8", "iso-8859-1")
-    ec.primitive_convert("\xf1abcd","").should == :invalid_byte_sequence
-    ec.primitive_convert("glark".force_encoding('utf-8'),"").should == :finished
+    ec.primitive_convert(+"\xf1abcd", +"").should == :invalid_byte_sequence
+    ec.primitive_convert("glark".dup.force_encoding('utf-8'), +"").should == :finished
     ec.last_error.should be_nil
   end
 
   it "returns an Encoding::InvalidByteSequenceError when #primitive_convert last returned :invalid_byte_sequence" do
     ec = Encoding::Converter.new("utf-8", "iso-8859-1")
-    ec.primitive_convert("\xf1abcd","").should == :invalid_byte_sequence
+    ec.primitive_convert(+"\xf1abcd", +"").should == :invalid_byte_sequence
     ec.last_error.should be_an_instance_of(Encoding::InvalidByteSequenceError)
   end
 
   it "returns an Encoding::UndefinedConversionError when #primitive_convert last returned :undefined_conversion" do
     ec = Encoding::Converter.new("utf-8", "iso-8859-1")
-    ec.primitive_convert("\u{9876}","").should == :undefined_conversion
+    ec.primitive_convert(+"\u{9876}", +"").should == :undefined_conversion
     ec.last_error.should be_an_instance_of(Encoding::UndefinedConversionError)
   end
 
   it "returns an Encoding::InvalidByteSequenceError when #primitive_convert last returned :incomplete_input" do
     ec = Encoding::Converter.new("EUC-JP", "ISO-8859-1")
-    ec.primitive_convert("\xa4", "", nil, 10).should == :incomplete_input
+    ec.primitive_convert(+"\xa4", +"", nil, 10).should == :incomplete_input
     ec.last_error.should be_an_instance_of(Encoding::InvalidByteSequenceError)
   end
 

--- a/core/encoding/converter/new_spec.rb
+++ b/core/encoding/converter/new_spec.rb
@@ -107,7 +107,7 @@ describe "Encoding::Converter.new" do
 
       it "sets the replacement String to '\\uFFFD'" do
         conv = Encoding::Converter.new("us-ascii", "utf-8", replace: nil)
-        conv.replacement.should == "\u{fffd}".force_encoding("utf-8")
+        conv.replacement.should == "\u{fffd}".dup.force_encoding("utf-8")
       end
 
       it "sets the replacement String encoding to UTF-8" do

--- a/core/encoding/converter/primitive_convert_spec.rb
+++ b/core/encoding/converter/primitive_convert_spec.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: false
 require_relative '../../../spec_helper'
 
 describe "Encoding::Converter#primitive_convert" do

--- a/core/encoding/converter/primitive_errinfo_spec.rb
+++ b/core/encoding/converter/primitive_errinfo_spec.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: false
 require_relative '../../../spec_helper'
 
 describe "Encoding::Converter#primitive_errinfo" do

--- a/core/encoding/converter/putback_spec.rb
+++ b/core/encoding/converter/putback_spec.rb
@@ -4,7 +4,7 @@ require_relative '../../../spec_helper'
 describe "Encoding::Converter#putback" do
   before :each do
     @ec = Encoding::Converter.new("EUC-JP", "ISO-8859-1")
-    @ret = @ec.primitive_convert(@src="abc\xa1def", @dst="", nil, 10)
+    @ret = @ec.primitive_convert(@src=+"abc\xa1def", @dst=+"", nil, 10)
   end
 
   it "returns a String" do
@@ -36,21 +36,21 @@ describe "Encoding::Converter#putback" do
 
   it "returns the problematic bytes for UTF-16LE" do
     ec = Encoding::Converter.new("utf-16le", "iso-8859-1")
-    src = "\x00\xd8\x61\x00"
-    dst = ""
+    src = +"\x00\xd8\x61\x00"
+    dst = +""
     ec.primitive_convert(src, dst).should == :invalid_byte_sequence
     ec.primitive_errinfo.should == [:invalid_byte_sequence, "UTF-16LE", "UTF-8", "\x00\xD8", "a\x00"]
-    ec.putback.should == "a\x00".force_encoding("utf-16le")
+    ec.putback.should == "a\x00".dup.force_encoding("utf-16le")
     ec.putback.should == ""
   end
 
   it "accepts an integer argument corresponding to the number of bytes to be put back" do
     ec = Encoding::Converter.new("utf-16le", "iso-8859-1")
-    src = "\x00\xd8\x61\x00"
-    dst = ""
+    src = +"\x00\xd8\x61\x00"
+    dst = +""
     ec.primitive_convert(src, dst).should == :invalid_byte_sequence
     ec.primitive_errinfo.should == [:invalid_byte_sequence, "UTF-16LE", "UTF-8", "\x00\xD8", "a\x00"]
-    ec.putback(2).should == "a\x00".force_encoding("utf-16le")
+    ec.putback(2).should == "a\x00".dup.force_encoding("utf-16le")
     ec.putback.should == ""
   end
 end

--- a/core/encoding/converter/replacement_spec.rb
+++ b/core/encoding/converter/replacement_spec.rb
@@ -13,7 +13,7 @@ describe "Encoding::Converter#replacement" do
 
   it "returns \\uFFFD when the destination encoding is UTF-8" do
     ec = Encoding::Converter.new("us-ascii", "utf-8")
-    ec.replacement.should == "\u{fffd}".force_encoding('utf-8')
+    ec.replacement.should == "\u{fffd}".dup.force_encoding('utf-8')
     ec.replacement.encoding.should == Encoding::UTF_8
   end
 end
@@ -38,33 +38,33 @@ describe "Encoding::Converter#replacement=" do
 
   it "sets #replacement" do
     ec = Encoding::Converter.new("us-ascii", "utf-8")
-    ec.replacement.should == "\u{fffd}".force_encoding('utf-8')
+    ec.replacement.should == "\u{fffd}".dup.force_encoding('utf-8')
     ec.replacement = '?'.encode('utf-8')
-    ec.replacement.should == '?'.force_encoding('utf-8')
+    ec.replacement.should == '?'.dup.force_encoding('utf-8')
   end
 
   it "raises an UndefinedConversionError is the argument cannot be converted into the destination encoding" do
     ec = Encoding::Converter.new("sjis", "ascii")
-    utf8_q = "\u{986}".force_encoding('utf-8')
-    ec.primitive_convert(utf8_q.dup, "").should == :undefined_conversion
+    utf8_q = "\u{986}".dup.force_encoding('utf-8')
+    ec.primitive_convert(utf8_q.dup, +"").should == :undefined_conversion
     -> { ec.replacement = utf8_q }.should \
       raise_error(Encoding::UndefinedConversionError)
   end
 
   it "does not change the replacement character if the argument cannot be converted into the destination encoding" do
     ec = Encoding::Converter.new("sjis", "ascii")
-    utf8_q = "\u{986}".force_encoding('utf-8')
-    ec.primitive_convert(utf8_q.dup, "").should == :undefined_conversion
+    utf8_q = "\u{986}".dup.force_encoding('utf-8')
+    ec.primitive_convert(utf8_q.dup, +"").should == :undefined_conversion
     -> { ec.replacement = utf8_q }.should \
       raise_error(Encoding::UndefinedConversionError)
-    ec.replacement.should == "?".force_encoding('us-ascii')
+    ec.replacement.should == "?".dup.force_encoding('us-ascii')
   end
 
   it "uses the replacement character" do
     ec = Encoding::Converter.new("utf-8", "us-ascii", :invalid => :replace, :undef => :replace)
     ec.replacement = "!"
-    dest = ""
-    status = ec.primitive_convert "中文123", dest
+    dest = +""
+    status = ec.primitive_convert(+"中文123", dest)
 
     status.should == :finished
     dest.should == "!!123"

--- a/core/encoding/invalid_byte_sequence_error/incomplete_input_spec.rb
+++ b/core/encoding/invalid_byte_sequence_error/incomplete_input_spec.rb
@@ -8,7 +8,7 @@ describe "Encoding::InvalidByteSequenceError#incomplete_input?" do
 
   it "returns true if #primitive_convert returned :incomplete_input for the same data" do
     ec = Encoding::Converter.new("EUC-JP", "ISO-8859-1")
-    ec.primitive_convert("\xA1",'').should == :incomplete_input
+    ec.primitive_convert(+"\xA1", +'').should == :incomplete_input
     begin
       ec.convert("\xA1")
     rescue Encoding::InvalidByteSequenceError => e
@@ -18,7 +18,7 @@ describe "Encoding::InvalidByteSequenceError#incomplete_input?" do
 
   it "returns false if #primitive_convert returned :invalid_byte_sequence for the same data" do
     ec = Encoding::Converter.new("ascii", "utf-8")
-    ec.primitive_convert("\xfffffffff",'').should == :invalid_byte_sequence
+    ec.primitive_convert(+"\xfffffffff", +'').should == :invalid_byte_sequence
     begin
       ec.convert("\xfffffffff")
     rescue Encoding::InvalidByteSequenceError => e

--- a/core/encoding/invalid_byte_sequence_error/readagain_bytes_spec.rb
+++ b/core/encoding/invalid_byte_sequence_error/readagain_bytes_spec.rb
@@ -15,11 +15,11 @@ describe "Encoding::InvalidByteSequenceError#readagain_bytes" do
 
   it "returns the bytes to be read again" do
     @exception.readagain_bytes.size.should == 1
-    @exception.readagain_bytes.should == "a".force_encoding('binary')
+    @exception.readagain_bytes.should == "a".dup.force_encoding('binary')
     @exception.readagain_bytes.should == @errinfo[-1]
 
     @exception2.readagain_bytes.size.should == 1
-    @exception2.readagain_bytes.should == "\xFF".force_encoding('binary')
+    @exception2.readagain_bytes.should == "\xFF".dup.force_encoding('binary')
     @exception2.readagain_bytes.should == @errinfo2[-1]
   end
 

--- a/core/encoding/replicate_spec.rb
+++ b/core/encoding/replicate_spec.rb
@@ -18,8 +18,8 @@ describe "Encoding#replicate" do
       e.name.should == name
       Encoding.find(name).should == e
 
-      "a".force_encoding(e).valid_encoding?.should be_true
-      "\x80".force_encoding(e).valid_encoding?.should be_false
+      "a".dup.force_encoding(e).valid_encoding?.should be_true
+      "\x80".dup.force_encoding(e).valid_encoding?.should be_false
     end
 
     it "returns a replica of UTF-8" do
@@ -28,9 +28,9 @@ describe "Encoding#replicate" do
       e.name.should == name
       Encoding.find(name).should == e
 
-      "a".force_encoding(e).valid_encoding?.should be_true
-      "\u3042".force_encoding(e).valid_encoding?.should be_true
-      "\x80".force_encoding(e).valid_encoding?.should be_false
+      "a".dup.force_encoding(e).valid_encoding?.should be_true
+      "\u3042".dup.force_encoding(e).valid_encoding?.should be_true
+      "\x80".dup.force_encoding(e).valid_encoding?.should be_false
     end
 
     it "returns a replica of UTF-16BE" do
@@ -39,9 +39,9 @@ describe "Encoding#replicate" do
       e.name.should == name
       Encoding.find(name).should == e
 
-      "a".force_encoding(e).valid_encoding?.should be_false
-      "\x30\x42".force_encoding(e).valid_encoding?.should be_true
-      "\x80".force_encoding(e).valid_encoding?.should be_false
+      "a".dup.force_encoding(e).valid_encoding?.should be_false
+      "\x30\x42".dup.force_encoding(e).valid_encoding?.should be_true
+      "\x80".dup.force_encoding(e).valid_encoding?.should be_false
     end
 
     it "returns a replica of ISO-2022-JP" do
@@ -61,7 +61,7 @@ describe "Encoding#replicate" do
       e.name.should == name
       Encoding.find(name).should == e
 
-      s = "abc".force_encoding(e)
+      s = "abc".dup.force_encoding(e)
       s.encoding.should == e
       s.encoding.name.should == name
     end

--- a/core/file/expand_path_spec.rb
+++ b/core/file/expand_path_spec.rb
@@ -137,7 +137,7 @@ describe "File.expand_path" do
   it "returns a String in the same encoding as the argument" do
     Encoding.default_external = Encoding::SHIFT_JIS
 
-    path = "./a".force_encoding Encoding::CP1251
+    path = "./a".dup.force_encoding Encoding::CP1251
     File.expand_path(path).encoding.should equal(Encoding::CP1251)
 
     weird_path = [222, 173, 190, 175].pack('C*')

--- a/core/file/shared/path.rb
+++ b/core/file/shared/path.rb
@@ -1,7 +1,7 @@
 describe :file_path, shared: true do
   before :each do
-    @name = "file_to_path"
-    @path = tmp(@name)
+    @path = tmp("file_to_path")
+    @name = File.basename(@path)
     touch @path
   end
 

--- a/core/hash/assoc_spec.rb
+++ b/core/hash/assoc_spec.rb
@@ -22,11 +22,11 @@ describe "Hash#assoc" do
   end
 
   it "only returns the first matching key-value pair for identity hashes" do
-    # Avoid literal String keys in Hash#[]= due to https://bugs.ruby-lang.org/issues/12855
+    # Avoid literal String keys since string literals can be frozen and interned e.g. with --enable-frozen-string-literal
     h = {}.compare_by_identity
-    k1 = 'pear'
+    k1 = 'pear'.dup
     h[k1] = :red
-    k2 = 'pear'
+    k2 = 'pear'.dup
     h[k2] = :green
     h.size.should == 2
     h.keys.grep(/pear/).size.should == 2

--- a/core/hash/compare_by_identity_spec.rb
+++ b/core/hash/compare_by_identity_spec.rb
@@ -85,19 +85,21 @@ describe "Hash#compare_by_identity" do
     -> { @h.compare_by_identity }.should raise_error(FrozenError)
   end
 
-  # Behaviour confirmed in bug #1871
+  # Behaviour confirmed in https://bugs.ruby-lang.org/issues/1871
   it "persists over #dups" do
-    @idh['foo'] = :bar
-    @idh['foo'] = :glark
+    @idh['foo'.dup] = :bar
+    @idh['foo'.dup] = :glark
     @idh.dup.should == @idh
     @idh.dup.size.should == @idh.size
+    @idh.dup.should.compare_by_identity?
   end
 
   it "persists over #clones" do
-    @idh['foo'] = :bar
-    @idh['foo'] = :glark
+    @idh['foo'.dup] = :bar
+    @idh['foo'.dup] = :glark
     @idh.clone.should == @idh
     @idh.clone.size.should == @idh.size
+    @idh.dup.should.compare_by_identity?
   end
 
   it "does not copy string keys" do
@@ -109,8 +111,11 @@ describe "Hash#compare_by_identity" do
   end
 
   it "gives different identity for string literals" do
+    eval <<~RUBY
+    # frozen_string_literal: false
     @idh['foo'] = 1
     @idh['foo'] = 2
+    RUBY
     @idh.values.should == [1, 2]
     @idh.size.should == 2
   end

--- a/core/hash/element_reference_spec.rb
+++ b/core/hash/element_reference_spec.rb
@@ -30,7 +30,7 @@ describe "Hash#[]" do
   end
 
   it "does not create copies of the immediate default value" do
-    str = "foo"
+    str = +"foo"
     h = Hash.new(str)
     a = h[:a]
     b = h[:b]

--- a/core/hash/shared/store.rb
+++ b/core/hash/shared/store.rb
@@ -9,7 +9,7 @@ describe :hash_store, shared: true do
 
   it "duplicates string keys using dup semantics" do
     # dup doesn't copy singleton methods
-    key = "foo"
+    key = +"foo"
     def key.reverse() "bar" end
     h = {}
     h.send(@method, key, 0)
@@ -44,7 +44,7 @@ describe :hash_store, shared: true do
   end
 
   it "duplicates and freezes string keys" do
-    key = "foo"
+    key = +"foo"
     h = {}
     h.send(@method, key, 0)
     key << "bar"
@@ -75,8 +75,8 @@ describe :hash_store, shared: true do
 
   it "keeps the existing String key in the hash if there is a matching one" do
     h = { "a" => 1, "b" => 2, "c" => 3, "d" => 4 }
-    key1 = "foo"
-    key2 = "foo"
+    key1 = "foo".dup
+    key2 = "foo".dup
     key1.should_not equal(key2)
     h[key1] = 41
     frozen_key = h.keys.last

--- a/core/hash/shared/to_s.rb
+++ b/core/hash/shared/to_s.rb
@@ -24,7 +24,7 @@ describe :hash_to_s, shared: true do
   end
 
   it "does not call #to_s on a String returned from #inspect" do
-    str = "abc"
+    str = +"abc"
     str.should_not_receive(:to_s)
 
     { a: str }.send(@method).should == '{:a=>"abc"}'
@@ -78,7 +78,7 @@ describe :hash_to_s, shared: true do
 
   it "does not raise if inspected result is not default external encoding" do
     utf_16be = mock("utf_16be")
-    utf_16be.should_receive(:inspect).and_return(%<"utf_16be \u3042">.encode!(Encoding::UTF_16BE))
+    utf_16be.should_receive(:inspect).and_return(%<"utf_16be \u3042">.encode(Encoding::UTF_16BE))
 
     {a: utf_16be}.send(@method).should == '{:a=>"utf_16be \u3042"}'
   end

--- a/core/io/ioctl_spec.rb
+++ b/core/io/ioctl_spec.rb
@@ -12,7 +12,7 @@ describe "IO#ioctl" do
     guard -> { RUBY_PLATFORM.include?("86") } do # x86 / x86_64
       it "resizes an empty String to match the output size" do
         File.open(__FILE__, 'r') do |f|
-          buffer = ''
+          buffer = +''
           # FIONREAD in /usr/include/asm-generic/ioctls.h
           f.ioctl 0x541B, buffer
           buffer.unpack('I').first.should be_kind_of(Integer)

--- a/core/io/pread_spec.rb
+++ b/core/io/pread_spec.rb
@@ -21,19 +21,19 @@ guard -> { platform_is_not :windows or ruby_version_is "3.3" } do
     end
 
     it "accepts a length, an offset, and an output buffer" do
-      buffer = "foo"
+      buffer = +"foo"
       @file.pread(3, 4, buffer)
       buffer.should == "567"
     end
 
     it "shrinks the buffer in case of less bytes read" do
-      buffer = "foo"
+      buffer = +"foo"
       @file.pread(1, 0, buffer)
       buffer.should == "1"
     end
 
     it "grows the buffer in case of more bytes read" do
-      buffer = "foo"
+      buffer = +"foo"
       @file.pread(5, 0, buffer)
       buffer.should == "12345"
     end
@@ -57,7 +57,7 @@ guard -> { platform_is_not :windows or ruby_version_is "3.3" } do
     end
 
     it "does not reset the buffer when reading with maxlen = 0" do
-      buffer = "foo"
+      buffer = +"foo"
       @file.pread(0, 4, buffer)
       buffer.should == "foo"
 
@@ -79,7 +79,7 @@ guard -> { platform_is_not :windows or ruby_version_is "3.3" } do
 
     it "converts a buffer to String using to_str" do
       buffer = mock('buffer')
-      buffer.should_receive(:to_str).at_least(1).and_return("foo")
+      buffer.should_receive(:to_str).at_least(1).and_return(+"foo")
       @file.pread(4, 0, buffer)
       buffer.should_not.is_a?(String)
       buffer.to_str.should == "1234"

--- a/core/io/puts_spec.rb
+++ b/core/io/puts_spec.rb
@@ -6,7 +6,7 @@ describe "IO#puts" do
     @before_separator = $/
     @name = tmp("io_puts.txt")
     @io = new_io @name
-    ScratchPad.record ""
+    ScratchPad.record(+"")
     def @io.write(str)
       ScratchPad << str
     end

--- a/core/io/read_nonblock_spec.rb
+++ b/core/io/read_nonblock_spec.rb
@@ -96,21 +96,21 @@ describe "IO#read_nonblock" do
   end
 
   it "reads into the passed buffer" do
-    buffer = ""
+    buffer = +""
     @write.write("1")
     @read.read_nonblock(1, buffer)
     buffer.should == "1"
   end
 
   it "returns the passed buffer" do
-    buffer = ""
+    buffer = +""
     @write.write("1")
     output = @read.read_nonblock(1, buffer)
     output.should equal(buffer)
   end
 
   it "discards the existing buffer content upon successful read" do
-    buffer = "existing content"
+    buffer = +"existing content"
     @write.write("hello world")
     @write.close
     @read.read_nonblock(11, buffer)
@@ -118,7 +118,7 @@ describe "IO#read_nonblock" do
   end
 
   it "discards the existing buffer content upon error" do
-    buffer = "existing content"
+    buffer = +"existing content"
     @write.close
     -> { @read.read_nonblock(1, buffer) }.should raise_error(EOFError)
     buffer.should be_empty

--- a/core/io/read_spec.rb
+++ b/core/io/read_spec.rb
@@ -294,19 +294,19 @@ describe "IO#read" do
   it "clears the output buffer if there is nothing to read" do
     @io.pos = 10
 
-    buf = 'non-empty string'
+    buf = +'non-empty string'
 
     @io.read(10, buf).should == nil
 
     buf.should == ''
 
-    buf = 'non-empty string'
+    buf = +'non-empty string'
 
     @io.read(nil, buf).should == ""
 
     buf.should == ''
 
-    buf = 'non-empty string'
+    buf = +'non-empty string'
 
     @io.read(0, buf).should == ""
 
@@ -344,53 +344,53 @@ describe "IO#read" do
   end
 
   it "places the specified number of bytes in the buffer" do
-    buf = ""
+    buf = +""
     @io.read 5, buf
 
     buf.should == "12345"
   end
 
   it "expands the buffer when too small" do
-    buf = "ABCDE"
+    buf = +"ABCDE"
     @io.read nil, buf
 
     buf.should == @contents
   end
 
   it "overwrites the buffer" do
-    buf = "ABCDEFGHIJ"
+    buf = +"ABCDEFGHIJ"
     @io.read nil, buf
 
     buf.should == @contents
   end
 
   it "truncates the buffer when too big" do
-    buf = "ABCDEFGHIJKLMNO"
+    buf = +"ABCDEFGHIJKLMNO"
     @io.read nil, buf
     buf.should == @contents
 
     @io.rewind
 
-    buf = "ABCDEFGHIJKLMNO"
+    buf = +"ABCDEFGHIJKLMNO"
     @io.read 5, buf
     buf.should == @contents[0..4]
   end
 
   it "returns the given buffer" do
-    buf = ""
+    buf = +""
 
     @io.read(nil, buf).should equal buf
   end
 
   it "returns the given buffer when there is nothing to read" do
-    buf = ""
+    buf = +""
 
     @io.read
     @io.read(nil, buf).should equal buf
   end
 
   it "coerces the second argument to string and uses it as a buffer" do
-    buf = "ABCDE"
+    buf = +"ABCDE"
     obj = mock("buff")
     obj.should_receive(:to_str).any_number_of_times.and_return(buf)
 
@@ -588,13 +588,13 @@ describe :io_read_internal_encoding, shared: true do
 
   describe "when passed nil for limit" do
     it "sets the buffer to a transcoded String" do
-      result = @io.read(nil, buf = "")
+      result = @io.read(nil, buf = +"")
       buf.should equal(result)
       buf.should == "ありがとう\n"
     end
 
     it "sets the buffer's encoding to the internal encoding" do
-      buf = "".force_encoding Encoding::ISO_8859_1
+      buf = "".dup.force_encoding Encoding::ISO_8859_1
       @io.read(nil, buf)
       buf.encoding.should equal(Encoding::UTF_8)
     end
@@ -612,14 +612,14 @@ describe :io_read_size_internal_encoding, shared: true do
   end
 
   it "does not change the buffer's encoding when passed a limit" do
-    buf = "".force_encoding Encoding::ISO_8859_1
+    buf = "".dup.force_encoding Encoding::ISO_8859_1
     @io.read(4, buf)
     buf.should == [164, 162, 164, 234].pack('C*').force_encoding(Encoding::ISO_8859_1)
     buf.encoding.should equal(Encoding::ISO_8859_1)
   end
 
   it "truncates the buffer but does not change the buffer's encoding when no data remains" do
-    buf = "abc".force_encoding Encoding::ISO_8859_1
+    buf = "abc".dup.force_encoding Encoding::ISO_8859_1
     @io.read
 
     @io.read(1, buf).should be_nil

--- a/core/io/readpartial_spec.rb
+++ b/core/io/readpartial_spec.rb
@@ -59,7 +59,7 @@ describe "IO#readpartial" do
   end
 
   it "discards the existing buffer content upon successful read" do
-    buffer = "existing content"
+    buffer = +"existing content"
     @wr.write("hello world")
     @wr.close
     @rd.readpartial(11, buffer)
@@ -74,7 +74,7 @@ describe "IO#readpartial" do
   end
 
   it "discards the existing buffer content upon error" do
-    buffer = 'hello'
+    buffer = +'hello'
     @wr.close
     -> { @rd.readpartial(1, buffer) }.should raise_error(EOFError)
     buffer.should be_empty
@@ -95,7 +95,7 @@ describe "IO#readpartial" do
 
   ruby_bug "#18421", ""..."3.0.4" do
     it "clears and returns the given buffer if the length argument is 0" do
-      buffer = "existing content"
+      buffer = +"existing content"
       @rd.readpartial(0, buffer).should == buffer
       buffer.should == ""
     end

--- a/core/io/shared/readlines.rb
+++ b/core/io/shared/readlines.rb
@@ -99,7 +99,7 @@ describe :io_readlines_options_19, shared: true do
       end
 
       it "accepts non-ASCII data as separator" do
-        result = IO.send(@method, @name, "\303\250".force_encoding("utf-8"), &@object)
+        result = IO.send(@method, @name, "\303\250".dup.force_encoding("utf-8"), &@object)
         (result ? result : ScratchPad.recorded).should == IOSpecs.lines_arbitrary_separator
       end
     end

--- a/core/io/sysread_spec.rb
+++ b/core/io/sysread_spec.rb
@@ -21,25 +21,25 @@ describe "IO#sysread on a file" do
   end
 
   it "reads the specified number of bytes from the file to the buffer" do
-    buf = "" # empty buffer
+    buf = +"" # empty buffer
     @file.sysread(15, buf).should == buf
     buf.should == "012345678901234"
 
     @file.rewind
 
-    buf = "ABCDE" # small buffer
+    buf = +"ABCDE" # small buffer
     @file.sysread(15, buf).should == buf
     buf.should == "012345678901234"
 
     @file.rewind
 
-    buf = "ABCDE" * 5 # large buffer
+    buf = +"ABCDE" * 5 # large buffer
     @file.sysread(15, buf).should == buf
     buf.should == "012345678901234"
   end
 
   it "coerces the second argument to string and uses it as a buffer" do
-    buf = "ABCDE"
+    buf = +"ABCDE"
     (obj = mock("buff")).should_receive(:to_str).any_number_of_times.and_return(buf)
     @file.sysread(15, obj).should == buf
     buf.should == "012345678901234"
@@ -90,19 +90,19 @@ describe "IO#sysread on a file" do
   end
 
   it "immediately returns the given buffer if the length argument is 0" do
-    buffer = "existing content"
+    buffer = +"existing content"
     @file.sysread(0, buffer).should == buffer
     buffer.should == "existing content"
   end
 
   it "discards the existing buffer content upon successful read" do
-    buffer = "existing content"
+    buffer = +"existing content"
     @file.sysread(11, buffer)
     buffer.should == "01234567890"
   end
 
   it "discards the existing buffer content upon error" do
-    buffer = "existing content"
+    buffer = +"existing content"
     @file.seek(0, :END)
     -> { @file.sysread(1, buffer) }.should raise_error(EOFError)
     buffer.should be_empty

--- a/core/kernel/Float_spec.rb
+++ b/core/kernel/Float_spec.rb
@@ -41,7 +41,7 @@ describe :kernel_float, shared: true do
   end
 
   it "converts Strings to floats without calling #to_f" do
-    string = "10"
+    string = +"10"
     string.should_not_receive(:to_f)
     @object.send(:Float, string).should == 10.0
   end

--- a/core/kernel/String_spec.rb
+++ b/core/kernel/String_spec.rb
@@ -78,7 +78,7 @@ describe :kernel_String, shared: true do
   end
 
   it "returns the same object if it is already a String" do
-    string = "Hello"
+    string = +"Hello"
     string.should_not_receive(:to_s)
     string2 = @object.send(@method, string)
     string.should equal(string2)

--- a/core/kernel/catch_spec.rb
+++ b/core/kernel/catch_spec.rb
@@ -35,7 +35,7 @@ describe "Kernel.catch" do
   end
 
   it "raises an ArgumentError if a String with different identity is thrown" do
-    -> { catch("exit") { throw "exit" } }.should raise_error(ArgumentError)
+    -> { catch("exit".dup) { throw "exit".dup } }.should raise_error(ArgumentError)
   end
 
   it "catches a Symbol when thrown a matching Symbol" do

--- a/core/kernel/class_spec.rb
+++ b/core/kernel/class_spec.rb
@@ -19,7 +19,7 @@ describe "Kernel#class" do
   end
 
   it "returns the first non-singleton class" do
-    a = "hello"
+    a = +"hello"
     def a.my_singleton_method; end
     a.class.should equal(String)
   end

--- a/core/kernel/eval_spec.rb
+++ b/core/kernel/eval_spec.rb
@@ -350,9 +350,6 @@ CODE
     end
 
     it "allows a magic encoding comment and a subsequent frozen_string_literal magic comment" do
-      # Make sure frozen_string_literal is not default true
-      eval("'foo'".b).frozen?.should be_false
-
       code = <<CODE.b
 # encoding: UTF-8
 # frozen_string_literal: true
@@ -403,6 +400,7 @@ CODE
     end
 
     it "ignores the frozen_string_literal magic comment if it appears after a token and warns if $VERBOSE is true" do
+      default_frozen_string_literal = "test".frozen?
       code = <<CODE
 some_token_before_magic_comment = :anything
 # frozen_string_literal: true
@@ -411,11 +409,11 @@ class EvalSpecs
 end
 CODE
       -> { eval(code) }.should complain(/warning: [`']frozen_string_literal' is ignored after any tokens/, verbose: true)
-      EvalSpecs::Vπstring_not_frozen.frozen?.should be_false
+      EvalSpecs::Vπstring_not_frozen.frozen?.should == default_frozen_string_literal
       EvalSpecs.send :remove_const, :Vπstring_not_frozen
 
       -> { eval(code) }.should_not complain(verbose: false)
-      EvalSpecs::Vπstring_not_frozen.frozen?.should be_false
+      EvalSpecs::Vπstring_not_frozen.frozen?.should == default_frozen_string_literal
       EvalSpecs.send :remove_const, :Vπstring_not_frozen
     end
   end

--- a/core/kernel/shared/sprintf_encoding.rb
+++ b/core/kernel/shared/sprintf_encoding.rb
@@ -14,14 +14,14 @@ describe :kernel_sprintf_encoding, shared: true do
   end
 
   it "returns a String in the same encoding as the format String if compatible" do
-    string = "%s".force_encoding(Encoding::KOI8_U)
+    string = "%s".dup.force_encoding(Encoding::KOI8_U)
     result = @method.call(string, "dogs")
     result.encoding.should equal(Encoding::KOI8_U)
   end
 
   it "returns a String in the argument's encoding if format encoding is more restrictive" do
-    string = "foo %s".force_encoding(Encoding::US_ASCII)
-    argument = "b\303\274r".force_encoding(Encoding::UTF_8)
+    string = "foo %s".dup.force_encoding(Encoding::US_ASCII)
+    argument = "b\303\274r".dup.force_encoding(Encoding::UTF_8)
 
     result = @method.call(string, argument)
     result.encoding.should equal(Encoding::UTF_8)
@@ -56,7 +56,7 @@ describe :kernel_sprintf_encoding, shared: true do
     end
 
     it "uses the encoding of the format string to interpret codepoints" do
-      format = "%c".force_encoding("euc-jp")
+      format = "%c".dup.force_encoding("euc-jp")
       result = @method.call(format, 9415601)
 
       result.encoding.should == Encoding::EUC_JP

--- a/core/marshal/dump_spec.rb
+++ b/core/marshal/dump_spec.rb
@@ -76,7 +76,7 @@ describe "Marshal.dump" do
     end
 
     it "dumps a binary encoded Symbol" do
-      s = "\u2192".force_encoding("binary").to_sym
+      s = "\u2192".dup.force_encoding("binary").to_sym
       Marshal.dump(s).should == "\x04\b:\b\xE2\x86\x92"
     end
 
@@ -85,8 +85,8 @@ describe "Marshal.dump" do
       symbol1 = "I:\t\xE2\x82\xACa\x06:\x06ET"
       symbol2 = "I:\t\xE2\x82\xACb\x06;\x06T"
       value = [
-        "€a".force_encoding(Encoding::UTF_8).to_sym,
-        "€b".force_encoding(Encoding::UTF_8).to_sym
+        "€a".dup.force_encoding(Encoding::UTF_8).to_sym,
+        "€b".dup.force_encoding(Encoding::UTF_8).to_sym
       ]
       Marshal.dump(value).should == "\x04\b[\a#{symbol1}#{symbol2}"
 
@@ -150,7 +150,7 @@ describe "Marshal.dump" do
     it "indexes instance variables of a String returned by #_dump at first and then indexes the object itself" do
       class MarshalSpec::M1::A
         def _dump(level)
-          s = "<dump>"
+          s = +"<dump>"
           s.instance_variable_set(:@foo, "bar")
           s
         end
@@ -194,7 +194,7 @@ describe "Marshal.dump" do
     end
 
     it "dumps a class with multibyte characters in name" do
-      source_object = eval("MarshalSpec::MultibyteぁあぃいClass".force_encoding(Encoding::UTF_8))
+      source_object = eval("MarshalSpec::MultibyteぁあぃいClass".dup.force_encoding(Encoding::UTF_8))
       Marshal.dump(source_object).should == "\x04\bc,MarshalSpec::Multibyte\xE3\x81\x81\xE3\x81\x82\xE3\x81\x83\xE3\x81\x84Class"
     end
 
@@ -217,7 +217,7 @@ describe "Marshal.dump" do
     end
 
     it "dumps a module with multibyte characters in name" do
-      source_object = eval("MarshalSpec::MultibyteけげこごModule".force_encoding(Encoding::UTF_8))
+      source_object = eval("MarshalSpec::MultibyteけげこごModule".dup.force_encoding(Encoding::UTF_8))
       Marshal.dump(source_object).should == "\x04\bm-MarshalSpec::Multibyte\xE3\x81\x91\xE3\x81\x92\xE3\x81\x93\xE3\x81\x94Module"
     end
 
@@ -285,11 +285,11 @@ describe "Marshal.dump" do
 
   describe "with a String" do
     it "dumps a blank String" do
-      Marshal.dump("".force_encoding("binary")).should == "\004\b\"\000"
+      Marshal.dump("".dup.force_encoding("binary")).should == "\004\b\"\000"
     end
 
     it "dumps a short String" do
-      Marshal.dump("short".force_encoding("binary")).should == "\004\b\"\012short"
+      Marshal.dump("short".dup.force_encoding("binary")).should == "\004\b\"\012short"
     end
 
     it "dumps a long String" do
@@ -297,7 +297,7 @@ describe "Marshal.dump" do
     end
 
     it "dumps a String extended with a Module" do
-      Marshal.dump("".extend(Meths).force_encoding("binary")).should == "\004\be:\nMeths\"\000"
+      Marshal.dump("".dup.extend(Meths).force_encoding("binary")).should == "\004\be:\nMeths\"\000"
     end
 
     it "dumps a String subclass" do
@@ -314,23 +314,23 @@ describe "Marshal.dump" do
     end
 
     it "dumps a String with instance variables" do
-      str = ""
+      str = +""
       str.instance_variable_set("@foo", "bar")
       Marshal.dump(str.force_encoding("binary")).should == "\x04\bI\"\x00\x06:\t@foo\"\bbar"
     end
 
     it "dumps a US-ASCII String" do
-      str = "abc".force_encoding("us-ascii")
+      str = "abc".dup.force_encoding("us-ascii")
       Marshal.dump(str).should == "\x04\bI\"\babc\x06:\x06EF"
     end
 
     it "dumps a UTF-8 String" do
-      str = "\x6d\xc3\xb6\x68\x72\x65".force_encoding("utf-8")
+      str = "\x6d\xc3\xb6\x68\x72\x65".dup.force_encoding("utf-8")
       Marshal.dump(str).should == "\x04\bI\"\vm\xC3\xB6hre\x06:\x06ET"
     end
 
     it "dumps a String in another encoding" do
-      str = "\x6d\x00\xf6\x00\x68\x00\x72\x00\x65\x00".force_encoding("utf-16le")
+      str = "\x6d\x00\xf6\x00\x68\x00\x72\x00\x65\x00".dup.force_encoding("utf-16le")
       result = "\x04\bI\"\x0Fm\x00\xF6\x00h\x00r\x00e\x00\x06:\rencoding\"\rUTF-16LE"
       Marshal.dump(str).should == result
     end
@@ -364,7 +364,7 @@ describe "Marshal.dump" do
     end
 
     it "dumps a binary Regexp" do
-      o = Regexp.new("".force_encoding("binary"), Regexp::FIXEDENCODING)
+      o = Regexp.new("".dup.force_encoding("binary"), Regexp::FIXEDENCODING)
       Marshal.dump(o).should == "\x04\b/\x00\x10"
     end
 
@@ -383,18 +383,18 @@ describe "Marshal.dump" do
     end
 
     it "dumps a UTF-8 Regexp" do
-      o = Regexp.new("".force_encoding("utf-8"), Regexp::FIXEDENCODING)
+      o = Regexp.new("".dup.force_encoding("utf-8"), Regexp::FIXEDENCODING)
       Marshal.dump(o).should == "\x04\bI/\x00\x10\x06:\x06ET"
 
-      o = Regexp.new("a".force_encoding("utf-8"), Regexp::FIXEDENCODING)
+      o = Regexp.new("a".dup.force_encoding("utf-8"), Regexp::FIXEDENCODING)
       Marshal.dump(o).should == "\x04\bI/\x06a\x10\x06:\x06ET"
 
-      o = Regexp.new("\u3042".force_encoding("utf-8"), Regexp::FIXEDENCODING)
+      o = Regexp.new("\u3042".dup.force_encoding("utf-8"), Regexp::FIXEDENCODING)
       Marshal.dump(o).should == "\x04\bI/\b\xE3\x81\x82\x10\x06:\x06ET"
     end
 
     it "dumps a Regexp in another encoding" do
-      o = Regexp.new("".force_encoding("utf-16le"), Regexp::FIXEDENCODING)
+      o = Regexp.new("".dup.force_encoding("utf-16le"), Regexp::FIXEDENCODING)
       Marshal.dump(o).should == "\x04\bI/\x00\x10\x06:\rencoding\"\rUTF-16LE"
 
       o = Regexp.new("a".encode("utf-16le"), Regexp::FIXEDENCODING)
@@ -553,7 +553,7 @@ describe "Marshal.dump" do
 
     it "dumps an Object with a non-US-ASCII instance variable" do
       obj = Object.new
-      ivar = "@é".force_encoding(Encoding::UTF_8).to_sym
+      ivar = "@é".dup.force_encoding(Encoding::UTF_8).to_sym
       obj.instance_variable_set(ivar, 1)
       Marshal.dump(obj).should == "\x04\bo:\vObject\x06I:\b@\xC3\xA9\x06:\x06ETi\x06"
     end
@@ -685,7 +685,7 @@ describe "Marshal.dump" do
     end
 
     it "dumps a Time subclass with multibyte characters in name" do
-      source_object = eval("MarshalSpec::MultibyteぁあぃいTime".force_encoding(Encoding::UTF_8))
+      source_object = eval("MarshalSpec::MultibyteぁあぃいTime".dup.force_encoding(Encoding::UTF_8))
       Marshal.dump(source_object).should == "\x04\bc+MarshalSpec::Multibyte\xE3\x81\x81\xE3\x81\x82\xE3\x81\x83\xE3\x81\x84Time"
     end
 

--- a/core/marshal/fixtures/marshal_data.rb
+++ b/core/marshal/fixtures/marshal_data.rb
@@ -38,7 +38,7 @@ class UserDefinedWithIvar
   attr_reader :a, :b, :c
 
   def initialize
-    @a = 'stuff'
+    @a = +'stuff'
     @a.instance_variable_set :@foo, :UserDefinedWithIvar
     @b = 'more'
     @c = @b
@@ -267,7 +267,7 @@ module MarshalSpec
     end
   end
 
-  module_eval(<<~ruby.force_encoding(Encoding::UTF_8))
+  module_eval(<<~ruby.dup.force_encoding(Encoding::UTF_8))
     class MultibyteぁあぃいClass
     end
 
@@ -313,7 +313,7 @@ module MarshalSpec
                        "\004\b\"\012small"],
     "String big" => ['big' * 100,
                      "\004\b\"\002,\001#{'big' * 100}"],
-    "String extended" => [''.extend(Meths), # TODO: check for module on load
+    "String extended" => [''.dup.extend(Meths), # TODO: check for module on load
                           "\004\be:\nMeths\"\000"],
     "String subclass" => [UserString.new,
                           "\004\bC:\017UserString\"\000"],
@@ -420,7 +420,7 @@ module MarshalSpec
                     "\x04\bI\"\nsmall\x06:\x06EF"],
     "String big" => ['big' * 100,
                     "\x04\bI\"\x02,\x01bigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbigbig\x06:\x06EF"],
-    "String extended" => [''.extend(Meths), # TODO: check for module on load
+    "String extended" => [''.dup.extend(Meths), # TODO: check for module on load
                           "\x04\bIe:\nMeths\"\x00\x06:\x06EF"],
     "String subclass" => [UserString.new,
                           "\004\bC:\017UserString\"\000"],

--- a/core/marshal/shared/load.rb
+++ b/core/marshal/shared/load.rb
@@ -183,7 +183,7 @@ describe :marshal_load, shared: true do
       describe "when called with a proc" do
         it "call the proc with frozen objects" do
           arr = []
-          s = 'hi'
+          s = +'hi'
           s.instance_variable_set(:@foo, 5)
           st = Struct.new("Brittle", :a).new
           st.instance_variable_set(:@clue, 'none')
@@ -268,7 +268,7 @@ describe :marshal_load, shared: true do
 
       it "loads an Array with proc" do
         arr = []
-        s = 'hi'
+        s = +'hi'
         s.instance_variable_set(:@foo, 5)
         st = Struct.new("Brittle", :a).new
         st.instance_variable_set(:@clue, 'none')
@@ -413,13 +413,13 @@ describe :marshal_load, shared: true do
   end
 
   it "raises a TypeError with bad Marshal version" do
-    marshal_data = '\xff\xff'
+    marshal_data = +'\xff\xff'
     marshal_data[0] = (Marshal::MAJOR_VERSION).chr
     marshal_data[1] = (Marshal::MINOR_VERSION + 1).chr
 
     -> { Marshal.send(@method, marshal_data) }.should raise_error(TypeError)
 
-    marshal_data = '\xff\xff'
+    marshal_data = +'\xff\xff'
     marshal_data[0] = (Marshal::MAJOR_VERSION - 1).chr
     marshal_data[1] = (Marshal::MINOR_VERSION).chr
 
@@ -470,7 +470,7 @@ describe :marshal_load, shared: true do
     end
 
     it "loads an array having ivar" do
-      s = 'well'
+      s = +'well'
       s.instance_variable_set(:@foo, 10)
       obj = ['5', s, 'hi'].extend(Meths, MethsMore)
       obj.instance_variable_set(:@mix, s)
@@ -516,7 +516,7 @@ describe :marshal_load, shared: true do
     end
 
     it "preserves hash ivars when hash contains a string having ivar" do
-      s = 'string'
+      s = +'string'
       s.instance_variable_set :@string_ivar, 'string ivar'
       h = { key: s }
       h.instance_variable_set :@hash_ivar, 'hash ivar'
@@ -600,7 +600,7 @@ describe :marshal_load, shared: true do
     end
 
     it "loads a binary encoded Symbol" do
-      s = "\u2192".force_encoding("binary").to_sym
+      s = "\u2192".dup.force_encoding("binary").to_sym
       sym = Marshal.send(@method, "\x04\b:\b\xE2\x86\x92")
       sym.should == s
       sym.encoding.should == Encoding::BINARY
@@ -614,8 +614,8 @@ describe :marshal_load, shared: true do
       value = Marshal.send(@method, dump)
       value.map(&:encoding).should == [Encoding::UTF_8, Encoding::UTF_8]
       expected = [
-        "€a".force_encoding(Encoding::UTF_8).to_sym,
-        "€b".force_encoding(Encoding::UTF_8).to_sym
+        "€a".dup.force_encoding(Encoding::UTF_8).to_sym,
+        "€b".dup.force_encoding(Encoding::UTF_8).to_sym
       ]
       value.should == expected
 
@@ -635,7 +635,7 @@ describe :marshal_load, shared: true do
 
   describe "for a String" do
     it "loads a string having ivar with ref to self" do
-      obj = 'hi'
+      obj = +'hi'
       obj.instance_variable_set(:@self, obj)
       Marshal.send(@method, "\004\bI\"\ahi\006:\n@self@\000").should == obj
     end
@@ -647,7 +647,7 @@ describe :marshal_load, shared: true do
     end
 
     it "sets binmode if it is loading through StringIO stream" do
-      io = StringIO.new("\004\b:\vsymbol")
+      io = StringIO.new(+"\004\b:\vsymbol")
       def io.binmode; raise "binmode"; end
       -> { Marshal.load(io) }.should raise_error(RuntimeError, "binmode")
     end
@@ -663,7 +663,7 @@ describe :marshal_load, shared: true do
     end
 
     it "loads a US-ASCII String" do
-      str = "abc".force_encoding("us-ascii")
+      str = "abc".dup.force_encoding("us-ascii")
       data = "\x04\bI\"\babc\x06:\x06EF"
       result = Marshal.send(@method, data)
       result.should == str
@@ -671,7 +671,7 @@ describe :marshal_load, shared: true do
     end
 
     it "loads a UTF-8 String" do
-      str = "\x6d\xc3\xb6\x68\x72\x65".force_encoding("utf-8")
+      str = "\x6d\xc3\xb6\x68\x72\x65".dup.force_encoding("utf-8")
       data = "\x04\bI\"\vm\xC3\xB6hre\x06:\x06ET"
       result = Marshal.send(@method, data)
       result.should == str
@@ -679,7 +679,7 @@ describe :marshal_load, shared: true do
     end
 
     it "loads a String in another encoding" do
-      str = "\x6d\x00\xf6\x00\x68\x00\x72\x00\x65\x00".force_encoding("utf-16le")
+      str = "\x6d\x00\xf6\x00\x68\x00\x72\x00\x65\x00".dup.force_encoding("utf-16le")
       data = "\x04\bI\"\x0Fm\x00\xF6\x00h\x00r\x00e\x00\x06:\rencoding\"\rUTF-16LE"
       result = Marshal.send(@method, data)
       result.should == str
@@ -687,8 +687,8 @@ describe :marshal_load, shared: true do
     end
 
     it "loads a String as BINARY if no encoding is specified at the end" do
-      str = "\xC3\xB8".force_encoding("BINARY")
-      data = "\x04\b\"\a\xC3\xB8".force_encoding("UTF-8")
+      str = "\xC3\xB8".dup.force_encoding("BINARY")
+      data = "\x04\b\"\a\xC3\xB8".dup.force_encoding("UTF-8")
       result = Marshal.send(@method, data)
       result.encoding.should == Encoding::BINARY
       result.should == str
@@ -823,7 +823,7 @@ describe :marshal_load, shared: true do
     end
 
     it "loads an Object with a non-US-ASCII instance variable" do
-      ivar = "@é".force_encoding(Encoding::UTF_8).to_sym
+      ivar = "@é".dup.force_encoding(Encoding::UTF_8).to_sym
       obj = Marshal.send(@method, "\x04\bo:\vObject\x06I:\b@\xC3\xA9\x06:\x06ETi\x06")
       obj.instance_variables.should == [ivar]
       obj.instance_variables[0].encoding.should == Encoding::UTF_8

--- a/core/matchdata/element_reference_spec.rb
+++ b/core/matchdata/element_reference_spec.rb
@@ -113,7 +113,7 @@ describe "MatchData#[Symbol]" do
 
   it "returns matches in the String's encoding" do
     rex = /(?<t>t(?<a>ack))/u
-    md = 'haystack'.force_encoding('euc-jp').match(rex)
+    md = 'haystack'.dup.force_encoding('euc-jp').match(rex)
     md[:t].encoding.should == Encoding::EUC_JP
   end
 end

--- a/core/matchdata/post_match_spec.rb
+++ b/core/matchdata/post_match_spec.rb
@@ -8,12 +8,12 @@ describe "MatchData#post_match" do
   end
 
   it "sets the encoding to the encoding of the source String" do
-    str = "abc".force_encoding Encoding::EUC_JP
+    str = "abc".dup.force_encoding Encoding::EUC_JP
     str.match(/b/).post_match.encoding.should equal(Encoding::EUC_JP)
   end
 
   it "sets an empty result to the encoding of the source String" do
-    str = "abc".force_encoding Encoding::ISO_8859_1
+    str = "abc".dup.force_encoding Encoding::ISO_8859_1
     str.match(/c/).post_match.encoding.should equal(Encoding::ISO_8859_1)
   end
 

--- a/core/matchdata/pre_match_spec.rb
+++ b/core/matchdata/pre_match_spec.rb
@@ -8,12 +8,12 @@ describe "MatchData#pre_match" do
   end
 
   it "sets the encoding to the encoding of the source String" do
-    str = "abc".force_encoding Encoding::EUC_JP
+    str = "abc".dup.force_encoding Encoding::EUC_JP
     str.match(/b/).pre_match.encoding.should equal(Encoding::EUC_JP)
   end
 
   it "sets an empty result to the encoding of the source String" do
-    str = "abc".force_encoding Encoding::ISO_8859_1
+    str = "abc".dup.force_encoding Encoding::ISO_8859_1
     str.match(/a/).pre_match.encoding.should equal(Encoding::ISO_8859_1)
   end
 

--- a/core/matchdata/string_spec.rb
+++ b/core/matchdata/string_spec.rb
@@ -17,8 +17,9 @@ describe "MatchData#string" do
     md.string.should equal(md.string)
   end
 
-  it "returns a frozen copy of the matched string for gsub(String)" do
-    'he[[o'.gsub!('[', ']')
+  it "returns a frozen copy of the matched string for gsub!(String)" do
+    s = +'he[[o'
+    s.gsub!('[', ']')
     $~.string.should == 'he[[o'
     $~.string.should.frozen?
   end

--- a/core/method/to_proc_spec.rb
+++ b/core/method/to_proc_spec.rb
@@ -35,7 +35,7 @@ describe "Method#to_proc" do
   end
 
   it "returns a proc that can be used by define_method" do
-    x = 'test'
+    x = +'test'
     to_s = class << x
       define_method :foo, method(:to_s).to_proc
       to_s

--- a/core/module/using_spec.rb
+++ b/core/module/using_spec.rb
@@ -316,7 +316,7 @@ describe "Module#using" do
         using refinement
 
         def initialize
-          @a = "1703"
+          @a = +"1703"
 
           @a.instance_eval do
             def abc

--- a/core/objectspace/define_finalizer_spec.rb
+++ b/core/objectspace/define_finalizer_spec.rb
@@ -52,7 +52,7 @@ describe "ObjectSpace.define_finalizer" do
         Proc.new { puts "finalizer run" }
       end
       handler = scoped
-      obj = "Test"
+      obj = +"Test"
       ObjectSpace.define_finalizer(obj, handler)
       exit 0
     RUBY
@@ -111,7 +111,7 @@ describe "ObjectSpace.define_finalizer" do
 
   it "calls a finalizer at exit even if it is self-referencing" do
     code = <<-RUBY
-      obj = "Test"
+      obj = +"Test"
       handler = Proc.new { puts "finalizer run" }
       ObjectSpace.define_finalizer(obj, handler)
       exit 0
@@ -141,9 +141,9 @@ describe "ObjectSpace.define_finalizer" do
 
   it "calls a finalizer defined in a finalizer running at exit" do
     code = <<-RUBY
-      obj = "Test"
+      obj = +"Test"
       handler = Proc.new do
-        obj2 = "Test"
+        obj2 = +"Test"
         handler2 = Proc.new { puts "finalizer 2 run" }
         ObjectSpace.define_finalizer(obj2, handler2)
         exit 0

--- a/core/proc/fixtures/proc_aref.rb
+++ b/core/proc/fixtures/proc_aref.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 module ProcArefSpecs
   def self.aref
     proc {|a| a }["sometext"]

--- a/core/regexp/shared/new.rb
+++ b/core/regexp/shared/new.rb
@@ -489,12 +489,12 @@ describe :regexp_new_string, shared: true do
     end
 
     it "returns a Regexp with the input String's encoding" do
-      str = "\x82\xa0".force_encoding(Encoding::Shift_JIS)
+      str = "\x82\xa0".dup.force_encoding(Encoding::Shift_JIS)
       Regexp.send(@method, str).encoding.should == Encoding::Shift_JIS
     end
 
     it "returns a Regexp with source String having the input String's encoding" do
-      str = "\x82\xa0".force_encoding(Encoding::Shift_JIS)
+      str = "\x82\xa0".dup.force_encoding(Encoding::Shift_JIS)
       Regexp.send(@method, str).source.encoding.should == Encoding::Shift_JIS
     end
   end

--- a/core/regexp/shared/quote.rb
+++ b/core/regexp/shared/quote.rb
@@ -18,23 +18,23 @@ describe :regexp_quote, shared: true do
   end
 
   it "works for broken strings" do
-    Regexp.send(@method, "a.\x85b.".force_encoding("US-ASCII")).should =="a\\.\x85b\\.".force_encoding("US-ASCII")
-    Regexp.send(@method, "a.\x80".force_encoding("UTF-8")).should == "a\\.\x80".force_encoding("UTF-8")
+    Regexp.send(@method, "a.\x85b.".dup.force_encoding("US-ASCII")).should =="a\\.\x85b\\.".dup.force_encoding("US-ASCII")
+    Regexp.send(@method, "a.\x80".dup.force_encoding("UTF-8")).should == "a\\.\x80".dup.force_encoding("UTF-8")
   end
 
   it "sets the encoding of the result to US-ASCII if there are only US-ASCII characters present in the input String" do
-    str = "abc".force_encoding("euc-jp")
+    str = "abc".dup.force_encoding("euc-jp")
     Regexp.send(@method, str).encoding.should == Encoding::US_ASCII
   end
 
   it "sets the encoding of the result to the encoding of the String if any non-US-ASCII characters are present in an input String with valid encoding" do
-    str = "ありがとう".force_encoding("utf-8")
+    str = "ありがとう".dup.force_encoding("utf-8")
     str.valid_encoding?.should be_true
     Regexp.send(@method, str).encoding.should == Encoding::UTF_8
   end
 
   it "sets the encoding of the result to BINARY if any non-US-ASCII characters are present in an input String with invalid encoding" do
-    str = "\xff".force_encoding "us-ascii"
+    str = "\xff".dup.force_encoding "us-ascii"
     str.valid_encoding?.should be_false
     Regexp.send(@method, "\xff").encoding.should == Encoding::BINARY
   end

--- a/core/string/ascii_only_spec.rb
+++ b/core/string/ascii_only_spec.rb
@@ -7,12 +7,12 @@ describe "String#ascii_only?" do
     it "returns true if the encoding is UTF-8" do
       [ ["hello",                         true],
         ["hello".encode('UTF-8'),         true],
-        ["hello".force_encoding('UTF-8'), true],
+        ["hello".dup.force_encoding('UTF-8'), true],
       ].should be_computed_by(:ascii_only?)
     end
 
     it "returns true if the encoding is US-ASCII" do
-      "hello".force_encoding(Encoding::US_ASCII).ascii_only?.should be_true
+      "hello".dup.force_encoding(Encoding::US_ASCII).ascii_only?.should be_true
       "hello".encode(Encoding::US_ASCII).ascii_only?.should be_true
     end
 
@@ -34,13 +34,13 @@ describe "String#ascii_only?" do
       [ ["\u{6666}",                          false],
         ["hello, \u{6666}",                   false],
         ["\u{6666}".encode('UTF-8'),          false],
-        ["\u{6666}".force_encoding('UTF-8'),  false],
+        ["\u{6666}".dup.force_encoding('UTF-8'),  false],
       ].should be_computed_by(:ascii_only?)
     end
 
     it "returns false if the encoding is US-ASCII" do
-      [ ["\u{6666}".force_encoding(Encoding::US_ASCII),         false],
-        ["hello, \u{6666}".force_encoding(Encoding::US_ASCII),  false],
+      [ ["\u{6666}".dup.force_encoding(Encoding::US_ASCII),         false],
+        ["hello, \u{6666}".dup.force_encoding(Encoding::US_ASCII),  false],
       ].should be_computed_by(:ascii_only?)
     end
   end
@@ -51,17 +51,16 @@ describe "String#ascii_only?" do
   end
 
   it "returns false for the empty String with a non-ASCII-compatible encoding" do
-    "".force_encoding('UTF-16LE').ascii_only?.should be_false
+    "".dup.force_encoding('UTF-16LE').ascii_only?.should be_false
     "".encode('UTF-16BE').ascii_only?.should be_false
   end
 
   it "returns false for a non-empty String with non-ASCII-compatible encoding" do
-    "\x78\x00".force_encoding("UTF-16LE").ascii_only?.should be_false
+    "\x78\x00".dup.force_encoding("UTF-16LE").ascii_only?.should be_false
   end
 
   it "returns false when interpolating non ascii strings" do
-    base = "EU currency is"
-    base.force_encoding(Encoding::US_ASCII)
+    base = "EU currency is".dup.force_encoding(Encoding::US_ASCII)
     euro = "\u20AC"
     interp = "#{base} #{euro}"
     euro.ascii_only?.should be_false
@@ -70,14 +69,14 @@ describe "String#ascii_only?" do
   end
 
   it "returns false after appending non ASCII characters to an empty String" do
-    ("" << "λ").ascii_only?.should be_false
+    ("".dup << "λ").ascii_only?.should be_false
   end
 
   it "returns false when concatenating an ASCII and non-ASCII String" do
-    "".concat("λ").ascii_only?.should be_false
+    "".dup.concat("λ").ascii_only?.should be_false
   end
 
   it "returns false when replacing an ASCII String with a non-ASCII String" do
-    "".replace("λ").ascii_only?.should be_false
+    "".dup.replace("λ").ascii_only?.should be_false
   end
 end

--- a/core/string/b_spec.rb
+++ b/core/string/b_spec.rb
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 
 describe "String#b" do

--- a/core/string/byteindex_spec.rb
+++ b/core/string/byteindex_spec.rb
@@ -156,11 +156,11 @@ describe "String#byteindex with String" do
     end
 
     it "handles a substring in a superset encoding" do
-      'abc'.force_encoding(Encoding::US_ASCII).byteindex('é').should == nil
+      'abc'.dup.force_encoding(Encoding::US_ASCII).byteindex('é').should == nil
     end
 
     it "handles a substring in a subset encoding" do
-      'été'.byteindex('t'.force_encoding(Encoding::US_ASCII)).should == 2
+      'été'.byteindex('t'.dup.force_encoding(Encoding::US_ASCII)).should == 2
     end
   end
 end

--- a/core/string/byterindex_spec.rb
+++ b/core/string/byterindex_spec.rb
@@ -191,11 +191,11 @@ describe "String#byterindex with String" do
     end
 
     it "handles a substring in a superset encoding" do
-      'abc'.force_encoding(Encoding::US_ASCII).byterindex('é').should == nil
+      'abc'.dup.force_encoding(Encoding::US_ASCII).byterindex('é').should == nil
     end
 
     it "handles a substring in a subset encoding" do
-      'été'.byterindex('t'.force_encoding(Encoding::US_ASCII)).should == 2
+      'été'.byterindex('t'.dup.force_encoding(Encoding::US_ASCII)).should == 2
     end
   end
 end

--- a/core/string/bytes_spec.rb
+++ b/core/string/bytes_spec.rb
@@ -50,6 +50,6 @@ describe "String#bytes" do
   end
 
   it "is unaffected by #force_encoding" do
-    @utf8.force_encoding('ASCII').bytes.to_a.should == @utf8.bytes.to_a
+    @utf8.dup.force_encoding('ASCII').bytes.to_a.should == @utf8.bytes.to_a
   end
 end

--- a/core/string/bytesize_spec.rb
+++ b/core/string/bytesize_spec.rb
@@ -13,21 +13,21 @@ describe "String#bytesize" do
   end
 
   it "works with pseudo-ASCII strings containing single UTF-8 characters" do
-    "\u{6666}".force_encoding('ASCII').bytesize.should == 3
+    "\u{6666}".dup.force_encoding('ASCII').bytesize.should == 3
   end
 
   it "works with strings containing UTF-8 characters" do
-    "c \u{6666}".force_encoding('UTF-8').bytesize.should == 5
+    "c \u{6666}".dup.force_encoding('UTF-8').bytesize.should == 5
     "c \u{6666}".bytesize.should == 5
   end
 
   it "works with pseudo-ASCII strings containing UTF-8 characters" do
-    "c \u{6666}".force_encoding('ASCII').bytesize.should == 5
+    "c \u{6666}".dup.force_encoding('ASCII').bytesize.should == 5
   end
 
   it "returns 0 for the empty string" do
     "".bytesize.should == 0
-    "".force_encoding('ASCII').bytesize.should == 0
-    "".force_encoding('UTF-8').bytesize.should == 0
+    "".dup.force_encoding('ASCII').bytesize.should == 0
+    "".dup.force_encoding('UTF-8').bytesize.should == 0
   end
 end

--- a/core/string/byteslice_spec.rb
+++ b/core/string/byteslice_spec.rb
@@ -19,10 +19,10 @@ end
 
 describe "String#byteslice on on non ASCII strings" do
   it "returns byteslice of unicode strings" do
-    "\u3042".byteslice(1).should == "\x81".force_encoding("UTF-8")
-    "\u3042".byteslice(1, 2).should == "\x81\x82".force_encoding("UTF-8")
-    "\u3042".byteslice(1..2).should == "\x81\x82".force_encoding("UTF-8")
-    "\u3042".byteslice(-1).should == "\x82".force_encoding("UTF-8")
+    "\u3042".byteslice(1).should == "\x81".dup.force_encoding("UTF-8")
+    "\u3042".byteslice(1, 2).should == "\x81\x82".dup.force_encoding("UTF-8")
+    "\u3042".byteslice(1..2).should == "\x81\x82".dup.force_encoding("UTF-8")
+    "\u3042".byteslice(-1).should == "\x82".dup.force_encoding("UTF-8")
   end
 
   it "returns a String in the same encoding as self" do

--- a/core/string/bytesplice_spec.rb
+++ b/core/string/bytesplice_spec.rb
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 
 describe "String#bytesplice" do

--- a/core/string/capitalize_spec.rb
+++ b/core/string/capitalize_spec.rb
@@ -90,7 +90,7 @@ end
 
 describe "String#capitalize!" do
   it "capitalizes self in place" do
-    a = "hello"
+    a = +"hello"
     a.capitalize!.should equal(a)
     a.should == "Hello"
   end
@@ -103,13 +103,13 @@ describe "String#capitalize!" do
 
   describe "full Unicode case mapping" do
     it "modifies self in place for all of Unicode with no option" do
-      a = "äöÜ"
+      a = +"äöÜ"
       a.capitalize!
       a.should == "Äöü"
     end
 
     it "only capitalizes the first resulting character when upcasing a character produces a multi-character sequence" do
-      a = "ß"
+      a = +"ß"
       a.capitalize!
       a.should == "Ss"
     end
@@ -121,7 +121,7 @@ describe "String#capitalize!" do
     end
 
     it "updates string metadata" do
-      capitalized = "ßeT"
+      capitalized = +"ßeT"
       capitalized.capitalize!
 
       capitalized.should == "Sset"
@@ -133,7 +133,7 @@ describe "String#capitalize!" do
 
   describe "modifies self in place for ASCII-only case mapping" do
     it "does not capitalize non-ASCII characters" do
-      a = "ßet"
+      a = +"ßet"
       a.capitalize!(:ascii)
       a.should == "ßet"
     end
@@ -147,13 +147,13 @@ describe "String#capitalize!" do
 
   describe "modifies self in place for full Unicode case mapping adapted for Turkic languages" do
     it "capitalizes ASCII characters according to Turkic semantics" do
-      a = "iSa"
+      a = +"iSa"
       a.capitalize!(:turkic)
       a.should == "İsa"
     end
 
     it "allows Lithuanian as an extra option" do
-      a = "iSa"
+      a = +"iSa"
       a.capitalize!(:turkic, :lithuanian)
       a.should == "İsa"
     end
@@ -165,13 +165,13 @@ describe "String#capitalize!" do
 
   describe "modifies self in place for full Unicode case mapping adapted for Lithuanian" do
     it "currently works the same as full Unicode case mapping" do
-      a = "iß"
+      a = +"iß"
       a.capitalize!(:lithuanian)
       a.should == "Iß"
     end
 
     it "allows Turkic as an extra option (and applies Turkic semantics)" do
-      a = "iß"
+      a = +"iß"
       a.capitalize!(:lithuanian, :turkic)
       a.should == "İß"
     end
@@ -190,12 +190,12 @@ describe "String#capitalize!" do
   end
 
   it "returns nil when no changes are made" do
-    a = "Hello"
+    a = +"Hello"
     a.capitalize!.should == nil
     a.should == "Hello"
 
-    "".capitalize!.should == nil
-    "H".capitalize!.should == nil
+    (+"").capitalize!.should == nil
+    (+"H").capitalize!.should == nil
   end
 
   it "raises a FrozenError when self is frozen" do

--- a/core/string/center_spec.rb
+++ b/core/string/center_spec.rb
@@ -92,7 +92,7 @@ describe "String#center with length, padding" do
 
   describe "with width" do
     it "returns a String in the same encoding as the original" do
-      str = "abc".force_encoding Encoding::IBM437
+      str = "abc".dup.force_encoding Encoding::IBM437
       result = str.center 6
       result.should == " abc  "
       result.encoding.should equal(Encoding::IBM437)
@@ -101,7 +101,7 @@ describe "String#center with length, padding" do
 
   describe "with width, pattern" do
     it "returns a String in the compatible encoding" do
-      str = "abc".force_encoding Encoding::IBM437
+      str = "abc".dup.force_encoding Encoding::IBM437
       result = str.center 6, "あ"
       result.should == "あabcああ"
       result.encoding.should equal(Encoding::UTF_8)

--- a/core/string/chomp_spec.rb
+++ b/core/string/chomp_spec.rb
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 

--- a/core/string/chop_spec.rb
+++ b/core/string/chop_spec.rb
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 

--- a/core/string/clear_spec.rb
+++ b/core/string/clear_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 
 describe "String#clear" do

--- a/core/string/codepoints_spec.rb
+++ b/core/string/codepoints_spec.rb
@@ -11,7 +11,7 @@ describe "String#codepoints" do
   end
 
   it "raises an ArgumentError when no block is given if self has an invalid encoding" do
-    s = "\xDF".force_encoding(Encoding::UTF_8)
+    s = "\xDF".dup.force_encoding(Encoding::UTF_8)
     s.valid_encoding?.should be_false
     -> { s.codepoints }.should raise_error(ArgumentError)
   end

--- a/core/string/comparison_spec.rb
+++ b/core/string/comparison_spec.rb
@@ -61,12 +61,12 @@ describe "String#<=> with String" do
   end
 
   it "ignores encoding difference" do
-    ("ÄÖÛ".force_encoding("utf-8") <=> "ÄÖÜ".force_encoding("iso-8859-1")).should == -1
-    ("ÄÖÜ".force_encoding("utf-8") <=> "ÄÖÛ".force_encoding("iso-8859-1")).should == 1
+    ("ÄÖÛ".dup.force_encoding("utf-8") <=> "ÄÖÜ".dup.force_encoding("iso-8859-1")).should == -1
+    ("ÄÖÜ".dup.force_encoding("utf-8") <=> "ÄÖÛ".dup.force_encoding("iso-8859-1")).should == 1
   end
 
   it "returns 0 with identical ASCII-compatible bytes of different encodings" do
-    ("abc".force_encoding("utf-8") <=> "abc".force_encoding("iso-8859-1")).should == 0
+    ("abc".dup.force_encoding("utf-8") <=> "abc".dup.force_encoding("iso-8859-1")).should == 0
   end
 
   it "compares the indices of the encodings when the strings have identical non-ASCII-compatible bytes" do
@@ -77,7 +77,7 @@ describe "String#<=> with String" do
   end
 
   it "returns 0 when comparing 2 empty strings but one is not ASCII-compatible" do
-    ("" <=> "".force_encoding('iso-2022-jp')).should == 0
+    ("" <=> "".dup.force_encoding('iso-2022-jp')).should == 0
   end
 end
 

--- a/core/string/concat_spec.rb
+++ b/core/string/concat_spec.rb
@@ -8,19 +8,19 @@ describe "String#concat" do
   it_behaves_like :string_concat_type_coercion, :concat
 
   it "takes multiple arguments" do
-    str = "hello "
+    str = +"hello "
     str.concat "wo", "", "rld"
     str.should == "hello world"
   end
 
   it "concatenates the initial value when given arguments contain 2 self" do
-    str = "hello"
+    str = +"hello"
     str.concat str, str
     str.should == "hellohellohello"
   end
 
   it "returns self when given no arguments" do
-    str = "hello"
+    str = +"hello"
     str.concat.should equal(str)
     str.should == "hello"
   end

--- a/core/string/delete_prefix_spec.rb
+++ b/core/string/delete_prefix_spec.rb
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 

--- a/core/string/delete_spec.rb
+++ b/core/string/delete_spec.rb
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 

--- a/core/string/delete_suffix_spec.rb
+++ b/core/string/delete_suffix_spec.rb
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 

--- a/core/string/downcase_spec.rb
+++ b/core/string/downcase_spec.rb
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 

--- a/core/string/dup_spec.rb
+++ b/core/string/dup_spec.rb
@@ -51,7 +51,7 @@ describe "String#dup" do
   end
 
   it "does not modify the original setbyte-mutated string when changing dupped string" do
-    orig = "a"
+    orig = +"a"
     orig.setbyte 0, "b".ord
     copy = orig.dup
     orig.setbyte 0, "c".ord

--- a/core/string/each_byte_spec.rb
+++ b/core/string/each_byte_spec.rb
@@ -9,26 +9,26 @@ describe "String#each_byte" do
   end
 
   it "keeps iterating from the old position (to new string end) when self changes" do
-    r = ""
-    s = "hello world"
+    r = +""
+    s = +"hello world"
     s.each_byte do |c|
       r << c
       s.insert(0, "<>") if r.size < 3
     end
     r.should == "h><>hello world"
 
-    r = ""
-    s = "hello world"
+    r = +""
+    s = +"hello world"
     s.each_byte { |c| s.slice!(-1); r << c }
     r.should == "hello "
 
-    r = ""
-    s = "hello world"
+    r = +""
+    s = +"hello world"
     s.each_byte { |c| s.slice!(0); r << c }
     r.should == "hlowrd"
 
-    r = ""
-    s = "hello world"
+    r = +""
+    s = +"hello world"
     s.each_byte { |c| s.slice!(0..-1); r << c }
     r.should == "h"
   end

--- a/core/string/element_set_spec.rb
+++ b/core/string/element_set_spec.rb
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 

--- a/core/string/encode_spec.rb
+++ b/core/string/encode_spec.rb
@@ -34,8 +34,8 @@ describe "String#encode" do
 
     it "encodes an ascii substring of a binary string to UTF-8" do
       x82 = [0x82].pack('C')
-      str =  "#{x82}foo".force_encoding("binary")[1..-1].encode("utf-8")
-      str.should == "foo".force_encoding("utf-8")
+      str =  "#{x82}foo".dup.force_encoding("binary")[1..-1].encode("utf-8")
+      str.should == "foo".dup.force_encoding("utf-8")
       str.encoding.should equal(Encoding::UTF_8)
     end
   end
@@ -49,7 +49,7 @@ describe "String#encode" do
     end
 
     it "round trips a String" do
-      str = "abc def".force_encoding Encoding::US_ASCII
+      str = "abc def".dup.force_encoding Encoding::US_ASCII
       str.encode("utf-32be").encode("ascii").should == "abc def"
     end
   end
@@ -122,8 +122,7 @@ describe "String#encode" do
 
   describe "when passed to, from" do
     it "returns a copy in the destination encoding when both encodings are the same" do
-      str = "あ"
-      str.force_encoding("binary")
+      str = "あ".dup.force_encoding("binary")
       encoded = str.encode("utf-8", "utf-8")
 
       encoded.should_not equal(str)
@@ -155,8 +154,7 @@ describe "String#encode" do
     end
 
     it "returns a copy in the destination encoding when both encodings are the same" do
-      str = "あ"
-      str.force_encoding("binary")
+      str = "あ".dup.force_encoding("binary")
       encoded = str.encode("utf-8", "utf-8", invalid: :replace)
 
       encoded.should_not equal(str)
@@ -191,13 +189,13 @@ describe "String#encode!" do
   describe "when passed no options" do
     it "returns self when Encoding.default_internal is nil" do
       Encoding.default_internal = nil
-      str = "あ"
+      str = +"あ"
       str.encode!.should equal(str)
     end
 
     it "returns self for a ASCII-only String when Encoding.default_internal is nil" do
       Encoding.default_internal = nil
-      str = "abc"
+      str = +"abc"
       str.encode!.should equal(str)
     end
   end
@@ -205,14 +203,14 @@ describe "String#encode!" do
   describe "when passed options" do
     it "returns self for ASCII-only String when Encoding.default_internal is nil" do
       Encoding.default_internal = nil
-      str = "abc"
+      str = +"abc"
       str.encode!(invalid: :replace).should equal(str)
     end
   end
 
   describe "when passed to encoding" do
     it "returns self" do
-      str = "abc"
+      str = +"abc"
       result = str.encode!(Encoding::BINARY)
       result.encoding.should equal(Encoding::BINARY)
       result.should equal(str)
@@ -221,7 +219,7 @@ describe "String#encode!" do
 
   describe "when passed to, from" do
     it "returns self" do
-      str = "ああ"
+      str = +"ああ"
       result = str.encode!("euc-jp", "utf-8")
       result.encoding.should equal(Encoding::EUC_JP)
       result.should equal(str)

--- a/core/string/encoding_spec.rb
+++ b/core/string/encoding_spec.rb
@@ -14,11 +14,11 @@ describe "String#encoding" do
   end
 
   it "returns the given encoding if #force_encoding has been called" do
-    "a".force_encoding(Encoding::SHIFT_JIS).encoding.should == Encoding::SHIFT_JIS
+    "a".dup.force_encoding(Encoding::SHIFT_JIS).encoding.should == Encoding::SHIFT_JIS
   end
 
   it "returns the given encoding if #encode!has been called" do
-    "a".encode!(Encoding::SHIFT_JIS).encoding.should == Encoding::SHIFT_JIS
+    "a".dup.encode!(Encoding::SHIFT_JIS).encoding.should == Encoding::SHIFT_JIS
   end
 end
 
@@ -108,13 +108,13 @@ describe "String#encoding for Strings with \\u escapes" do
   end
 
   it "returns the given encoding if #force_encoding has been called" do
-    "\u{20}".force_encoding(Encoding::SHIFT_JIS).encoding.should == Encoding::SHIFT_JIS
-    "\u{2020}".force_encoding(Encoding::SHIFT_JIS).encoding.should == Encoding::SHIFT_JIS
+    "\u{20}".dup.force_encoding(Encoding::SHIFT_JIS).encoding.should == Encoding::SHIFT_JIS
+    "\u{2020}".dup.force_encoding(Encoding::SHIFT_JIS).encoding.should == Encoding::SHIFT_JIS
   end
 
   it "returns the given encoding if #encode!has been called" do
-    "\u{20}".encode!(Encoding::SHIFT_JIS).encoding.should == Encoding::SHIFT_JIS
-    "\u{2020}".encode!(Encoding::SHIFT_JIS).encoding.should == Encoding::SHIFT_JIS
+    "\u{20}".dup.encode!(Encoding::SHIFT_JIS).encoding.should == Encoding::SHIFT_JIS
+    "\u{2020}".dup.encode!(Encoding::SHIFT_JIS).encoding.should == Encoding::SHIFT_JIS
   end
 end
 
@@ -173,16 +173,12 @@ describe "String#encoding for Strings with \\x escapes" do
   end
 
   it "returns the given encoding if #force_encoding has been called" do
-    x50 = "\x50"
-    x50.force_encoding(Encoding::SHIFT_JIS).encoding.should == Encoding::SHIFT_JIS
-    xD4 = [212].pack('C')
-    xD4.force_encoding(Encoding::ISO_8859_9).encoding.should == Encoding::ISO_8859_9
+    "\x50".dup.force_encoding(Encoding::SHIFT_JIS).encoding.should == Encoding::SHIFT_JIS
+    [212].pack('C').force_encoding(Encoding::ISO_8859_9).encoding.should == Encoding::ISO_8859_9
   end
 
   it "returns the given encoding if #encode!has been called" do
-    x50 = "\x50"
-    x50.encode!(Encoding::SHIFT_JIS).encoding.should == Encoding::SHIFT_JIS
-    x00 = "x\00"
-    x00.encode!(Encoding::UTF_8).encoding.should == Encoding::UTF_8
+    "\x50".dup.encode!(Encoding::SHIFT_JIS).encoding.should == Encoding::SHIFT_JIS
+    "x\00".dup.encode!(Encoding::UTF_8).encoding.should == Encoding::UTF_8
   end
 end

--- a/core/string/force_encoding_spec.rb
+++ b/core/string/force_encoding_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 
 describe "String#force_encoding" do

--- a/core/string/freeze_spec.rb
+++ b/core/string/freeze_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 
 describe "String#freeze" do

--- a/core/string/gsub_spec.rb
+++ b/core/string/gsub_spec.rb
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 

--- a/core/string/include_spec.rb
+++ b/core/string/include_spec.rb
@@ -15,16 +15,16 @@ describe "String#include? with String" do
 
   it "returns true if both strings are empty" do
     "".should.include?("")
-    "".force_encoding("EUC-JP").should.include?("")
-    "".should.include?("".force_encoding("EUC-JP"))
-    "".force_encoding("EUC-JP").should.include?("".force_encoding("EUC-JP"))
+    "".dup.force_encoding("EUC-JP").should.include?("")
+    "".should.include?("".dup.force_encoding("EUC-JP"))
+    "".dup.force_encoding("EUC-JP").should.include?("".dup.force_encoding("EUC-JP"))
   end
 
   it "returns true if the RHS is empty" do
     "a".should.include?("")
-    "a".force_encoding("EUC-JP").should.include?("")
-    "a".should.include?("".force_encoding("EUC-JP"))
-    "a".force_encoding("EUC-JP").should.include?("".force_encoding("EUC-JP"))
+    "a".dup.force_encoding("EUC-JP").should.include?("")
+    "a".should.include?("".dup.force_encoding("EUC-JP"))
+    "a".dup.force_encoding("EUC-JP").should.include?("".dup.force_encoding("EUC-JP"))
   end
 
   it "tries to convert other to string using to_str" do

--- a/core/string/index_spec.rb
+++ b/core/string/index_spec.rb
@@ -161,16 +161,16 @@ describe "String#index with String" do
   end
 
   it "handles a substring in a superset encoding" do
-    'abc'.force_encoding(Encoding::US_ASCII).index('é').should == nil
+    'abc'.dup.force_encoding(Encoding::US_ASCII).index('é').should == nil
   end
 
   it "handles a substring in a subset encoding" do
-    'été'.index('t'.force_encoding(Encoding::US_ASCII)).should == 1
+    'été'.index('t'.dup.force_encoding(Encoding::US_ASCII)).should == 1
   end
 
   it "raises an Encoding::CompatibilityError if the encodings are incompatible" do
-    str = 'abc'.force_encoding("ISO-2022-JP")
-    pattern = 'b'.force_encoding("EUC-JP")
+    str = 'abc'.dup.force_encoding("ISO-2022-JP")
+    pattern = 'b'.dup.force_encoding("EUC-JP")
 
     -> { str.index(pattern) }.should raise_error(Encoding::CompatibilityError, "incompatible character encodings: ISO-2022-JP and EUC-JP")
   end

--- a/core/string/insert_spec.rb
+++ b/core/string/insert_spec.rb
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 

--- a/core/string/inspect_spec.rb
+++ b/core/string/inspect_spec.rb
@@ -327,7 +327,7 @@ describe "String#inspect" do
   end
 
   it "works for broken US-ASCII strings" do
-    s = "©".force_encoding("US-ASCII")
+    s = "©".dup.force_encoding("US-ASCII")
     s.inspect.should == '"\xC2\xA9"'
   end
 

--- a/core/string/ljust_spec.rb
+++ b/core/string/ljust_spec.rb
@@ -75,7 +75,7 @@ describe "String#ljust with length, padding" do
 
   describe "with width" do
     it "returns a String in the same encoding as the original" do
-      str = "abc".force_encoding Encoding::IBM437
+      str = "abc".dup.force_encoding Encoding::IBM437
       result = str.ljust 5
       result.should == "abc  "
       result.encoding.should equal(Encoding::IBM437)
@@ -84,7 +84,7 @@ describe "String#ljust with length, padding" do
 
   describe "with width, pattern" do
     it "returns a String in the compatible encoding" do
-      str = "abc".force_encoding Encoding::IBM437
+      str = "abc".dup.force_encoding Encoding::IBM437
       result = str.ljust 5, "あ"
       result.should == "abcああ"
       result.encoding.should equal(Encoding::UTF_8)

--- a/core/string/lstrip_spec.rb
+++ b/core/string/lstrip_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/strip'

--- a/core/string/ord_spec.rb
+++ b/core/string/ord_spec.rb
@@ -27,7 +27,7 @@ describe "String#ord" do
   end
 
   it "raises ArgumentError if the character is broken" do
-    s = "©".force_encoding("US-ASCII")
+    s = "©".dup.force_encoding("US-ASCII")
     -> { s.ord }.should raise_error(ArgumentError, "invalid byte sequence in US-ASCII")
   end
 end

--- a/core/string/partition_spec.rb
+++ b/core/string/partition_spec.rb
@@ -40,7 +40,7 @@ describe "String#partition with String" do
   end
 
   it "handles a pattern in a superset encoding" do
-    string = "hello".force_encoding(Encoding::US_ASCII)
+    string = "hello".dup.force_encoding(Encoding::US_ASCII)
 
     result = string.partition("é")
 
@@ -51,7 +51,7 @@ describe "String#partition with String" do
   end
 
   it "handles a pattern in a subset encoding" do
-    pattern = "o".force_encoding(Encoding::US_ASCII)
+    pattern = "o".dup.force_encoding(Encoding::US_ASCII)
 
     result = "héllo world".partition(pattern)
 

--- a/core/string/prepend_spec.rb
+++ b/core/string/prepend_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 

--- a/core/string/reverse_spec.rb
+++ b/core/string/reverse_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: false
 
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'

--- a/core/string/rindex_spec.rb
+++ b/core/string/rindex_spec.rb
@@ -197,16 +197,16 @@ describe "String#rindex with String" do
   end
 
   it "handles a substring in a superset encoding" do
-    'abc'.force_encoding(Encoding::US_ASCII).rindex('é').should == nil
+    'abc'.dup.force_encoding(Encoding::US_ASCII).rindex('é').should == nil
   end
 
   it "handles a substring in a subset encoding" do
-    'été'.rindex('t'.force_encoding(Encoding::US_ASCII)).should == 1
+    'été'.rindex('t'.dup.force_encoding(Encoding::US_ASCII)).should == 1
   end
 
   it "raises an Encoding::CompatibilityError if the encodings are incompatible" do
-    str = 'abc'.force_encoding("ISO-2022-JP")
-    pattern = 'b'.force_encoding("EUC-JP")
+    str = 'abc'.dup.force_encoding("ISO-2022-JP")
+    pattern = 'b'.dup.force_encoding("EUC-JP")
 
     -> { str.rindex(pattern) }.should raise_error(Encoding::CompatibilityError, "incompatible character encodings: ISO-2022-JP and EUC-JP")
   end

--- a/core/string/rjust_spec.rb
+++ b/core/string/rjust_spec.rb
@@ -75,7 +75,7 @@ describe "String#rjust with length, padding" do
 
   describe "with width" do
     it "returns a String in the same encoding as the original" do
-      str = "abc".force_encoding Encoding::IBM437
+      str = "abc".dup.force_encoding Encoding::IBM437
       result = str.rjust 5
       result.should == "  abc"
       result.encoding.should equal(Encoding::IBM437)
@@ -84,7 +84,7 @@ describe "String#rjust with length, padding" do
 
   describe "with width, pattern" do
     it "returns a String in the compatible encoding" do
-      str = "abc".force_encoding Encoding::IBM437
+      str = "abc".dup.force_encoding Encoding::IBM437
       result = str.rjust 5, "あ"
       result.should == "ああabc"
       result.encoding.should equal(Encoding::UTF_8)

--- a/core/string/rpartition_spec.rb
+++ b/core/string/rpartition_spec.rb
@@ -48,7 +48,7 @@ describe "String#rpartition with String" do
   end
 
   it "handles a pattern in a superset encoding" do
-    string = "hello".force_encoding(Encoding::US_ASCII)
+    string = "hello".dup.force_encoding(Encoding::US_ASCII)
 
     result = string.rpartition("é")
 
@@ -59,7 +59,7 @@ describe "String#rpartition with String" do
   end
 
   it "handles a pattern in a subset encoding" do
-    pattern = "o".force_encoding(Encoding::US_ASCII)
+    pattern = "o".dup.force_encoding(Encoding::US_ASCII)
 
     result = "héllo world".rpartition(pattern)
 

--- a/core/string/rstrip_spec.rb
+++ b/core/string/rstrip_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/strip'

--- a/core/string/scrub_spec.rb
+++ b/core/string/scrub_spec.rb
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 

--- a/core/string/setbyte_spec.rb
+++ b/core/string/setbyte_spec.rb
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 
 describe "String#setbyte" do

--- a/core/string/shared/chars.rb
+++ b/core/string/shared/chars.rb
@@ -21,12 +21,12 @@ describe :string_chars, shared: true do
   end
 
   it "returns characters in the same encoding as self" do
-    "&%".force_encoding('Shift_JIS').send(@method).to_a.all? {|c| c.encoding.name.should == 'Shift_JIS'}
+    "&%".dup.force_encoding('Shift_JIS').send(@method).to_a.all? {|c| c.encoding.name.should == 'Shift_JIS'}
     "&%".encode('BINARY').send(@method).to_a.all? {|c| c.encoding.should == Encoding::BINARY }
   end
 
   it "works with multibyte characters" do
-    s = "\u{8987}".force_encoding("UTF-8")
+    s = "\u{8987}".dup.force_encoding("UTF-8")
     s.bytesize.should == 3
     s.send(@method).to_a.should == [s]
   end
@@ -39,14 +39,14 @@ describe :string_chars, shared: true do
   end
 
   it "returns a different character if the String is transcoded" do
-    s = "\u{20AC}".force_encoding('UTF-8')
-    s.encode('UTF-8').send(@method).to_a.should == ["\u{20AC}".force_encoding('UTF-8')]
+    s = "\u{20AC}".dup.force_encoding('UTF-8')
+    s.encode('UTF-8').send(@method).to_a.should == ["\u{20AC}".dup.force_encoding('UTF-8')]
     s.encode('iso-8859-15').send(@method).to_a.should == [[0xA4].pack('C').force_encoding('iso-8859-15')]
-    s.encode('iso-8859-15').encode('UTF-8').send(@method).to_a.should == ["\u{20AC}".force_encoding('UTF-8')]
+    s.encode('iso-8859-15').encode('UTF-8').send(@method).to_a.should == ["\u{20AC}".dup.force_encoding('UTF-8')]
   end
 
   it "uses the String's encoding to determine what characters it contains" do
-    s = "\u{24B62}"
+    s = +"\u{24B62}"
 
     s.force_encoding('UTF-8').send(@method).to_a.should == [
       s.force_encoding('UTF-8')

--- a/core/string/shared/codepoints.rb
+++ b/core/string/shared/codepoints.rb
@@ -7,7 +7,7 @@ describe :string_codepoints, shared: true do
   end
 
   it "raises an ArgumentError when self has an invalid encoding and a method is called on the returned Enumerator" do
-    s = "\xDF".force_encoding(Encoding::UTF_8)
+    s = "\xDF".dup.force_encoding(Encoding::UTF_8)
     s.valid_encoding?.should be_false
     -> { s.send(@method).to_a }.should raise_error(ArgumentError)
   end
@@ -21,7 +21,7 @@ describe :string_codepoints, shared: true do
   end
 
   it "raises an ArgumentError if self's encoding is invalid and a block is given" do
-    s = "\xDF".force_encoding(Encoding::UTF_8)
+    s = "\xDF".dup.force_encoding(Encoding::UTF_8)
     s.valid_encoding?.should be_false
     -> { s.send(@method) { } }.should raise_error(ArgumentError)
   end
@@ -49,7 +49,7 @@ describe :string_codepoints, shared: true do
 
   it "round-trips to the original String using Integer#chr" do
     s = "\u{13}\u{7711}\u{1010}"
-    s2 = ""
+    s2 = +""
     s.send(@method) {|n| s2 << n.chr(Encoding::UTF_8)}
     s.should == s2
   end

--- a/core/string/shared/concat.rb
+++ b/core/string/shared/concat.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 describe :string_concat, shared: true do
   it "concatenates the given argument to self and returns self" do
     str = 'hello '

--- a/core/string/shared/dedup.rb
+++ b/core/string/shared/dedup.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 describe :string_dedup, shared: true do
   it 'returns self if the String is frozen' do
     input  = 'foo'.freeze

--- a/core/string/shared/each_codepoint_without_block.rb
+++ b/core/string/shared/each_codepoint_without_block.rb
@@ -6,7 +6,7 @@ describe :string_each_codepoint_without_block, shared: true do
     end
 
     it "returns an Enumerator even when self has an invalid encoding" do
-      s = "\xDF".force_encoding(Encoding::UTF_8)
+      s = "\xDF".dup.force_encoding(Encoding::UTF_8)
       s.valid_encoding?.should be_false
       s.send(@method).should be_an_instance_of(Enumerator)
     end
@@ -23,7 +23,7 @@ describe :string_each_codepoint_without_block, shared: true do
         end
 
         it "should return the size of the string even when the string has an invalid encoding" do
-          s = "\xDF".force_encoding(Encoding::UTF_8)
+          s = "\xDF".dup.force_encoding(Encoding::UTF_8)
           s.valid_encoding?.should be_false
           s.send(@method).size.should == 1
         end

--- a/core/string/shared/each_line.rb
+++ b/core/string/shared/each_line.rb
@@ -106,7 +106,7 @@ describe :string_each_line, shared: true do
   end
 
   it "does not care if the string is modified while substituting" do
-    str = "hello\nworld."
+    str = +"hello\nworld."
     out = []
     str.send(@method){|x| out << x; str[-1] = '!' }.should == "hello\nworld!"
     out.should == ["hello\n", "world."]

--- a/core/string/shared/encode.rb
+++ b/core/string/shared/encode.rb
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: false
 describe :string_encode, shared: true do
   describe "when passed no options" do
     it "transcodes to Encoding.default_internal when set" do

--- a/core/string/shared/eql.rb
+++ b/core/string/shared/eql.rb
@@ -13,15 +13,15 @@ describe :string_eql_value, shared: true do
   end
 
   it "ignores encoding difference of compatible string" do
-    "hello".force_encoding("utf-8").send(@method, "hello".force_encoding("iso-8859-1")).should be_true
+    "hello".dup.force_encoding("utf-8").send(@method, "hello".dup.force_encoding("iso-8859-1")).should be_true
   end
 
   it "considers encoding difference of incompatible string" do
-    "\xff".force_encoding("utf-8").send(@method, "\xff".force_encoding("iso-8859-1")).should be_false
+    "\xff".dup.force_encoding("utf-8").send(@method, "\xff".dup.force_encoding("iso-8859-1")).should be_false
   end
 
   it "considers encoding compatibility" do
-    "abcd".force_encoding("utf-8").send(@method, "abcd".force_encoding("utf-32le")).should be_false
+    "abcd".dup.force_encoding("utf-8").send(@method, "abcd".dup.force_encoding("utf-32le")).should be_false
   end
 
   it "ignores subclass differences" do
@@ -33,6 +33,6 @@ describe :string_eql_value, shared: true do
   end
 
   it "returns true when comparing 2 empty strings but one is not ASCII-compatible" do
-    "".send(@method, "".force_encoding('iso-2022-jp')).should == true
+    "".send(@method, "".dup.force_encoding('iso-2022-jp')).should == true
   end
 end

--- a/core/string/shared/length.rb
+++ b/core/string/shared/length.rb
@@ -18,7 +18,7 @@ describe :string_length, shared: true do
   end
 
   it "returns the length of the new self after encoding is changed" do
-    str = 'こにちわ'
+    str = +'こにちわ'
     str.send(@method)
 
     str.force_encoding('BINARY').send(@method).should == 12
@@ -44,12 +44,12 @@ describe :string_length, shared: true do
   end
 
   it "adds 1 (and not 2) for a incomplete surrogate in UTF-16" do
-    "\x00\xd8".force_encoding("UTF-16LE").send(@method).should == 1
-    "\xd8\x00".force_encoding("UTF-16BE").send(@method).should == 1
+    "\x00\xd8".dup.force_encoding("UTF-16LE").send(@method).should == 1
+    "\xd8\x00".dup.force_encoding("UTF-16BE").send(@method).should == 1
   end
 
   it "adds 1 for a broken sequence in UTF-32" do
-    "\x04\x03\x02\x01".force_encoding("UTF-32LE").send(@method).should == 1
-    "\x01\x02\x03\x04".force_encoding("UTF-32BE").send(@method).should == 1
+    "\x04\x03\x02\x01".dup.force_encoding("UTF-32LE").send(@method).should == 1
+    "\x01\x02\x03\x04".dup.force_encoding("UTF-32BE").send(@method).should == 1
   end
 end

--- a/core/string/shared/replace.rb
+++ b/core/string/shared/replace.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 describe :string_replace, shared: true do
   it "returns self" do
     a = "a"

--- a/core/string/shared/slice.rb
+++ b/core/string/shared/slice.rb
@@ -84,8 +84,8 @@ describe :string_slice_index_length, shared: true do
     s = "hello there"
     s.send(@method, 1, 9).encoding.should == s.encoding
 
-    a = "hello".force_encoding("binary")
-    b = " there".force_encoding("ISO-8859-1")
+    a = "hello".dup.force_encoding("binary")
+    b = " there".dup.force_encoding("ISO-8859-1")
     c = (a + b).force_encoding(Encoding::US_ASCII)
 
     c.send(@method, 0, 5).encoding.should == Encoding::US_ASCII

--- a/core/string/shared/succ.rb
+++ b/core/string/shared/succ.rb
@@ -73,6 +73,7 @@ end
 describe :string_succ_bang, shared: true do
   it "is equivalent to succ, but modifies self in place (still returns self)" do
     ["", "abcd", "THX1138"].each do |s|
+      s = +s
       r = s.dup.send(@method)
       s.send(@method).should equal(s)
       s.should == r

--- a/core/string/shared/to_sym.rb
+++ b/core/string/shared/to_sym.rb
@@ -56,9 +56,9 @@ describe :string_to_sym, shared: true do
   it "ignores existing symbols with different encoding" do
     source = "fée"
 
-    iso_symbol = source.force_encoding(Encoding::ISO_8859_1).send(@method)
+    iso_symbol = source.dup.force_encoding(Encoding::ISO_8859_1).send(@method)
     iso_symbol.encoding.should == Encoding::ISO_8859_1
-    binary_symbol = source.force_encoding(Encoding::BINARY).send(@method)
+    binary_symbol = source.dup.force_encoding(Encoding::BINARY).send(@method)
     binary_symbol.encoding.should == Encoding::BINARY
   end
 

--- a/core/string/slice_spec.rb
+++ b/core/string/slice_spec.rb
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/slice'

--- a/core/string/split_spec.rb
+++ b/core/string/split_spec.rb
@@ -4,7 +4,7 @@ require_relative 'fixtures/classes'
 
 describe "String#split with String" do
   it "throws an ArgumentError if the string  is not a valid" do
-    s = "\xDF".force_encoding(Encoding::UTF_8)
+    s = "\xDF".dup.force_encoding(Encoding::UTF_8)
 
     -> { s.split }.should raise_error(ArgumentError)
     -> { s.split(':') }.should raise_error(ArgumentError)
@@ -12,7 +12,7 @@ describe "String#split with String" do
 
   it "throws an ArgumentError if the pattern is not a valid string" do
     str = 'проверка'
-    broken_str = "\xDF".force_encoding(Encoding::UTF_8)
+    broken_str = "\xDF".dup.force_encoding(Encoding::UTF_8)
 
     -> { str.split(broken_str) }.should raise_error(ArgumentError)
   end
@@ -229,7 +229,7 @@ end
 
 describe "String#split with Regexp" do
   it "throws an ArgumentError if the string  is not a valid" do
-    s = "\xDF".force_encoding(Encoding::UTF_8)
+    s = "\xDF".dup.force_encoding(Encoding::UTF_8)
 
     -> { s.split(/./) }.should raise_error(ArgumentError)
   end
@@ -409,7 +409,7 @@ describe "String#split with Regexp" do
   end
 
   it "returns an ArgumentError if an invalid UTF-8 string is supplied" do
-    broken_str = 'проверка' # in russian, means "test"
+    broken_str = +'проверка' # in russian, means "test"
     broken_str.force_encoding('binary')
     broken_str.chop!
     broken_str.force_encoding('utf-8')

--- a/core/string/squeeze_spec.rb
+++ b/core/string/squeeze_spec.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 

--- a/core/string/strip_spec.rb
+++ b/core/string/strip_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/strip'

--- a/core/string/sub_spec.rb
+++ b/core/string/sub_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 

--- a/core/string/swapcase_spec.rb
+++ b/core/string/swapcase_spec.rb
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 

--- a/core/string/tr_s_spec.rb
+++ b/core/string/tr_s_spec.rb
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 

--- a/core/string/tr_spec.rb
+++ b/core/string/tr_spec.rb
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 

--- a/core/string/unicode_normalize_spec.rb
+++ b/core/string/unicode_normalize_spec.rb
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 
 # Examples taken from http://www.unicode.org/reports/tr15/#Norm_Forms

--- a/core/string/unicode_normalized_spec.rb
+++ b/core/string/unicode_normalized_spec.rb
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 
 describe "String#unicode_normalized?" do

--- a/core/string/unpack/a_spec.rb
+++ b/core/string/unpack/a_spec.rb
@@ -31,7 +31,7 @@ describe "String#unpack with format 'A'" do
   end
 
   it "decodes into raw (ascii) string values" do
-    str = "str".force_encoding('UTF-8').unpack("A*")[0]
+    str = "str".dup.force_encoding('UTF-8').unpack("A*")[0]
     str.encoding.should == Encoding::BINARY
   end
 

--- a/core/string/unpack/b_spec.rb
+++ b/core/string/unpack/b_spec.rb
@@ -107,7 +107,7 @@ describe "String#unpack with format 'B'" do
   end
 
   it "decodes into US-ASCII string values" do
-    str = "s".force_encoding('UTF-8').unpack("B*")[0]
+    str = "s".dup.force_encoding('UTF-8').unpack("B*")[0]
     str.encoding.name.should == 'US-ASCII'
   end
 end
@@ -215,7 +215,7 @@ describe "String#unpack with format 'b'" do
   end
 
   it "decodes into US-ASCII string values" do
-    str = "s".force_encoding('UTF-8').unpack("b*")[0]
+    str = "s".dup.force_encoding('UTF-8').unpack("b*")[0]
     str.encoding.name.should == 'US-ASCII'
   end
 end

--- a/core/string/unpack/u_spec.rb
+++ b/core/string/unpack/u_spec.rb
@@ -33,7 +33,7 @@ describe "String#unpack with format 'u'" do
     str = "".unpack("u")[0]
     str.encoding.should == Encoding::BINARY
 
-    str = "1".force_encoding('UTF-8').unpack("u")[0]
+    str = "1".dup.force_encoding('UTF-8').unpack("u")[0]
     str.encoding.should == Encoding::BINARY
   end
 

--- a/core/string/upcase_spec.rb
+++ b/core/string/upcase_spec.rb
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 

--- a/core/string/uplus_spec.rb
+++ b/core/string/uplus_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 require_relative '../../spec_helper'
 
 describe 'String#+@' do

--- a/core/string/upto_spec.rb
+++ b/core/string/upto_spec.rb
@@ -81,8 +81,8 @@ describe "String#upto" do
   end
 
   it "raises Encoding::CompatibilityError when incompatible characters are given" do
-    char1 = 'a'.force_encoding("EUC-JP")
-    char2 = 'b'.force_encoding("ISO-2022-JP")
+    char1 = 'a'.dup.force_encoding("EUC-JP")
+    char2 = 'b'.dup.force_encoding("ISO-2022-JP")
     -> { char1.upto(char2) {} }.should raise_error(Encoding::CompatibilityError, "incompatible character encodings: EUC-JP and ISO-2022-JP")
   end
 

--- a/core/string/valid_encoding_spec.rb
+++ b/core/string/valid_encoding_spec.rb
@@ -7,13 +7,13 @@ describe "String#valid_encoding?" do
   end
 
   it "returns true if self is valid in the current encoding and other encodings" do
-    str = "\x77"
+    str = +"\x77"
     str.force_encoding('utf-8').valid_encoding?.should be_true
     str.force_encoding('binary').valid_encoding?.should be_true
   end
 
   it "returns true for all encodings self is valid in" do
-    str = "\xE6\x9D\x94"
+    str = +"\xE6\x9D\x94"
     str.force_encoding('BINARY').valid_encoding?.should be_true
     str.force_encoding('UTF-8').valid_encoding?.should be_true
     str.force_encoding('US-ASCII').valid_encoding?.should be_false
@@ -43,10 +43,10 @@ describe "String#valid_encoding?" do
     str.force_encoding('KOI8-R').valid_encoding?.should be_true
     str.force_encoding('KOI8-U').valid_encoding?.should be_true
     str.force_encoding('Shift_JIS').valid_encoding?.should be_false
-    "\xD8\x00".force_encoding('UTF-16BE').valid_encoding?.should be_false
-    "\x00\xD8".force_encoding('UTF-16LE').valid_encoding?.should be_false
-    "\x04\x03\x02\x01".force_encoding('UTF-32BE').valid_encoding?.should be_false
-    "\x01\x02\x03\x04".force_encoding('UTF-32LE').valid_encoding?.should be_false
+    "\xD8\x00".dup.force_encoding('UTF-16BE').valid_encoding?.should be_false
+    "\x00\xD8".dup.force_encoding('UTF-16LE').valid_encoding?.should be_false
+    "\x04\x03\x02\x01".dup.force_encoding('UTF-32BE').valid_encoding?.should be_false
+    "\x01\x02\x03\x04".dup.force_encoding('UTF-32LE').valid_encoding?.should be_false
     str.force_encoding('Windows-1251').valid_encoding?.should be_true
     str.force_encoding('IBM437').valid_encoding?.should be_true
     str.force_encoding('IBM737').valid_encoding?.should be_true
@@ -101,24 +101,24 @@ describe "String#valid_encoding?" do
   end
 
   it "returns true for IBM720 encoding self is valid in" do
-    str = "\xE6\x9D\x94"
+    str = +"\xE6\x9D\x94"
     str.force_encoding('IBM720').valid_encoding?.should be_true
     str.force_encoding('CP720').valid_encoding?.should be_true
   end
 
   it "returns false if self is valid in one encoding, but invalid in the one it's tagged with" do
-    str = "\u{8765}"
+    str = +"\u{8765}"
     str.valid_encoding?.should be_true
-    str = str.force_encoding('ascii')
+    str.force_encoding('ascii')
     str.valid_encoding?.should be_false
   end
 
   it "returns false if self contains a character invalid in the associated encoding" do
-    "abc#{[0x80].pack('C')}".force_encoding('ascii').valid_encoding?.should be_false
+    "abc#{[0x80].pack('C')}".dup.force_encoding('ascii').valid_encoding?.should be_false
   end
 
   it "returns false if a valid String had an invalid character appended to it" do
-    str = "a"
+    str = +"a"
     str.valid_encoding?.should be_true
     str << [0xDD].pack('C').force_encoding('utf-8')
     str.valid_encoding?.should be_false

--- a/core/struct/new_spec.rb
+++ b/core/struct/new_spec.rb
@@ -48,7 +48,7 @@ describe "Struct.new" do
   end
 
   it "allows non-ASCII member name" do
-    name = "r\xe9sum\xe9".force_encoding(Encoding::ISO_8859_1).to_sym
+    name = "r\xe9sum\xe9".dup.force_encoding(Encoding::ISO_8859_1).to_sym
     struct = Struct.new(name)
     struct.new("foo").send(name).should == "foo"
   end

--- a/core/time/_load_spec.rb
+++ b/core/time/_load_spec.rb
@@ -44,8 +44,7 @@ describe "Time._load" do
   end
 
   it "treats the data as binary data" do
-    data = "\x04\bu:\tTime\r\fM\x1C\xC0\x00\x00\xD0\xBE"
-    data.force_encoding Encoding::UTF_8
+    data = "\x04\bu:\tTime\r\fM\x1C\xC0\x00\x00\xD0\xBE".dup.force_encoding Encoding::UTF_8
     t = Marshal.load(data)
     t.to_s.should == "2013-04-08 12:47:45 UTC"
   end

--- a/core/time/at_spec.rb
+++ b/core/time/at_spec.rb
@@ -196,7 +196,7 @@ describe "Time.at" do
       end
 
       it "does not try to convert format to Symbol with #to_sym" do
-        format = "usec"
+        format = +"usec"
         format.should_not_receive(:to_sym)
         -> { Time.at(0, 123456, format) }.should raise_error(ArgumentError)
       end

--- a/language/def_spec.rb
+++ b/language/def_spec.rb
@@ -238,7 +238,7 @@ describe "A singleton method definition" do
   end
 
   it "can be declared for a global variable" do
-    $__a__ = "hi"
+    $__a__ = +"hi"
     def $__a__.foo
       7
     end

--- a/language/encoding_spec.rb
+++ b/language/encoding_spec.rb
@@ -13,15 +13,15 @@ describe "The __ENCODING__ pseudo-variable" do
   end
 
   it "is the evaluated strings's one inside an eval" do
-    eval("__ENCODING__".force_encoding("US-ASCII")).should == Encoding::US_ASCII
-    eval("__ENCODING__".force_encoding("BINARY")).should == Encoding::BINARY
+    eval("__ENCODING__".dup.force_encoding("US-ASCII")).should == Encoding::US_ASCII
+    eval("__ENCODING__".dup.force_encoding("BINARY")).should == Encoding::BINARY
   end
 
   it "is the encoding specified by a magic comment inside an eval" do
-    code = "# encoding: BINARY\n__ENCODING__".force_encoding("US-ASCII")
+    code = "# encoding: BINARY\n__ENCODING__".dup.force_encoding("US-ASCII")
     eval(code).should == Encoding::BINARY
 
-    code = "# encoding: us-ascii\n__ENCODING__".force_encoding("BINARY")
+    code = "# encoding: us-ascii\n__ENCODING__".dup.force_encoding("BINARY")
     eval(code).should == Encoding::US_ASCII
   end
 

--- a/language/hash_spec.rb
+++ b/language/hash_spec.rb
@@ -33,7 +33,7 @@ describe "Hash literal" do
   end
 
   it "freezes string keys on initialization" do
-    key = "foo"
+    key = +"foo"
     h = {key => "bar"}
     key.reverse!
     h["foo"].should == "bar"

--- a/language/method_spec.rb
+++ b/language/method_spec.rb
@@ -1459,7 +1459,7 @@ ruby_version_is "3.1" do
   describe "Inside 'endless' method definitions" do
     it "allows method calls without parenthesis" do
       eval <<-ruby
-        def greet(person) = "Hi, ".concat person
+        def greet(person) = "Hi, ".dup.concat person
       ruby
 
       greet("Homer").should == "Hi, Homer"

--- a/language/predefined_spec.rb
+++ b/language/predefined_spec.rb
@@ -133,7 +133,7 @@ describe "Predefined global $&" do
   end
 
   it "sets the encoding to the encoding of the source String" do
-    "abc".force_encoding(Encoding::EUC_JP) =~ /b/
+    "abc".dup.force_encoding(Encoding::EUC_JP) =~ /b/
     $&.encoding.should equal(Encoding::EUC_JP)
   end
 end
@@ -146,12 +146,12 @@ describe "Predefined global $`" do
   end
 
   it "sets the encoding to the encoding of the source String" do
-    "abc".force_encoding(Encoding::EUC_JP) =~ /b/
+    "abc".dup.force_encoding(Encoding::EUC_JP) =~ /b/
     $`.encoding.should equal(Encoding::EUC_JP)
   end
 
   it "sets an empty result to the encoding of the source String" do
-    "abc".force_encoding(Encoding::ISO_8859_1) =~ /a/
+    "abc".dup.force_encoding(Encoding::ISO_8859_1) =~ /a/
     $`.encoding.should equal(Encoding::ISO_8859_1)
   end
 end
@@ -164,12 +164,12 @@ describe "Predefined global $'" do
   end
 
   it "sets the encoding to the encoding of the source String" do
-    "abc".force_encoding(Encoding::EUC_JP) =~ /b/
+    "abc".dup.force_encoding(Encoding::EUC_JP) =~ /b/
     $'.encoding.should equal(Encoding::EUC_JP)
   end
 
   it "sets an empty result to the encoding of the source String" do
-    "abc".force_encoding(Encoding::ISO_8859_1) =~ /c/
+    "abc".dup.force_encoding(Encoding::ISO_8859_1) =~ /c/
     $'.encoding.should equal(Encoding::ISO_8859_1)
   end
 end
@@ -187,7 +187,7 @@ describe "Predefined global $+" do
   end
 
   it "sets the encoding to the encoding of the source String" do
-    "abc".force_encoding(Encoding::EUC_JP) =~ /(b)/
+    "abc".dup.force_encoding(Encoding::EUC_JP) =~ /(b)/
     $+.encoding.should equal(Encoding::EUC_JP)
   end
 end
@@ -214,7 +214,7 @@ describe "Predefined globals $1..N" do
   end
 
   it "sets the encoding to the encoding of the source String" do
-    "abc".force_encoding(Encoding::EUC_JP) =~ /(b)/
+    "abc".dup.force_encoding(Encoding::EUC_JP) =~ /(b)/
     $1.encoding.should equal(Encoding::EUC_JP)
   end
 end

--- a/language/regexp/encoding_spec.rb
+++ b/language/regexp/encoding_spec.rb
@@ -4,18 +4,18 @@ require_relative '../fixtures/classes'
 
 describe "Regexps with encoding modifiers" do
   it "supports /e (EUC encoding)" do
-    match = /./e.match("\303\251".force_encoding(Encoding::EUC_JP))
-    match.to_a.should == ["\303\251".force_encoding(Encoding::EUC_JP)]
+    match = /./e.match("\303\251".dup.force_encoding(Encoding::EUC_JP))
+    match.to_a.should == ["\303\251".dup.force_encoding(Encoding::EUC_JP)]
   end
 
   it "supports /e (EUC encoding) with interpolation" do
-    match = /#{/./}/e.match("\303\251".force_encoding(Encoding::EUC_JP))
-    match.to_a.should == ["\303\251".force_encoding(Encoding::EUC_JP)]
+    match = /#{/./}/e.match("\303\251".dup.force_encoding(Encoding::EUC_JP))
+    match.to_a.should == ["\303\251".dup.force_encoding(Encoding::EUC_JP)]
   end
 
   it "supports /e (EUC encoding) with interpolation /o" do
-    match = /#{/./}/e.match("\303\251".force_encoding(Encoding::EUC_JP))
-    match.to_a.should == ["\303\251".force_encoding(Encoding::EUC_JP)]
+    match = /#{/./}/e.match("\303\251".dup.force_encoding(Encoding::EUC_JP))
+    match.to_a.should == ["\303\251".dup.force_encoding(Encoding::EUC_JP)]
   end
 
   it 'uses EUC-JP as /e encoding' do
@@ -39,7 +39,7 @@ describe "Regexps with encoding modifiers" do
   end
 
   it "warns when using /n with a match string with non-ASCII characters and an encoding other than ASCII-8BIT" do
-    -> { /./n.match("\303\251".force_encoding('utf-8')) }.should complain(%r{historical binary regexp match /.../n against UTF-8 string})
+    -> { /./n.match("\303\251".dup.force_encoding('utf-8')) }.should complain(%r{historical binary regexp match /.../n against UTF-8 string})
   end
 
   it 'uses US-ASCII as /n encoding if all chars are 7-bit' do
@@ -63,18 +63,18 @@ describe "Regexps with encoding modifiers" do
   end
 
   it "supports /s (Windows_31J encoding)" do
-    match = /./s.match("\303\251".force_encoding(Encoding::Windows_31J))
-    match.to_a.should == ["\303".force_encoding(Encoding::Windows_31J)]
+    match = /./s.match("\303\251".dup.force_encoding(Encoding::Windows_31J))
+    match.to_a.should == ["\303".dup.force_encoding(Encoding::Windows_31J)]
   end
 
   it "supports /s (Windows_31J encoding) with interpolation" do
-    match = /#{/./}/s.match("\303\251".force_encoding(Encoding::Windows_31J))
-    match.to_a.should == ["\303".force_encoding(Encoding::Windows_31J)]
+    match = /#{/./}/s.match("\303\251".dup.force_encoding(Encoding::Windows_31J))
+    match.to_a.should == ["\303".dup.force_encoding(Encoding::Windows_31J)]
   end
 
   it "supports /s (Windows_31J encoding) with interpolation and /o" do
-    match = /#{/./}/s.match("\303\251".force_encoding(Encoding::Windows_31J))
-    match.to_a.should == ["\303".force_encoding(Encoding::Windows_31J)]
+    match = /#{/./}/s.match("\303\251".dup.force_encoding(Encoding::Windows_31J))
+    match.to_a.should == ["\303".dup.force_encoding(Encoding::Windows_31J)]
   end
 
   it 'uses Windows-31J as /s encoding' do
@@ -86,15 +86,15 @@ describe "Regexps with encoding modifiers" do
   end
 
   it "supports /u (UTF8 encoding)" do
-    /./u.match("\303\251".force_encoding('utf-8')).to_a.should == ["\u{e9}"]
+    /./u.match("\303\251".dup.force_encoding('utf-8')).to_a.should == ["\u{e9}"]
   end
 
   it "supports /u (UTF8 encoding) with interpolation" do
-    /#{/./}/u.match("\303\251".force_encoding('utf-8')).to_a.should == ["\u{e9}"]
+    /#{/./}/u.match("\303\251".dup.force_encoding('utf-8')).to_a.should == ["\u{e9}"]
   end
 
   it "supports /u (UTF8 encoding) with interpolation and /o" do
-    /#{/./}/u.match("\303\251".force_encoding('utf-8')).to_a.should == ["\u{e9}"]
+    /#{/./}/u.match("\303\251".dup.force_encoding('utf-8')).to_a.should == ["\u{e9}"]
   end
 
   it 'uses UTF-8 as /u encoding' do
@@ -122,26 +122,26 @@ describe "Regexps with encoding modifiers" do
   end
 
   it "raises Encoding::CompatibilityError when the regexp has a fixed, non-ASCII-compatible encoding" do
-    -> { Regexp.new("".force_encoding("UTF-16LE"), Regexp::FIXEDENCODING) =~ " ".encode("UTF-8") }.should raise_error(Encoding::CompatibilityError)
+    -> { Regexp.new("".dup.force_encoding("UTF-16LE"), Regexp::FIXEDENCODING) =~ " ".encode("UTF-8") }.should raise_error(Encoding::CompatibilityError)
   end
 
   it "raises Encoding::CompatibilityError when the regexp has a fixed encoding and the match string has non-ASCII characters" do
-    -> { Regexp.new("".force_encoding("US-ASCII"), Regexp::FIXEDENCODING) =~ "\303\251".force_encoding('UTF-8') }.should raise_error(Encoding::CompatibilityError)
+    -> { Regexp.new("".dup.force_encoding("US-ASCII"), Regexp::FIXEDENCODING) =~ "\303\251".dup.force_encoding('UTF-8') }.should raise_error(Encoding::CompatibilityError)
   end
 
   it "raises ArgumentError when trying to match a broken String" do
-    s = "\x80".force_encoding('UTF-8')
+    s = "\x80".dup.force_encoding('UTF-8')
     -> { s =~ /./ }.should raise_error(ArgumentError, "invalid byte sequence in UTF-8")
   end
 
   it "computes the Regexp Encoding for each interpolated Regexp instance" do
     make_regexp = -> str { /#{str}/ }
 
-    r = make_regexp.call("été".force_encoding(Encoding::UTF_8))
+    r = make_regexp.call("été".dup.force_encoding(Encoding::UTF_8))
     r.should.fixed_encoding?
     r.encoding.should == Encoding::UTF_8
 
-    r = make_regexp.call("abc".force_encoding(Encoding::UTF_8))
+    r = make_regexp.call("abc".dup.force_encoding(Encoding::UTF_8))
     r.should_not.fixed_encoding?
     r.encoding.should == Encoding::US_ASCII
   end

--- a/language/send_spec.rb
+++ b/language/send_spec.rb
@@ -43,7 +43,7 @@ describe "Invoking a method" do
   end
 
   describe "with optional arguments" do
-    it "uses the optional argument if none is is passed" do
+    it "uses the optional argument if none is passed" do
       specs.fooM0O1.should == [1]
     end
 

--- a/language/singleton_class_spec.rb
+++ b/language/singleton_class_spec.rb
@@ -70,7 +70,7 @@ describe "A singleton class" do
   end
 
   it "has class String as the superclass of a String instance" do
-    "blah".singleton_class.superclass.should == String
+    "blah".dup.singleton_class.superclass.should == String
   end
 
   it "doesn't have singleton class" do

--- a/language/string_spec.rb
+++ b/language/string_spec.rb
@@ -232,7 +232,8 @@ describe "Ruby String literals" do
     end
 
     it "produce different objects for literals with the same content in different files if the other file doesn't have the comment" do
-      ruby_exe(fixture(__FILE__, "freeze_magic_comment_across_files_no_comment.rb")).chomp.should == "true"
+      frozen_literals_by_default = eval("'test'").frozen?
+      ruby_exe(fixture(__FILE__, "freeze_magic_comment_across_files_no_comment.rb")).chomp.should == (!frozen_literals_by_default).to_s
     end
 
     it "produce different objects for literals with the same content in different files if they have different encodings" do
@@ -251,12 +252,12 @@ describe "Ruby String interpolation" do
 
   it "returns a string with the source encoding by default" do
     "a#{"b"}c".encoding.should == Encoding::BINARY
-    eval('"a#{"b"}c"'.force_encoding("us-ascii")).encoding.should == Encoding::US_ASCII
+    eval('"a#{"b"}c"'.dup.force_encoding("us-ascii")).encoding.should == Encoding::US_ASCII
     eval("# coding: US-ASCII \n 'a#{"b"}c'").encoding.should == Encoding::US_ASCII
   end
 
   it "returns a string with the source encoding, even if the components have another encoding" do
-    a = "abc".force_encoding("euc-jp")
+    a = "abc".dup.force_encoding("euc-jp")
     "#{a}".encoding.should == Encoding::BINARY
 
     b = "abc".encode("utf-8")
@@ -265,7 +266,7 @@ describe "Ruby String interpolation" do
 
   it "raises an Encoding::CompatibilityError if the Encodings are not compatible" do
     a = "\u3042"
-    b = "\xff".force_encoding "binary"
+    b = "\xff".dup.force_encoding "binary"
 
     -> { "#{a} #{b}" }.should raise_error(Encoding::CompatibilityError)
   end

--- a/library/cgi/escapeURIComponent_spec.rb
+++ b/library/cgi/escapeURIComponent_spec.rb
@@ -14,7 +14,7 @@ ruby_version_is "3.2" do
     end
 
     it "supports String with invalid encoding" do
-      string = "\xC0\<\<".force_encoding("UTF-8")
+      string = "\xC0\<\<".dup.force_encoding("UTF-8")
       CGI.escapeURIComponent(string).should == "%C0%3C%3C"
     end
 

--- a/library/csv/generate_spec.rb
+++ b/library/csv/generate_spec.rb
@@ -21,7 +21,7 @@ describe "CSV.generate" do
   end
 
   it "appends and returns the argument itself" do
-    str = ""
+    str = +""
     csv_str = CSV.generate(str) do |csv|
       csv.add_row [1, 2, 3]
       csv << [4, 5, 6]

--- a/library/erb/run_spec.rb
+++ b/library/erb/run_spec.rb
@@ -6,7 +6,7 @@ describe "ERB#run" do
   # lambda { ... }.should output
   def _steal_stdout
     orig = $stdout
-    s = ''
+    s = +''
     def s.write(arg); self << arg.to_s; end
     $stdout = s
     begin

--- a/library/net-http/http/post_spec.rb
+++ b/library/net-http/http/post_spec.rb
@@ -60,7 +60,7 @@ describe "Net::HTTP#post" do
 
   describe "when passed a block" do
     it "yields fragments of the response body to the passed block" do
-      str = ""
+      str = +""
       @http.post("/request", "test=test") do |res|
         str << res
       end

--- a/library/net-http/httpgenericrequest/exec_spec.rb
+++ b/library/net-http/httpgenericrequest/exec_spec.rb
@@ -4,7 +4,7 @@ require "stringio"
 
 describe "Net::HTTPGenericRequest#exec when passed socket, version, path" do
   before :each do
-    @socket = StringIO.new("")
+    @socket = StringIO.new(+"")
     @buffered_socket = Net::BufferedIO.new(@socket)
   end
 

--- a/library/net-http/httpresponse/inspect_spec.rb
+++ b/library/net-http/httpresponse/inspect_spec.rb
@@ -8,7 +8,7 @@ describe "Net::HTTPResponse#inspect" do
     res.inspect.should == "#<Net::HTTPUnknownResponse ??? test response readbody=false>"
 
     res = Net::HTTPUnknownResponse.new("1.0", "???", "test response")
-    socket = Net::BufferedIO.new(StringIO.new("test body"))
+    socket = Net::BufferedIO.new(StringIO.new(+"test body"))
     res.reading_body(socket, true) {}
     res.inspect.should == "#<Net::HTTPUnknownResponse ??? test response readbody=true>"
   end

--- a/library/net-http/httpresponse/read_body_spec.rb
+++ b/library/net-http/httpresponse/read_body_spec.rb
@@ -5,7 +5,7 @@ require 'stringio'
 describe "Net::HTTPResponse#read_body" do
   before :each do
     @res = Net::HTTPUnknownResponse.new("1.0", "???", "test response")
-    @socket = Net::BufferedIO.new(StringIO.new("test body"))
+    @socket = Net::BufferedIO.new(StringIO.new(+"test body"))
   end
 
   describe "when passed no arguments" do
@@ -25,7 +25,7 @@ describe "Net::HTTPResponse#read_body" do
   describe "when passed a buffer" do
     it "reads the body to the passed buffer" do
       @res.reading_body(@socket, true) do
-        buffer = ""
+        buffer = +""
         @res.read_body(buffer)
         buffer.should == "test body"
       end
@@ -33,15 +33,15 @@ describe "Net::HTTPResponse#read_body" do
 
     it "returns the passed buffer" do
       @res.reading_body(@socket, true) do
-        buffer = ""
+        buffer = +""
         @res.read_body(buffer).should equal(buffer)
       end
     end
 
     it "raises an IOError if called a second time" do
       @res.reading_body(@socket, true) do
-        @res.read_body("")
-        -> { @res.read_body("") }.should raise_error(IOError)
+        @res.read_body(+"")
+        -> { @res.read_body(+"") }.should raise_error(IOError)
       end
     end
   end
@@ -51,7 +51,7 @@ describe "Net::HTTPResponse#read_body" do
       @res.reading_body(@socket, true) do
         yielded = false
 
-        buffer = ""
+        buffer = +""
         @res.read_body do |body|
           yielded = true
           buffer << body
@@ -79,7 +79,7 @@ describe "Net::HTTPResponse#read_body" do
   describe "when passed buffer and block" do
     it "raises an ArgumentError" do
       @res.reading_body(@socket, true) do
-        -> { @res.read_body("") {} }.should raise_error(ArgumentError)
+        -> { @res.read_body(+"") {} }.should raise_error(ArgumentError)
       end
     end
   end

--- a/library/net-http/httpresponse/reading_body_spec.rb
+++ b/library/net-http/httpresponse/reading_body_spec.rb
@@ -5,7 +5,7 @@ require "stringio"
 describe "Net::HTTPResponse#reading_body" do
   before :each do
     @res = Net::HTTPUnknownResponse.new("1.0", "???", "test response")
-    @socket = Net::BufferedIO.new(StringIO.new("test body"))
+    @socket = Net::BufferedIO.new(StringIO.new(+"test body"))
   end
 
   describe "when body_allowed is true" do

--- a/library/net-http/httpresponse/shared/body.rb
+++ b/library/net-http/httpresponse/shared/body.rb
@@ -3,7 +3,7 @@ require 'stringio'
 describe :net_httpresponse_body, shared: true do
   before :each do
     @res = Net::HTTPUnknownResponse.new("1.0", "???", "test response")
-    @socket = Net::BufferedIO.new(StringIO.new("test body"))
+    @socket = Net::BufferedIO.new(StringIO.new(+"test body"))
   end
 
   it "returns the read body" do

--- a/library/objectspace/fixtures/trace.rb
+++ b/library/objectspace/fixtures/trace.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 require "objspace/trace"
 a = "foo"
 b = "b" + "a" + "r"

--- a/library/objectspace/trace_spec.rb
+++ b/library/objectspace/trace_spec.rb
@@ -6,8 +6,8 @@ ruby_version_is "3.1" do
       file = fixture(__FILE__ , "trace.rb")
       ruby_exe(file, args: "2>&1").lines(chomp: true).should == [
         "objspace/trace is enabled",
-        "\"foo\" @ #{file}:2",
-        "\"bar\" @ #{file}:3",
+        "\"foo\" @ #{file}:3",
+        "\"bar\" @ #{file}:4",
         "42"
       ]
     end

--- a/library/set/compare_by_identity_spec.rb
+++ b/library/set/compare_by_identity_spec.rb
@@ -5,7 +5,7 @@ describe "Set#compare_by_identity" do
   it "compares its members by identity" do
     a = "a"
     b1 = "b"
-    b2 = "b"
+    b2 = b1.dup
 
     set = Set.new
     set.compare_by_identity

--- a/library/socket/basicsocket/recv_nonblock_spec.rb
+++ b/library/socket/basicsocket/recv_nonblock_spec.rb
@@ -52,7 +52,7 @@ describe "Socket::BasicSocket#recv_nonblock" do
       @s2.send("data", 0, @s1.getsockname)
       IO.select([@s1], nil, nil, 2)
 
-      buf = "foo"
+      buf = +"foo"
       @s1.recv_nonblock(5, 0, buf)
       buf.should == "data"
     end

--- a/library/socket/basicsocket/recv_spec.rb
+++ b/library/socket/basicsocket/recv_spec.rb
@@ -100,7 +100,7 @@ describe "BasicSocket#recv" do
     socket.write("data")
 
     client = @server.accept
-    buf = "foo"
+    buf = +"foo"
     begin
       client.recv(4, 0, buf)
     ensure

--- a/library/socket/basicsocket/send_spec.rb
+++ b/library/socket/basicsocket/send_spec.rb
@@ -17,7 +17,7 @@ describe "BasicSocket#send" do
   end
 
    it "sends a message to another socket and returns the number of bytes sent" do
-     data = ""
+     data = +""
      t = Thread.new do
        client = @server.accept
        loop do
@@ -62,7 +62,7 @@ describe "BasicSocket#send" do
   end
 
   it "accepts a sockaddr as recipient address" do
-     data = ""
+     data = +""
      t = Thread.new do
        client = @server.accept
        loop do

--- a/library/socket/udpsocket/send_spec.rb
+++ b/library/socket/udpsocket/send_spec.rb
@@ -63,7 +63,7 @@ describe "UDPSocket#send" do
     @msg[1][3].should == "127.0.0.1"
   end
 
-  it "raises EMSGSIZE if data is too too big" do
+  it "raises EMSGSIZE if data is too big" do
     @socket = UDPSocket.open
     begin
       -> do

--- a/library/stringio/append_spec.rb
+++ b/library/stringio/append_spec.rb
@@ -3,7 +3,7 @@ require_relative 'fixtures/classes'
 
 describe "StringIO#<< when passed [Object]" do
   before :each do
-    @io = StringIO.new("example")
+    @io = StringIO.new(+"example")
   end
 
   it "returns self" do
@@ -44,10 +44,10 @@ end
 
 describe "StringIO#<< when self is not writable" do
   it "raises an IOError" do
-    io = StringIO.new("test", "r")
+    io = StringIO.new(+"test", "r")
     -> { io << "test" }.should raise_error(IOError)
 
-    io = StringIO.new("test")
+    io = StringIO.new(+"test")
     io.close_write
     -> { io << "test" }.should raise_error(IOError)
   end
@@ -55,7 +55,7 @@ end
 
 describe "StringIO#<< when in append mode" do
   before :each do
-    @io = StringIO.new("example", "a")
+    @io = StringIO.new(+"example", "a")
   end
 
   it "appends the passed argument to the end of self, ignoring current position" do

--- a/library/stringio/close_read_spec.rb
+++ b/library/stringio/close_read_spec.rb
@@ -3,7 +3,7 @@ require_relative 'fixtures/classes'
 
 describe "StringIO#close_read" do
   before :each do
-    @io = StringIO.new("example")
+    @io = StringIO.new(+"example")
   end
 
   it "returns nil" do
@@ -21,7 +21,7 @@ describe "StringIO#close_read" do
   end
 
   it "raises an IOError when in write-only mode" do
-    io = StringIO.new("example", "w")
+    io = StringIO.new(+"example", "w")
     -> { io.close_read }.should raise_error(IOError)
 
     io = StringIO.new("example")

--- a/library/stringio/close_write_spec.rb
+++ b/library/stringio/close_write_spec.rb
@@ -3,7 +3,7 @@ require_relative 'fixtures/classes'
 
 describe "StringIO#close_write" do
   before :each do
-    @io = StringIO.new("example")
+    @io = StringIO.new(+"example")
   end
 
   it "returns nil" do
@@ -21,10 +21,10 @@ describe "StringIO#close_write" do
   end
 
   it "raises an IOError when in read-only mode" do
-    io = StringIO.new("example", "r")
+    io = StringIO.new(+"example", "r")
     -> { io.close_write }.should raise_error(IOError)
 
-    io = StringIO.new("example")
+    io = StringIO.new(+"example")
     io.close_write
     io.close_write.should == nil
   end

--- a/library/stringio/closed_read_spec.rb
+++ b/library/stringio/closed_read_spec.rb
@@ -3,7 +3,7 @@ require_relative 'fixtures/classes'
 
 describe "StringIO#closed_read?" do
   it "returns true if self is not readable" do
-    io = StringIO.new("example", "r+")
+    io = StringIO.new(+"example", "r+")
     io.close_write
     io.closed_read?.should be_false
     io.close_read

--- a/library/stringio/closed_spec.rb
+++ b/library/stringio/closed_spec.rb
@@ -3,13 +3,13 @@ require_relative 'fixtures/classes'
 
 describe "StringIO#closed?" do
   it "returns true if self is completely closed" do
-    io = StringIO.new("example", "r+")
+    io = StringIO.new(+"example", "r+")
     io.close_read
     io.closed?.should be_false
     io.close_write
     io.closed?.should be_true
 
-    io = StringIO.new("example", "r+")
+    io = StringIO.new(+"example", "r+")
     io.close
     io.closed?.should be_true
   end

--- a/library/stringio/closed_write_spec.rb
+++ b/library/stringio/closed_write_spec.rb
@@ -3,7 +3,7 @@ require_relative 'fixtures/classes'
 
 describe "StringIO#closed_write?" do
   it "returns true if self is not writable" do
-    io = StringIO.new("example", "r+")
+    io = StringIO.new(+"example", "r+")
     io.close_read
     io.closed_write?.should be_false
     io.close_write

--- a/library/stringio/fcntl_spec.rb
+++ b/library/stringio/fcntl_spec.rb
@@ -3,6 +3,6 @@ require_relative 'fixtures/classes'
 
 describe "StringIO#fcntl" do
   it "raises a NotImplementedError" do
-    -> { StringIO.new("boom").fcntl }.should raise_error(NotImplementedError)
+    -> { StringIO.new(+"boom").fcntl }.should raise_error(NotImplementedError)
   end
 end

--- a/library/stringio/flush_spec.rb
+++ b/library/stringio/flush_spec.rb
@@ -3,7 +3,7 @@ require_relative 'fixtures/classes'
 
 describe "StringIO#flush" do
   it "returns self" do
-    io = StringIO.new("flush")
+    io = StringIO.new(+"flush")
     io.flush.should equal(io)
   end
 end

--- a/library/stringio/fsync_spec.rb
+++ b/library/stringio/fsync_spec.rb
@@ -3,7 +3,7 @@ require_relative 'fixtures/classes'
 
 describe "StringIO#fsync" do
   it "returns zero" do
-    io = StringIO.new("fsync")
+    io = StringIO.new(+"fsync")
     io.fsync.should eql(0)
   end
 end

--- a/library/stringio/gets_spec.rb
+++ b/library/stringio/gets_spec.rb
@@ -233,7 +233,7 @@ end
 
 describe "StringIO#gets when in write-only mode" do
   it "raises an IOError" do
-    io = StringIO.new("xyz", "w")
+    io = StringIO.new(+"xyz", "w")
     -> { io.gets }.should raise_error(IOError)
 
     io = StringIO.new("xyz")

--- a/library/stringio/initialize_spec.rb
+++ b/library/stringio/initialize_spec.rb
@@ -13,99 +13,99 @@ describe "StringIO#initialize when passed [Object, mode]" do
 
   it "sets the mode based on the passed mode" do
     io = StringIO.allocate
-    io.send(:initialize, "example", "r")
+    io.send(:initialize, +"example", "r")
     io.closed_read?.should be_false
     io.closed_write?.should be_true
 
     io = StringIO.allocate
-    io.send(:initialize, "example", "rb")
+    io.send(:initialize, +"example", "rb")
     io.closed_read?.should be_false
     io.closed_write?.should be_true
 
     io = StringIO.allocate
-    io.send(:initialize, "example", "r+")
+    io.send(:initialize, +"example", "r+")
     io.closed_read?.should be_false
     io.closed_write?.should be_false
 
     io = StringIO.allocate
-    io.send(:initialize, "example", "rb+")
+    io.send(:initialize, +"example", "rb+")
     io.closed_read?.should be_false
     io.closed_write?.should be_false
 
     io = StringIO.allocate
-    io.send(:initialize, "example", "w")
+    io.send(:initialize, +"example", "w")
     io.closed_read?.should be_true
     io.closed_write?.should be_false
 
     io = StringIO.allocate
-    io.send(:initialize, "example", "wb")
+    io.send(:initialize, +"example", "wb")
     io.closed_read?.should be_true
     io.closed_write?.should be_false
 
     io = StringIO.allocate
-    io.send(:initialize, "example", "w+")
+    io.send(:initialize, +"example", "w+")
     io.closed_read?.should be_false
     io.closed_write?.should be_false
 
     io = StringIO.allocate
-    io.send(:initialize, "example", "wb+")
+    io.send(:initialize, +"example", "wb+")
     io.closed_read?.should be_false
     io.closed_write?.should be_false
 
     io = StringIO.allocate
-    io.send(:initialize, "example", "a")
+    io.send(:initialize, +"example", "a")
     io.closed_read?.should be_true
     io.closed_write?.should be_false
 
     io = StringIO.allocate
-    io.send(:initialize, "example", "ab")
+    io.send(:initialize, +"example", "ab")
     io.closed_read?.should be_true
     io.closed_write?.should be_false
 
     io = StringIO.allocate
-    io.send(:initialize, "example", "a+")
+    io.send(:initialize, +"example", "a+")
     io.closed_read?.should be_false
     io.closed_write?.should be_false
 
     io = StringIO.allocate
-    io.send(:initialize, "example", "ab+")
+    io.send(:initialize, +"example", "ab+")
     io.closed_read?.should be_false
     io.closed_write?.should be_false
   end
 
   it "allows passing the mode as an Integer" do
     io = StringIO.allocate
-    io.send(:initialize, "example", IO::RDONLY)
+    io.send(:initialize, +"example", IO::RDONLY)
     io.closed_read?.should be_false
     io.closed_write?.should be_true
 
     io = StringIO.allocate
-    io.send(:initialize, "example", IO::RDWR)
+    io.send(:initialize, +"example", IO::RDWR)
     io.closed_read?.should be_false
     io.closed_write?.should be_false
 
     io = StringIO.allocate
-    io.send(:initialize, "example", IO::WRONLY)
+    io.send(:initialize, +"example", IO::WRONLY)
     io.closed_read?.should be_true
     io.closed_write?.should be_false
 
     io = StringIO.allocate
-    io.send(:initialize, "example", IO::WRONLY | IO::TRUNC)
+    io.send(:initialize, +"example", IO::WRONLY | IO::TRUNC)
     io.closed_read?.should be_true
     io.closed_write?.should be_false
 
     io = StringIO.allocate
-    io.send(:initialize, "example", IO::RDWR | IO::TRUNC)
+    io.send(:initialize, +"example", IO::RDWR | IO::TRUNC)
     io.closed_read?.should be_false
     io.closed_write?.should be_false
 
     io = StringIO.allocate
-    io.send(:initialize, "example", IO::WRONLY | IO::APPEND)
+    io.send(:initialize, +"example", IO::WRONLY | IO::APPEND)
     io.closed_read?.should be_true
     io.closed_write?.should be_false
 
     io = StringIO.allocate
-    io.send(:initialize, "example", IO::RDWR | IO::APPEND)
+    io.send(:initialize, +"example", IO::RDWR | IO::APPEND)
     io.closed_read?.should be_false
     io.closed_write?.should be_false
   end
@@ -118,7 +118,7 @@ describe "StringIO#initialize when passed [Object, mode]" do
   it "tries to convert the passed mode to a String using #to_str" do
     obj = mock('to_str')
     obj.should_receive(:to_str).and_return("r")
-    @io.send(:initialize, "example", obj)
+    @io.send(:initialize, +"example", obj)
 
     @io.closed_read?.should be_false
     @io.closed_write?.should be_true
@@ -142,10 +142,16 @@ describe "StringIO#initialize when passed [Object]" do
     @io.string.should equal(str)
   end
 
-  it "sets the mode to read-write" do
-    @io.send(:initialize, "example")
+  it "sets the mode to read-write if the string is mutable" do
+    @io.send(:initialize, +"example")
     @io.closed_read?.should be_false
     @io.closed_write?.should be_false
+  end
+
+  it "sets the mode to read if the string is frozen" do
+    @io.send(:initialize, -"example")
+    @io.closed_read?.should be_false
+    @io.closed_write?.should be_true
   end
 
   it "tries to convert the passed Object to a String using #to_str" do
@@ -166,28 +172,28 @@ end
 # NOTE: Synchronise with core/io/new_spec.rb (core/io/shared/new.rb)
 describe "StringIO#initialize when passed keyword arguments" do
   it "sets the mode based on the passed :mode option" do
-    io = StringIO.new("example", "r")
+    io = StringIO.new(+"example", "r")
     io.closed_read?.should be_false
     io.closed_write?.should be_true
   end
 
   it "accepts a mode argument set to nil with a valid :mode option" do
-    @io = StringIO.new('', nil, mode: "w")
+    @io = StringIO.new(+'', nil, mode: "w")
     @io.write("foo").should == 3
   end
 
   it "accepts a mode argument with a :mode option set to nil" do
-    @io = StringIO.new('', "w", mode: nil)
+    @io = StringIO.new(+'', "w", mode: nil)
     @io.write("foo").should == 3
   end
 
   it "sets binmode from :binmode option" do
-    @io = StringIO.new('', 'w', binmode: true)
+    @io = StringIO.new(+'', 'w', binmode: true)
     @io.external_encoding.to_s.should == "ASCII-8BIT" # #binmode? isn't implemented in StringIO
   end
 
   it "does not set binmode from false :binmode" do
-    @io = StringIO.new('', 'w', binmode: false)
+    @io = StringIO.new(+'', 'w', binmode: false)
     @io.external_encoding.to_s.should == "UTF-8" # #binmode? isn't implemented in StringIO
   end
 end
@@ -196,54 +202,54 @@ end
 describe "StringIO#initialize when passed keyword arguments and error happens" do
   it "raises an error if passed encodings two ways" do
     -> {
-      @io = StringIO.new('', 'w:ISO-8859-1', encoding: 'ISO-8859-1')
+      @io = StringIO.new(+'', 'w:ISO-8859-1', encoding: 'ISO-8859-1')
     }.should raise_error(ArgumentError)
     -> {
-      @io = StringIO.new('', 'w:ISO-8859-1', external_encoding: 'ISO-8859-1')
+      @io = StringIO.new(+'', 'w:ISO-8859-1', external_encoding: 'ISO-8859-1')
     }.should raise_error(ArgumentError)
     -> {
-      @io = StringIO.new('', 'w:ISO-8859-1:UTF-8', internal_encoding: 'ISO-8859-1')
+      @io = StringIO.new(+'', 'w:ISO-8859-1:UTF-8', internal_encoding: 'ISO-8859-1')
     }.should raise_error(ArgumentError)
   end
 
   it "raises an error if passed matching binary/text mode two ways" do
     -> {
-      @io = StringIO.new('', "wb", binmode: true)
+      @io = StringIO.new(+'', "wb", binmode: true)
     }.should raise_error(ArgumentError)
     -> {
-      @io = StringIO.new('', "wt", textmode: true)
+      @io = StringIO.new(+'', "wt", textmode: true)
     }.should raise_error(ArgumentError)
 
     -> {
-      @io = StringIO.new('', "wb", textmode: false)
+      @io = StringIO.new(+'', "wb", textmode: false)
     }.should raise_error(ArgumentError)
     -> {
-      @io = StringIO.new('', "wt", binmode: false)
+      @io = StringIO.new(+'', "wt", binmode: false)
     }.should raise_error(ArgumentError)
   end
 
   it "raises an error if passed conflicting binary/text mode two ways" do
     -> {
-      @io = StringIO.new('', "wb", binmode: false)
+      @io = StringIO.new(+'', "wb", binmode: false)
     }.should raise_error(ArgumentError)
     -> {
-      @io = StringIO.new('', "wt", textmode: false)
+      @io = StringIO.new(+'', "wt", textmode: false)
     }.should raise_error(ArgumentError)
 
     -> {
-      @io = StringIO.new('', "wb", textmode: true)
+      @io = StringIO.new(+'', "wb", textmode: true)
     }.should raise_error(ArgumentError)
     -> {
-      @io = StringIO.new('', "wt", binmode: true)
+      @io = StringIO.new(+'', "wt", binmode: true)
     }.should raise_error(ArgumentError)
   end
 
   it "raises an error when trying to set both binmode and textmode" do
     -> {
-      @io = StringIO.new('', "w", textmode: true, binmode: true)
+      @io = StringIO.new(+'', "w", textmode: true, binmode: true)
     }.should raise_error(ArgumentError)
     -> {
-      @io = StringIO.new('', File::Constants::WRONLY, textmode: true, binmode: true)
+      @io = StringIO.new(+'', File::Constants::WRONLY, textmode: true, binmode: true)
     }.should raise_error(ArgumentError)
   end
 end
@@ -258,7 +264,7 @@ describe "StringIO#initialize when passed no arguments" do
   end
 
   it "sets the mode to read-write" do
-    @io.send(:initialize, "example")
+    @io.send(:initialize)
     @io.closed_read?.should be_false
     @io.closed_write?.should be_false
   end
@@ -289,13 +295,13 @@ describe "StringIO#initialize sets" do
   end
 
   it "the encoding to the encoding of the String when passed a String" do
-    s = ''.force_encoding(Encoding::EUC_JP)
+    s = ''.dup.force_encoding(Encoding::EUC_JP)
     io = StringIO.new(s)
     io.string.encoding.should == Encoding::EUC_JP
   end
 
   it "the #external_encoding to the encoding of the String when passed a String" do
-    s = ''.force_encoding(Encoding::EUC_JP)
+    s = ''.dup.force_encoding(Encoding::EUC_JP)
     io = StringIO.new(s)
     io.external_encoding.should == Encoding::EUC_JP
   end

--- a/library/stringio/open_spec.rb
+++ b/library/stringio/open_spec.rb
@@ -8,26 +8,26 @@ describe "StringIO.open when passed [Object, mode]" do
   end
 
   it "returns the blocks return value when yielding" do
-    ret = StringIO.open("example", "r") { :test }
+    ret = StringIO.open(+"example", "r") { :test }
     ret.should equal(:test)
   end
 
   it "yields self to the passed block" do
     io = nil
-    StringIO.open("example", "r") { |strio| io = strio }
+    StringIO.open(+"example", "r") { |strio| io = strio }
     io.should be_kind_of(StringIO)
   end
 
   it "closes self after yielding" do
     io = nil
-    StringIO.open("example", "r") { |strio| io = strio }
+    StringIO.open(+"example", "r") { |strio| io = strio }
     io.closed?.should be_true
   end
 
   it "even closes self when an exception is raised while yielding" do
     io = nil
     begin
-      StringIO.open("example", "r") do |strio|
+      StringIO.open(+"example", "r") do |strio|
         io = strio
         raise "Error"
       end
@@ -38,14 +38,14 @@ describe "StringIO.open when passed [Object, mode]" do
 
   it "sets self's string to nil after yielding" do
     io = nil
-    StringIO.open("example", "r") { |strio| io = strio }
+    StringIO.open(+"example", "r") { |strio| io = strio }
     io.string.should be_nil
   end
 
   it "even sets self's string to nil when an exception is raised while yielding" do
     io = nil
     begin
-      StringIO.open("example", "r") do |strio|
+      StringIO.open(+"example", "r") do |strio|
         io = strio
         raise "Error"
       end
@@ -55,81 +55,81 @@ describe "StringIO.open when passed [Object, mode]" do
   end
 
   it "sets the mode based on the passed mode" do
-    io = StringIO.open("example", "r")
+    io = StringIO.open(+"example", "r")
     io.closed_read?.should be_false
     io.closed_write?.should be_true
 
-    io = StringIO.open("example", "rb")
+    io = StringIO.open(+"example", "rb")
     io.closed_read?.should be_false
     io.closed_write?.should be_true
 
-    io = StringIO.open("example", "r+")
+    io = StringIO.open(+"example", "r+")
     io.closed_read?.should be_false
     io.closed_write?.should be_false
 
-    io = StringIO.open("example", "rb+")
+    io = StringIO.open(+"example", "rb+")
     io.closed_read?.should be_false
     io.closed_write?.should be_false
 
-    io = StringIO.open("example", "w")
+    io = StringIO.open(+"example", "w")
     io.closed_read?.should be_true
     io.closed_write?.should be_false
 
-    io = StringIO.open("example", "wb")
+    io = StringIO.open(+"example", "wb")
     io.closed_read?.should be_true
     io.closed_write?.should be_false
 
-    io = StringIO.open("example", "w+")
+    io = StringIO.open(+"example", "w+")
     io.closed_read?.should be_false
     io.closed_write?.should be_false
 
-    io = StringIO.open("example", "wb+")
+    io = StringIO.open(+"example", "wb+")
     io.closed_read?.should be_false
     io.closed_write?.should be_false
 
-    io = StringIO.open("example", "a")
+    io = StringIO.open(+"example", "a")
     io.closed_read?.should be_true
     io.closed_write?.should be_false
 
-    io = StringIO.open("example", "ab")
+    io = StringIO.open(+"example", "ab")
     io.closed_read?.should be_true
     io.closed_write?.should be_false
 
-    io = StringIO.open("example", "a+")
+    io = StringIO.open(+"example", "a+")
     io.closed_read?.should be_false
     io.closed_write?.should be_false
 
-    io = StringIO.open("example", "ab+")
+    io = StringIO.open(+"example", "ab+")
     io.closed_read?.should be_false
     io.closed_write?.should be_false
   end
 
   it "allows passing the mode as an Integer" do
-    io = StringIO.open("example", IO::RDONLY)
+    io = StringIO.open(+"example", IO::RDONLY)
     io.closed_read?.should be_false
     io.closed_write?.should be_true
 
-    io = StringIO.open("example", IO::RDWR)
+    io = StringIO.open(+"example", IO::RDWR)
     io.closed_read?.should be_false
     io.closed_write?.should be_false
 
-    io = StringIO.open("example", IO::WRONLY)
+    io = StringIO.open(+"example", IO::WRONLY)
     io.closed_read?.should be_true
     io.closed_write?.should be_false
 
-    io = StringIO.open("example", IO::WRONLY | IO::TRUNC)
+    io = StringIO.open(+"example", IO::WRONLY | IO::TRUNC)
     io.closed_read?.should be_true
     io.closed_write?.should be_false
 
-    io = StringIO.open("example", IO::RDWR | IO::TRUNC)
+    io = StringIO.open(+"example", IO::RDWR | IO::TRUNC)
     io.closed_read?.should be_false
     io.closed_write?.should be_false
 
-    io = StringIO.open("example", IO::WRONLY | IO::APPEND)
+    io = StringIO.open(+"example", IO::WRONLY | IO::APPEND)
     io.closed_read?.should be_true
     io.closed_write?.should be_false
 
-    io = StringIO.open("example", IO::RDWR | IO::APPEND)
+    io = StringIO.open(+"example", IO::RDWR | IO::APPEND)
     io.closed_read?.should be_false
     io.closed_write?.should be_false
   end
@@ -141,7 +141,7 @@ describe "StringIO.open when passed [Object, mode]" do
   it "tries to convert the passed mode to a String using #to_str" do
     obj = mock('to_str')
     obj.should_receive(:to_str).and_return("r")
-    io = StringIO.open("example", obj)
+    io = StringIO.open(+"example", obj)
 
     io.closed_read?.should be_false
     io.closed_write?.should be_true
@@ -163,16 +163,16 @@ describe "StringIO.open when passed [Object]" do
 
   it "yields self to the passed block" do
     io = nil
-    ret = StringIO.open("example") { |strio| io = strio }
+    ret = StringIO.open(+"example") { |strio| io = strio }
     io.should equal(ret)
   end
 
   it "sets the mode to read-write (r+)" do
-    io = StringIO.open("example")
+    io = StringIO.open(+"example")
     io.closed_read?.should be_false
     io.closed_write?.should be_false
 
-    io = StringIO.new("example")
+    io = StringIO.new(+"example")
     io.printf("%d", 123)
     io.string.should == "123mple"
   end
@@ -204,7 +204,7 @@ describe "StringIO.open when passed no arguments" do
     io.closed_read?.should be_false
     io.closed_write?.should be_false
 
-    io = StringIO.new("example")
+    io = StringIO.new(+"example")
     io.printf("%d", 123)
     io.string.should == "123mple"
   end

--- a/library/stringio/print_spec.rb
+++ b/library/stringio/print_spec.rb
@@ -3,7 +3,7 @@ require_relative 'fixtures/classes'
 
 describe "StringIO#print" do
   before :each do
-    @io = StringIO.new('example')
+    @io = StringIO.new(+'example')
   end
 
   it "prints $_ when passed no arguments" do
@@ -73,7 +73,7 @@ end
 
 describe "StringIO#print when in append mode" do
   before :each do
-    @io = StringIO.new("example", "a")
+    @io = StringIO.new(+"example", "a")
   end
 
   it "appends the passed argument to the end of self" do
@@ -92,10 +92,10 @@ end
 
 describe "StringIO#print when self is not writable" do
   it "raises an IOError" do
-    io = StringIO.new("test", "r")
+    io = StringIO.new(+"test", "r")
     -> { io.print("test") }.should raise_error(IOError)
 
-    io = StringIO.new("test")
+    io = StringIO.new(+"test")
     io.close_write
     -> { io.print("test") }.should raise_error(IOError)
   end

--- a/library/stringio/printf_spec.rb
+++ b/library/stringio/printf_spec.rb
@@ -41,7 +41,7 @@ end
 
 describe "StringIO#printf when in read-write mode" do
   before :each do
-    @io = StringIO.new("example", "r+")
+    @io = StringIO.new(+"example", "r+")
   end
 
   it "starts from the beginning" do
@@ -62,7 +62,7 @@ end
 
 describe "StringIO#printf when in append mode" do
   before :each do
-    @io = StringIO.new("example", "a")
+    @io = StringIO.new(+"example", "a")
   end
 
   it "appends the passed argument to the end of self" do
@@ -81,10 +81,10 @@ end
 
 describe "StringIO#printf when self is not writable" do
   it "raises an IOError" do
-    io = StringIO.new("test", "r")
+    io = StringIO.new(+"test", "r")
     -> { io.printf("test") }.should raise_error(IOError)
 
-    io = StringIO.new("test")
+    io = StringIO.new(+"test")
     io.close_write
     -> { io.printf("test") }.should raise_error(IOError)
   end

--- a/library/stringio/putc_spec.rb
+++ b/library/stringio/putc_spec.rb
@@ -3,7 +3,7 @@ require_relative 'fixtures/classes'
 
 describe "StringIO#putc when passed [String]" do
   before :each do
-    @io = StringIO.new('example')
+    @io = StringIO.new(+'example')
   end
 
   it "overwrites the character at the current position" do
@@ -54,7 +54,7 @@ end
 
 describe "StringIO#putc when passed [Object]" do
   before :each do
-    @io = StringIO.new('example')
+    @io = StringIO.new(+'example')
   end
 
   it "it writes the passed Integer % 256 to self" do
@@ -85,7 +85,7 @@ end
 
 describe "StringIO#putc when in append mode" do
   it "appends to the end of self" do
-    io = StringIO.new("test", "a")
+    io = StringIO.new(+"test", "a")
     io.putc(?t)
     io.string.should == "testt"
   end
@@ -93,10 +93,10 @@ end
 
 describe "StringIO#putc when self is not writable" do
   it "raises an IOError" do
-    io = StringIO.new("test", "r")
+    io = StringIO.new(+"test", "r")
     -> { io.putc(?a) }.should raise_error(IOError)
 
-    io = StringIO.new("test")
+    io = StringIO.new(+"test")
     io.close_write
     -> { io.putc("t") }.should raise_error(IOError)
   end

--- a/library/stringio/puts_spec.rb
+++ b/library/stringio/puts_spec.rb
@@ -145,7 +145,7 @@ end
 
 describe "StringIO#puts when in append mode" do
   before :each do
-    @io = StringIO.new("example", "a")
+    @io = StringIO.new(+"example", "a")
   end
 
   it "appends the passed argument to the end of self" do
@@ -164,10 +164,10 @@ end
 
 describe "StringIO#puts when self is not writable" do
   it "raises an IOError" do
-    io = StringIO.new("test", "r")
+    io = StringIO.new(+"test", "r")
     -> { io.puts }.should raise_error(IOError)
 
-    io = StringIO.new("test")
+    io = StringIO.new(+"test")
     io.close_write
     -> { io.puts }.should raise_error(IOError)
   end
@@ -175,7 +175,7 @@ end
 
 describe "StringIO#puts when passed an encoded string" do
   it "stores the bytes unmodified" do
-    io = StringIO.new("")
+    io = StringIO.new(+"")
     io.puts "\x00\x01\x02"
     io.puts "æåø"
 

--- a/library/stringio/read_nonblock_spec.rb
+++ b/library/stringio/read_nonblock_spec.rb
@@ -8,7 +8,7 @@ describe "StringIO#read_nonblock when passed length, buffer" do
 
   it "accepts :exception option" do
     io = StringIO.new("example")
-    io.read_nonblock(3, buffer = "", exception: true)
+    io.read_nonblock(3, buffer = +"", exception: true)
     buffer.should == "exa"
   end
 end
@@ -33,14 +33,14 @@ end
 describe "StringIO#read_nonblock" do
 
   it "accepts an exception option" do
-    stringio = StringIO.new('foo')
+    stringio = StringIO.new(+'foo')
     stringio.read_nonblock(3, exception: false).should == 'foo'
   end
 
   context "when exception option is set to false" do
     context "when the end is reached" do
       it "returns nil" do
-        stringio = StringIO.new('')
+        stringio = StringIO.new(+'')
         stringio << "hello"
         stringio.rewind
 

--- a/library/stringio/read_spec.rb
+++ b/library/stringio/read_spec.rb
@@ -53,7 +53,7 @@ describe "StringIO#read when passed length and a buffer" do
   end
 
   it "reads [length] characters into the buffer" do
-    buf = "foo"
+    buf = +"foo"
     result = @io.read(10, buf)
 
     buf.should == "abcdefghij"

--- a/library/stringio/readline_spec.rb
+++ b/library/stringio/readline_spec.rb
@@ -113,7 +113,7 @@ end
 
 describe "StringIO#readline when in write-only mode" do
   it "raises an IOError" do
-    io = StringIO.new("xyz", "w")
+    io = StringIO.new(+"xyz", "w")
     -> { io.readline }.should raise_error(IOError)
 
     io = StringIO.new("xyz")

--- a/library/stringio/readlines_spec.rb
+++ b/library/stringio/readlines_spec.rb
@@ -83,7 +83,7 @@ end
 
 describe "StringIO#readlines when in write-only mode" do
   it "raises an IOError" do
-    io = StringIO.new("xyz", "w")
+    io = StringIO.new(+"xyz", "w")
     -> { io.readlines }.should raise_error(IOError)
 
     io = StringIO.new("xyz")

--- a/library/stringio/readpartial_spec.rb
+++ b/library/stringio/readpartial_spec.rb
@@ -3,7 +3,7 @@ require_relative 'fixtures/classes'
 
 describe "StringIO#readpartial" do
   before :each do
-    @string = StringIO.new('Stop, look, listen')
+    @string = StringIO.new(+'Stop, look, listen')
   end
 
   after :each do
@@ -48,7 +48,7 @@ describe "StringIO#readpartial" do
   end
 
   it "discards the existing buffer content upon successful read" do
-    buffer = "existing"
+    buffer = +"existing"
     @string.readpartial(11, buffer)
     buffer.should == "Stop, look,"
   end
@@ -59,7 +59,7 @@ describe "StringIO#readpartial" do
   end
 
   it "discards the existing buffer content upon error" do
-    buffer = 'hello'
+    buffer = +'hello'
     @string.readpartial(100)
     -> { @string.readpartial(1, buffer) }.should raise_error(EOFError)
     buffer.should be_empty

--- a/library/stringio/reopen_spec.rb
+++ b/library/stringio/reopen_spec.rb
@@ -3,21 +3,21 @@ require_relative 'fixtures/classes'
 
 describe "StringIO#reopen when passed [Object, Integer]" do
   before :each do
-    @io = StringIO.new("example")
+    @io = StringIO.new(+"example")
   end
 
   it "reopens self with the passed Object in the passed mode" do
-    @io.reopen("reopened", IO::RDONLY)
+    @io.reopen(+"reopened", IO::RDONLY)
     @io.closed_read?.should be_false
     @io.closed_write?.should be_true
     @io.string.should == "reopened"
 
-    @io.reopen("reopened, twice", IO::WRONLY)
+    @io.reopen(+"reopened, twice", IO::WRONLY)
     @io.closed_read?.should be_true
     @io.closed_write?.should be_false
     @io.string.should == "reopened, twice"
 
-    @io.reopen("reopened, another time", IO::RDWR)
+    @io.reopen(+"reopened, another time", IO::RDWR)
     @io.closed_read?.should be_false
     @io.closed_write?.should be_false
     @io.string.should == "reopened, another time"
@@ -25,7 +25,7 @@ describe "StringIO#reopen when passed [Object, Integer]" do
 
   it "tries to convert the passed Object to a String using #to_str" do
     obj = mock("to_str")
-    obj.should_receive(:to_str).and_return("to_str")
+    obj.should_receive(:to_str).and_return(+"to_str")
     @io.reopen(obj, IO::RDWR)
     @io.string.should == "to_str"
   end
@@ -51,39 +51,39 @@ end
 
 describe "StringIO#reopen when passed [Object, Object]" do
   before :each do
-    @io = StringIO.new("example")
+    @io = StringIO.new(+"example")
   end
 
   it "reopens self with the passed Object in the passed mode" do
-    @io.reopen("reopened", "r")
+    @io.reopen(+"reopened", "r")
     @io.closed_read?.should be_false
     @io.closed_write?.should be_true
     @io.string.should == "reopened"
 
-    @io.reopen("reopened, twice", "r+")
+    @io.reopen(+"reopened, twice", "r+")
     @io.closed_read?.should be_false
     @io.closed_write?.should be_false
     @io.string.should == "reopened, twice"
 
-    @io.reopen("reopened, another", "w+")
+    @io.reopen(+"reopened, another", "w+")
     @io.closed_read?.should be_false
     @io.closed_write?.should be_false
     @io.string.should == ""
 
-    @io.reopen("reopened, another time", "r+")
+    @io.reopen(+"reopened, another time", "r+")
     @io.closed_read?.should be_false
     @io.closed_write?.should be_false
     @io.string.should == "reopened, another time"
   end
 
   it "truncates the passed String when opened in truncate mode" do
-    @io.reopen(str = "reopened", "w")
+    @io.reopen(str = +"reopened", "w")
     str.should == ""
   end
 
   it "tries to convert the passed Object to a String using #to_str" do
     obj = mock("to_str")
-    obj.should_receive(:to_str).and_return("to_str")
+    obj.should_receive(:to_str).and_return(+"to_str")
     @io.reopen(obj, "r")
     @io.string.should == "to_str"
   end
@@ -94,20 +94,20 @@ describe "StringIO#reopen when passed [Object, Object]" do
 
   it "resets self's position to 0" do
     @io.read(5)
-    @io.reopen("reopened")
+    @io.reopen(+"reopened")
     @io.pos.should eql(0)
   end
 
   it "resets self's line number to 0" do
     @io.gets
-    @io.reopen("reopened")
+    @io.reopen(+"reopened")
     @io.lineno.should eql(0)
   end
 
   it "tries to convert the passed mode Object to an Integer using #to_str" do
     obj = mock("to_str")
     obj.should_receive(:to_str).and_return("r")
-    @io.reopen("reopened", obj)
+    @io.reopen(+"reopened", obj)
     @io.closed_read?.should be_false
     @io.closed_write?.should be_true
     @io.string.should == "reopened"
@@ -128,13 +128,13 @@ end
 
 describe "StringIO#reopen when passed [String]" do
   before :each do
-    @io = StringIO.new("example")
+    @io = StringIO.new(+"example")
   end
 
   it "reopens self with the passed String in read-write mode" do
     @io.close
 
-    @io.reopen("reopened")
+    @io.reopen(+"reopened")
 
     @io.closed_write?.should be_false
     @io.closed_read?.should be_false
@@ -144,20 +144,20 @@ describe "StringIO#reopen when passed [String]" do
 
   it "resets self's position to 0" do
     @io.read(5)
-    @io.reopen("reopened")
+    @io.reopen(+"reopened")
     @io.pos.should eql(0)
   end
 
   it "resets self's line number to 0" do
     @io.gets
-    @io.reopen("reopened")
+    @io.reopen(+"reopened")
     @io.lineno.should eql(0)
   end
 end
 
 describe "StringIO#reopen when passed [Object]" do
   before :each do
-    @io = StringIO.new("example")
+    @io = StringIO.new(+"example")
   end
 
   it "raises a TypeError when passed an Object that can't be converted to a StringIO" do
@@ -172,7 +172,7 @@ describe "StringIO#reopen when passed [Object]" do
 
   it "tries to convert the passed Object to a StringIO using #to_strio" do
     obj = mock("to_strio")
-    obj.should_receive(:to_strio).and_return(StringIO.new("to_strio"))
+    obj.should_receive(:to_strio).and_return(StringIO.new(+"to_strio"))
     @io.reopen(obj)
     @io.string.should == "to_strio"
   end
@@ -180,7 +180,7 @@ end
 
 describe "StringIO#reopen when passed no arguments" do
   before :each do
-    @io = StringIO.new("example\nsecond line")
+    @io = StringIO.new(+"example\nsecond line")
   end
 
   it "resets self's mode to read-write" do
@@ -208,40 +208,40 @@ end
 # for details.
 describe "StringIO#reopen" do
   before :each do
-    @io = StringIO.new('hello','a')
+    @io = StringIO.new(+'hello','a')
   end
 
   # TODO: find out if this is really a bug
   it "reopens a stream when given a String argument" do
-    @io.reopen('goodbye').should == @io
+    @io.reopen(+'goodbye').should == @io
     @io.string.should == 'goodbye'
     @io << 'x'
     @io.string.should == 'xoodbye'
   end
 
   it "reopens a stream in append mode when flagged as such" do
-    @io.reopen('goodbye', 'a').should == @io
+    @io.reopen(+'goodbye', 'a').should == @io
     @io.string.should == 'goodbye'
     @io << 'x'
     @io.string.should == 'goodbyex'
   end
 
   it "reopens and truncate when reopened in write mode" do
-    @io.reopen('goodbye', 'wb').should == @io
+    @io.reopen(+'goodbye', 'wb').should == @io
     @io.string.should == ''
     @io << 'x'
     @io.string.should == 'x'
   end
 
   it "truncates the given string, not a copy" do
-    str = 'goodbye'
+    str = +'goodbye'
     @io.reopen(str, 'w')
     @io.string.should == ''
     str.should == ''
   end
 
   it "does not truncate the content even when the StringIO argument is in the truncate mode" do
-    orig_io = StringIO.new("Original StringIO", IO::RDWR|IO::TRUNC)
+    orig_io = StringIO.new(+"Original StringIO", IO::RDWR|IO::TRUNC)
     orig_io.write("BLAH") # make sure the content is not empty
 
     @io.reopen(orig_io)

--- a/library/stringio/shared/codepoints.rb
+++ b/library/stringio/shared/codepoints.rb
@@ -27,7 +27,7 @@ describe :stringio_codepoints, shared: true do
     @io.close_read
     -> { @enum.to_a }.should raise_error(IOError)
 
-    io = StringIO.new("xyz", "w")
+    io = StringIO.new(+"xyz", "w")
     -> { io.send(@method).to_a }.should raise_error(IOError)
   end
 

--- a/library/stringio/shared/each.rb
+++ b/library/stringio/shared/each.rb
@@ -107,7 +107,7 @@ end
 
 describe :stringio_each_not_readable, shared: true do
   it "raises an IOError" do
-    io = StringIO.new("a b c d e", "w")
+    io = StringIO.new(+"a b c d e", "w")
     -> { io.send(@method) { |b| b } }.should raise_error(IOError)
 
     io = StringIO.new("a b c d e")

--- a/library/stringio/shared/each_byte.rb
+++ b/library/stringio/shared/each_byte.rb
@@ -38,7 +38,7 @@ end
 
 describe :stringio_each_byte_not_readable, shared: true do
   it "raises an IOError" do
-    io = StringIO.new("xyz", "w")
+    io = StringIO.new(+"xyz", "w")
     -> { io.send(@method) { |b| b } }.should raise_error(IOError)
 
     io = StringIO.new("xyz")

--- a/library/stringio/shared/each_char.rb
+++ b/library/stringio/shared/each_char.rb
@@ -26,7 +26,7 @@ end
 
 describe :stringio_each_char_not_readable, shared: true do
   it "raises an IOError" do
-    io = StringIO.new("xyz", "w")
+    io = StringIO.new(+"xyz", "w")
     -> { io.send(@method) { |b| b } }.should raise_error(IOError)
 
     io = StringIO.new("xyz")

--- a/library/stringio/shared/getc.rb
+++ b/library/stringio/shared/getc.rb
@@ -33,7 +33,7 @@ end
 
 describe :stringio_getc_not_readable, shared: true do
   it "raises an IOError" do
-    io = StringIO.new("xyz", "w")
+    io = StringIO.new(+"xyz", "w")
     -> { io.send(@method) }.should raise_error(IOError)
 
     io = StringIO.new("xyz")

--- a/library/stringio/shared/isatty.rb
+++ b/library/stringio/shared/isatty.rb
@@ -1,5 +1,5 @@
 describe :stringio_isatty, shared: true do
   it "returns false" do
-    StringIO.new('tty').send(@method).should be_false
+    StringIO.new("tty").send(@method).should be_false
   end
 end

--- a/library/stringio/shared/read.rb
+++ b/library/stringio/shared/read.rb
@@ -5,19 +5,19 @@ describe :stringio_read, shared: true do
 
   it "returns the passed buffer String" do
     # Note: Rubinius bug:
-    # @io.send(@method, 7, buffer = "").should equal(buffer)
-    ret = @io.send(@method, 7, buffer = "")
+    # @io.send(@method, 7, buffer = +"").should equal(buffer)
+    ret = @io.send(@method, 7, buffer = +"")
     ret.should equal(buffer)
   end
 
   it "reads length bytes and writes them to the buffer String" do
-    @io.send(@method, 7, buffer = "")
+    @io.send(@method, 7, buffer = +"")
     buffer.should == "example"
   end
 
   it "tries to convert the passed buffer Object to a String using #to_str" do
     obj = mock("to_str")
-    obj.should_receive(:to_str).and_return(buffer = "")
+    obj.should_receive(:to_str).and_return(buffer = +"")
 
     @io.send(@method, 7, obj)
     buffer.should == "example"
@@ -75,7 +75,7 @@ end
 
 describe :stringio_read_no_arguments, shared: true do
   before :each do
-    @io = StringIO.new("example")
+    @io = StringIO.new(+"example")
   end
 
   it "reads the whole content starting from the current position" do
@@ -117,7 +117,7 @@ end
 
 describe :stringio_read_not_readable, shared: true do
   it "raises an IOError" do
-    io = StringIO.new("test", "w")
+    io = StringIO.new(+"test", "w")
     -> { io.send(@method) }.should raise_error(IOError)
 
     io = StringIO.new("test")

--- a/library/stringio/shared/readchar.rb
+++ b/library/stringio/shared/readchar.rb
@@ -19,7 +19,7 @@ end
 
 describe :stringio_readchar_not_readable, shared: true do
   it "raises an IOError" do
-    io = StringIO.new("a b c d e", "w")
+    io = StringIO.new(+"a b c d e", "w")
     -> { io.send(@method) }.should raise_error(IOError)
 
     io = StringIO.new("a b c d e")

--- a/library/stringio/shared/write.rb
+++ b/library/stringio/shared/write.rb
@@ -1,6 +1,6 @@
 describe :stringio_write, shared: true do
   before :each do
-    @io = StringIO.new('12345')
+    @io = StringIO.new(+'12345')
   end
 
   it "tries to convert the passed Object to a String using #to_s" do
@@ -13,7 +13,7 @@ end
 
 describe :stringio_write_string, shared: true do
   before :each do
-    @io = StringIO.new('12345')
+    @io = StringIO.new(+'12345')
   end
 
   # TODO: RDoc says that #write appends at the current position.
@@ -106,10 +106,10 @@ end
 
 describe :stringio_write_not_writable, shared: true do
   it "raises an IOError" do
-    io = StringIO.new("test", "r")
+    io = StringIO.new(+"test", "r")
     -> { io.send(@method, "test") }.should raise_error(IOError)
 
-    io = StringIO.new("test")
+    io = StringIO.new(+"test")
     io.close_write
     -> { io.send(@method, "test") }.should raise_error(IOError)
   end
@@ -117,7 +117,7 @@ end
 
 describe :stringio_write_append, shared: true do
   before :each do
-    @io = StringIO.new("example", "a")
+    @io = StringIO.new(+"example", "a")
   end
 
   it "appends the passed argument to the end of self" do

--- a/library/stringio/truncate_spec.rb
+++ b/library/stringio/truncate_spec.rb
@@ -3,7 +3,7 @@ require "stringio"
 
 describe "StringIO#truncate when passed [length]" do
   before :each do
-    @io = StringIO.new('123456789')
+    @io = StringIO.new(+'123456789')
   end
 
   it "returns an Integer" do
@@ -16,7 +16,7 @@ describe "StringIO#truncate when passed [length]" do
   end
 
   it "does not create a copy of the underlying string" do
-    io = StringIO.new(str = "123456789")
+    io = StringIO.new(str = +"123456789")
     io.truncate(4)
     io.string.should equal(str)
   end
@@ -52,10 +52,10 @@ end
 
 describe "StringIO#truncate when self is not writable" do
   it "raises an IOError" do
-    io = StringIO.new("test", "r")
+    io = StringIO.new(+"test", "r")
     -> { io.truncate(2) }.should raise_error(IOError)
 
-    io = StringIO.new("test")
+    io = StringIO.new(+"test")
     io.close_write
     -> { io.truncate(2) }.should raise_error(IOError)
   end

--- a/library/stringio/ungetc_spec.rb
+++ b/library/stringio/ungetc_spec.rb
@@ -3,7 +3,7 @@ require_relative 'fixtures/classes'
 
 describe "StringIO#ungetc when passed [char]" do
   before :each do
-    @io = StringIO.new('1234')
+    @io = StringIO.new(+'1234')
   end
 
   it "writes the passed char before the current position" do
@@ -45,11 +45,11 @@ end
 
 describe "StringIO#ungetc when self is not readable" do
   it "raises an IOError" do
-    io = StringIO.new("test", "w")
+    io = StringIO.new(+"test", "w")
     io.pos = 1
     -> { io.ungetc(?A) }.should raise_error(IOError)
 
-    io = StringIO.new("test")
+    io = StringIO.new(+"test")
     io.pos = 1
     io.close_read
     -> { io.ungetc(?A) }.should raise_error(IOError)
@@ -60,11 +60,11 @@ end
 #
 # describe "StringIO#ungetc when self is not writable" do
 #   it "raises an IOError" do
-#     io = StringIO.new("test", "r")
+#     io = StringIO.new(+"test", "r")
 #     io.pos = 1
 #     lambda { io.ungetc(?A) }.should raise_error(IOError)
 #
-#     io = StringIO.new("test")
+#     io = StringIO.new(+"test")
 #     io.pos = 1
 #     io.close_write
 #     lambda { io.ungetc(?A) }.should raise_error(IOError)

--- a/library/stringio/write_nonblock_spec.rb
+++ b/library/stringio/write_nonblock_spec.rb
@@ -10,7 +10,7 @@ describe "StringIO#write_nonblock when passed [String]" do
   it_behaves_like :stringio_write_string, :write_nonblock
 
   it "accepts :exception option" do
-    io = StringIO.new("12345", "a")
+    io = StringIO.new(+"12345", "a")
     io.write_nonblock("67890", exception: true)
     io.string.should == "1234567890"
   end

--- a/library/stringscanner/getch_spec.rb
+++ b/library/stringscanner/getch_spec.rb
@@ -13,7 +13,7 @@ describe "StringScanner#getch" do
 
   it "is multi-byte character sensitive" do
     # Japanese hiragana "A" in EUC-JP
-    src = "\244\242".force_encoding("euc-jp")
+    src = "\244\242".dup.force_encoding("euc-jp")
 
     s = StringScanner.new(src)
     s.getch.should == src

--- a/library/stringscanner/shared/concat.rb
+++ b/library/stringscanner/shared/concat.rb
@@ -1,6 +1,6 @@
 describe :strscan_concat, shared: true do
   it "concatenates the given argument to self and returns self" do
-    s = StringScanner.new("hello ")
+    s = StringScanner.new(+"hello ")
     s.send(@method, 'world').should == s
     s.string.should == "hello world"
     s.eos?.should be_false

--- a/library/stringscanner/string_spec.rb
+++ b/library/stringscanner/string_spec.rb
@@ -3,7 +3,7 @@ require 'strscan'
 
 describe "StringScanner#string" do
   before :each do
-    @string = "This is a test"
+    @string = +"This is a test"
     @s = StringScanner.new(@string)
   end
 

--- a/library/zlib/deflate/deflate_spec.rb
+++ b/library/zlib/deflate/deflate_spec.rb
@@ -23,7 +23,7 @@ describe "Zlib::Deflate.deflate" do
 
   it "deflates chunked data" do
     random_generator = Random.new(0)
-    deflated         = ''
+    deflated         = +''
 
     Zlib::Deflate.deflate(random_generator.bytes(20000)) do |chunk|
       deflated << chunk
@@ -70,7 +70,7 @@ describe "Zlib::Deflate#deflate" do
   before :each do
     @deflator         = Zlib::Deflate.new
     @random_generator = Random.new(0)
-    @original         = ''
+    @original         = +''
     @chunks           = []
   end
 

--- a/library/zlib/deflate/params_spec.rb
+++ b/library/zlib/deflate/params_spec.rb
@@ -3,7 +3,7 @@ require 'zlib'
 
 describe "Zlib::Deflate#params" do
   it "changes the deflate parameters" do
-    data = 'abcdefghijklm'
+    data = +'abcdefghijklm'
 
     d = Zlib::Deflate.new Zlib::NO_COMPRESSION, Zlib::MAX_WBITS,
     Zlib::DEF_MEM_LEVEL, Zlib::DEFAULT_STRATEGY

--- a/library/zlib/inflate/inflate_spec.rb
+++ b/library/zlib/inflate/inflate_spec.rb
@@ -72,7 +72,7 @@ describe "Zlib::Inflate.inflate" do
     data = [120, 156, 75, 203, 207, 7, 0, 2, 130, 1, 69].pack('C*')
     z = Zlib::Inflate.new
     # add bytes, one by one
-    result = ""
+    result = +""
     data.each_byte { |d| result << z.inflate(d.chr)}
     result << z.finish
     result.should == "foo"
@@ -82,7 +82,7 @@ describe "Zlib::Inflate.inflate" do
     data = [120, 156, 75, 203, 207, 7, 0, 2, 130, 1, 69].pack('C*')[0,5]
     z = Zlib::Inflate.new
     # add bytes, one by one, but not all
-    result = ""
+    result = +""
     data.each_byte { |d| result << z.inflate(d.chr)}
     -> { result << z.finish }.should raise_error(Zlib::BufError)
   end
@@ -90,7 +90,7 @@ describe "Zlib::Inflate.inflate" do
   it "properly handles excessive data, byte-by-byte" do
     main_data = [120, 156, 75, 203, 207, 7, 0, 2, 130, 1, 69].pack('C*')
     data =  main_data * 2
-    result = ""
+    result = +""
 
     z = Zlib::Inflate.new
     # add bytes, one by one
@@ -105,7 +105,7 @@ describe "Zlib::Inflate.inflate" do
   it "properly handles excessive data, in one go" do
     main_data = [120, 156, 75, 203, 207, 7, 0, 2, 130, 1, 69].pack('C*')
     data =  main_data * 2
-    result = ""
+    result = +""
 
     z = Zlib::Inflate.new
     result << z.inflate(data)

--- a/optional/capi/encoding_spec.rb
+++ b/optional/capi/encoding_spec.rb
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: false
 require_relative 'spec_helper'
 require_relative 'fixtures/encoding'
 

--- a/optional/capi/file_spec.rb
+++ b/optional/capi/file_spec.rb
@@ -69,7 +69,7 @@ describe "C-API File function" do
     end
 
     it "does not call #to_str on a String" do
-      obj = "path"
+      obj = +"path"
       obj.should_not_receive(:to_str)
       @s.FilePathValue(obj).should eql(obj)
     end

--- a/optional/capi/object_spec.rb
+++ b/optional/capi/object_spec.rb
@@ -686,7 +686,7 @@ describe "CApiObject" do
     end
 
     it "returns false if object passed to it is not frozen" do
-      obj = ""
+      obj = +""
       @o.rb_obj_frozen_p(obj).should == false
     end
   end
@@ -700,7 +700,7 @@ describe "CApiObject" do
     end
 
     it "does nothing when object isn't frozen" do
-      obj = ""
+      obj = +""
       -> { @o.rb_check_frozen(obj) }.should_not raise_error(TypeError)
     end
   end
@@ -894,9 +894,9 @@ describe "CApiObject" do
 
     describe "rb_copy_generic_ivar for objects which do not store ivars directly" do
       it "copies the instance variables from one object to another" do
-        original = "abc"
+        original = +"abc"
         original.instance_variable_set(:@foo, :bar)
-        clone = "def"
+        clone = +"def"
         @o.rb_copy_generic_ivar(clone, original)
         clone.instance_variable_get(:@foo).should == :bar
       end
@@ -904,7 +904,7 @@ describe "CApiObject" do
 
     describe "rb_free_generic_ivar for objects which do not store ivars directly" do
       it "removes the instance variables from an object" do
-        o = "abc"
+        o = +"abc"
         o.instance_variable_set(:@baz, :flibble)
         @o.rb_free_generic_ivar(o)
         o.instance_variables.should == []

--- a/optional/capi/string_spec.rb
+++ b/optional/capi/string_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: false
 require_relative 'spec_helper'
 require_relative '../../shared/string/times'
 
@@ -47,7 +48,7 @@ describe "C-API String function" do
   [Encoding::BINARY, Encoding::UTF_8].each do |enc|
     describe "rb_str_set_len on a #{enc.name} String" do
       before :each do
-        @str = "abcdefghij".force_encoding(enc)
+        @str = "abcdefghij".dup.force_encoding(enc)
         # Make sure to unshare the string
         @s.rb_str_modify(@str)
       end
@@ -99,7 +100,7 @@ describe "C-API String function" do
 
   describe "rb_str_set_len on a UTF-16 String" do
     before :each do
-      @str = "abcdefghij".force_encoding(Encoding::UTF_16BE)
+      @str = "abcdefghij".dup.force_encoding(Encoding::UTF_16BE)
       # Make sure to unshare the string
       @s.rb_str_modify(@str)
     end
@@ -112,7 +113,7 @@ describe "C-API String function" do
 
   describe "rb_str_set_len on a UTF-32 String" do
     before :each do
-      @str = "abcdefghijkl".force_encoding(Encoding::UTF_32BE)
+      @str = "abcdefghijkl".dup.force_encoding(Encoding::UTF_32BE)
       # Make sure to unshare the string
       @s.rb_str_modify(@str)
     end
@@ -231,7 +232,7 @@ describe "C-API String function" do
 
   describe "rb_usascii_str_new" do
     it "creates a new String with US-ASCII Encoding from a char buffer of len characters" do
-      str = "abc".force_encoding("us-ascii")
+      str = "abc".dup.force_encoding("us-ascii")
       result = @s.rb_usascii_str_new("abcdef", 3)
       result.should == str
       result.encoding.should == Encoding::US_ASCII
@@ -247,14 +248,14 @@ describe "C-API String function" do
 
     it "returns US-ASCII string for non-US-ASCII string literal" do
       str = @s.rb_usascii_str_new_lit_non_ascii
-      str.should == "r\xC3\xA9sum\xC3\xA9".force_encoding(Encoding::US_ASCII)
+      str.should == "r\xC3\xA9sum\xC3\xA9".dup.force_encoding(Encoding::US_ASCII)
       str.encoding.should == Encoding::US_ASCII
     end
   end
 
   describe "rb_usascii_str_new_cstr" do
     it "creates a new String with US-ASCII Encoding" do
-      str = "abc".force_encoding("us-ascii")
+      str = "abc".dup.force_encoding("us-ascii")
       result = @s.rb_usascii_str_new_cstr("abc")
       result.should == str
       result.encoding.should == Encoding::US_ASCII
@@ -418,7 +419,7 @@ describe "C-API String function" do
 
   describe "rb_enc_str_buf_cat" do
     it "concatenates a C string literal to a ruby string with the given encoding" do
-      input = "hello ".force_encoding(Encoding::US_ASCII)
+      input = "hello ".dup.force_encoding(Encoding::US_ASCII)
       result = @s.rb_enc_str_buf_cat(input, "résumé", Encoding::UTF_8)
       result.should == "hello résumé"
       result.encoding.should == Encoding::UTF_8
@@ -500,8 +501,8 @@ describe "C-API String function" do
 
   describe "rb_str_subseq" do
     it "returns a byte-indexed substring" do
-      str = "\x00\x01\x02\x03\x04".force_encoding("binary")
-      @s.rb_str_subseq(str, 1, 2).should == "\x01\x02".force_encoding("binary")
+      str = "\x00\x01\x02\x03\x04".dup.force_encoding("binary")
+      @s.rb_str_subseq(str, 1, 2).should == "\x01\x02".dup.force_encoding("binary")
     end
   end
 
@@ -712,7 +713,7 @@ describe "C-API String function" do
     end
 
     it "increases the size of the string" do
-      expected = "test".force_encoding("US-ASCII")
+      expected = "test".dup.force_encoding("US-ASCII")
       str = @s.rb_str_resize(expected.dup, 12)
       str.size.should == 12
       str.bytesize.should == 12
@@ -843,11 +844,11 @@ describe "C-API String function" do
 #     it "transcodes a String to Encoding.default_internal if it is set" do
 #       Encoding.default_internal = Encoding::EUC_JP
 #
-#  -      a = "\xE3\x81\x82\xe3\x82\x8c".force_encoding("utf-8")
+#  -      a = "\xE3\x81\x82\xe3\x82\x8c".dup.force_encoding("utf-8")
 #  +      a = [0xE3, 0x81, 0x82, 0xe3, 0x82, 0x8c].pack('C6').force_encoding("utf-8")
 #         s = @s.rb_external_str_new_with_enc(a, a.bytesize, Encoding::UTF_8)
 #  -
-#  -      s.should == "\xA4\xA2\xA4\xEC".force_encoding("euc-jp")
+#  -      s.should == "\xA4\xA2\xA4\xEC".dup.force_encoding("euc-jp")
 #  +      x = [0xA4, 0xA2, 0xA4, 0xEC].pack('C4')#.force_encoding('binary')
 #  +      s.should == x
 #         s.encoding.should equal(Encoding::EUC_JP)
@@ -867,7 +868,7 @@ describe "C-API String function" do
   describe "rb_locale_str_new" do
     it "returns a String with 'locale' encoding" do
       s = @s.rb_locale_str_new("abc", 3)
-      s.should == "abc".force_encoding(Encoding.find("locale"))
+      s.should == "abc".dup.force_encoding(Encoding.find("locale"))
       s.encoding.should equal(Encoding.find("locale"))
     end
   end
@@ -875,14 +876,14 @@ describe "C-API String function" do
   describe "rb_locale_str_new_cstr" do
     it "returns a String with 'locale' encoding" do
       s = @s.rb_locale_str_new_cstr("abc")
-      s.should == "abc".force_encoding(Encoding.find("locale"))
+      s.should == "abc".dup.force_encoding(Encoding.find("locale"))
       s.encoding.should equal(Encoding.find("locale"))
     end
   end
 
   describe "rb_str_conv_enc" do
     it "returns the original String when to encoding is not specified" do
-      a = "abc".force_encoding("us-ascii")
+      a = "abc".dup.force_encoding("us-ascii")
       @s.rb_str_conv_enc(a, Encoding::US_ASCII, nil).should equal(a)
     end
 
@@ -892,7 +893,7 @@ describe "C-API String function" do
     end
 
     it "returns a transcoded String" do
-      a = "\xE3\x81\x82\xE3\x82\x8C".force_encoding("utf-8")
+      a = "\xE3\x81\x82\xE3\x82\x8C".dup.force_encoding("utf-8")
       result = @s.rb_str_conv_enc(a, Encoding::UTF_8, Encoding::EUC_JP)
       x = [0xA4, 0xA2, 0xA4, 0xEC].pack('C4').force_encoding('utf-8')
       result.should == x.force_encoding("euc-jp")
@@ -901,7 +902,7 @@ describe "C-API String function" do
 
     describe "when the String encoding is equal to the destination encoding" do
       it "returns the original String" do
-        a = "abc".force_encoding("us-ascii")
+        a = "abc".dup.force_encoding("us-ascii")
         @s.rb_str_conv_enc(a, Encoding::US_ASCII, Encoding::US_ASCII).should equal(a)
       end
 
@@ -911,7 +912,7 @@ describe "C-API String function" do
       end
 
       it "returns the origin String if the destination encoding is BINARY" do
-        a = "abc".force_encoding("binary")
+        a = "abc".dup.force_encoding("binary")
         @s.rb_str_conv_enc(a, Encoding::US_ASCII, Encoding::BINARY).should equal(a)
       end
     end
@@ -919,7 +920,7 @@ describe "C-API String function" do
 
   describe "rb_str_conv_enc_opts" do
     it "returns the original String when to encoding is not specified" do
-      a = "abc".force_encoding("us-ascii")
+      a = "abc".dup.force_encoding("us-ascii")
       @s.rb_str_conv_enc_opts(a, Encoding::US_ASCII, nil, 0, nil).should equal(a)
     end
 
@@ -930,7 +931,7 @@ describe "C-API String function" do
     end
 
     it "returns a transcoded String" do
-      a = "\xE3\x81\x82\xE3\x82\x8C".force_encoding("utf-8")
+      a = "\xE3\x81\x82\xE3\x82\x8C".dup.force_encoding("utf-8")
       result = @s.rb_str_conv_enc_opts(a, Encoding::UTF_8, Encoding::EUC_JP, 0, nil)
       x = [0xA4, 0xA2, 0xA4, 0xEC].pack('C4').force_encoding('utf-8')
       result.should == x.force_encoding("euc-jp")
@@ -939,7 +940,7 @@ describe "C-API String function" do
 
     describe "when the String encoding is equal to the destination encoding" do
       it "returns the original String" do
-        a = "abc".force_encoding("us-ascii")
+        a = "abc".dup.force_encoding("us-ascii")
         @s.rb_str_conv_enc_opts(a, Encoding::US_ASCII,
                                 Encoding::US_ASCII, 0, nil).should equal(a)
       end
@@ -951,7 +952,7 @@ describe "C-API String function" do
       end
 
       it "returns the origin String if the destination encoding is BINARY" do
-        a = "abc".force_encoding("binary")
+        a = "abc".dup.force_encoding("binary")
         @s.rb_str_conv_enc_opts(a, Encoding::US_ASCII,
                                 Encoding::BINARY, 0, nil).should equal(a)
       end
@@ -969,7 +970,7 @@ describe "C-API String function" do
   describe "rb_str_export_locale" do
     it "returns the original String with the locale encoding" do
       s = @s.rb_str_export_locale("abc")
-      s.should == "abc".force_encoding(Encoding.find("locale"))
+      s.should == "abc".dup.force_encoding(Encoding.find("locale"))
       s.encoding.should equal(Encoding.find("locale"))
     end
   end
@@ -1254,8 +1255,8 @@ end
     end
 
     it "returns different frozen strings for different encodings" do
-      result1 = @s.rb_str_to_interned_str("hello".force_encoding(Encoding::US_ASCII))
-      result2 = @s.rb_str_to_interned_str("hello".force_encoding(Encoding::UTF_8))
+      result1 = @s.rb_str_to_interned_str("hello".dup.force_encoding(Encoding::US_ASCII))
+      result2 = @s.rb_str_to_interned_str("hello".dup.force_encoding(Encoding::UTF_8))
       result1.should_not.equal?(result2)
     end
 

--- a/security/cve_2010_1330_spec.rb
+++ b/security/cve_2010_1330_spec.rb
@@ -8,7 +8,7 @@ describe "String#gsub" do
     # #gsub on a string in the UTF-8 encoding but with invalid an UTF-8 byte
     # sequence.
 
-    str = "\xF6<script>"
+    str = +"\xF6<script>"
     str.force_encoding Encoding::BINARY
     str.gsub(/</, "&lt;").should == "\xF6&lt;script>".b
     str.force_encoding Encoding::UTF_8

--- a/shared/kernel/object_id.rb
+++ b/shared/kernel/object_id.rb
@@ -52,10 +52,20 @@ describe :object_id, shared: true do
     o1.send(@method).should_not == o2.send(@method)
   end
 
-  it "returns a different value for two String literals" do
-    o1 = "hello"
-    o2 = "hello"
-    o1.send(@method).should_not == o2.send(@method)
+  guard -> { "test".frozen? } do # --enable-frozen-string-literal in $RUBYOPT
+    it "returns the same value for two identical String literals" do
+      o1 = "hello"
+      o2 = "hello"
+      o1.send(@method).should == o2.send(@method)
+    end
+  end
+
+  guard_not -> { "test".frozen? } do
+    it "returns a different value for two String literals" do
+      o1 = "hello"
+      o2 = "hello"
+      o1.send(@method).should_not == o2.send(@method)
+    end
   end
 
   it "returns a different value for an object and its dup" do

--- a/shared/string/end_with.rb
+++ b/shared/string/end_with.rb
@@ -55,7 +55,7 @@ describe :end_with, shared: true do
   it "checks that we are starting to match at the head of a character" do
     "\xC3\xA9".send(@method).should_not.end_with?("\xA9")
     "\xe3\x81\x82".send(@method).should_not.end_with?("\x82")
-    "ab".force_encoding("UTF-16BE").send(@method).should_not.end_with?(
-        "b".force_encoding("UTF-16BE"))
+    "ab".dup.force_encoding("UTF-16BE").send(@method).should_not.end_with?(
+        "b".dup.force_encoding("UTF-16BE"))
   end
 end

--- a/shared/string/times.rb
+++ b/shared/string/times.rb
@@ -39,7 +39,7 @@ describe :string_times, shared: true do
   end
 
   it "returns a String in the same encoding as self" do
-    str = "\xE3\x81\x82".force_encoding Encoding::UTF_8
+    str = "\xE3\x81\x82".dup.force_encoding Encoding::UTF_8
     result = @object.call(str, 2)
     result.encoding.should equal(Encoding::UTF_8)
   end


### PR DESCRIPTION
Extracted from: https://github.com/ruby/ruby/pull/10235

Ref: https://bugs.ruby-lang.org/issues/20205

Ruby will gradually move towards enabling frozen string literals by default. Making the ruby spec suite compatible is a good first step.