### PR TITLE
Additionally polish specs to run with `--enable-frozen-string-literal`

### DIFF
--- a/core/hash/compare_by_identity_spec.rb
+++ b/core/hash/compare_by_identity_spec.rb
@@ -110,6 +110,10 @@ describe "Hash#compare_by_identity" do
     @idh.keys.first.should equal foo
   end
 
+  # Check `#[]=` call with a String literal.
+  # Don't use `#+` because with `#+` it's no longer a String literal.
+  #
+  # See https://bugs.ruby-lang.org/issues/12855
   it "gives different identity for string literals" do
     eval <<~RUBY
     # frozen_string_literal: false

--- a/core/marshal/shared/load.rb
+++ b/core/marshal/shared/load.rb
@@ -647,7 +647,7 @@ describe :marshal_load, shared: true do
     end
 
     it "sets binmode if it is loading through StringIO stream" do
-      io = StringIO.new(+"\004\b:\vsymbol")
+      io = StringIO.new("\004\b:\vsymbol")
       def io.binmode; raise "binmode"; end
       -> { Marshal.load(io) }.should raise_error(RuntimeError, "binmode")
     end

--- a/language/string_spec.rb
+++ b/language/string_spec.rb
@@ -231,9 +231,18 @@ describe "Ruby String literals" do
       ruby_exe(fixture(__FILE__, "freeze_magic_comment_across_files.rb")).chomp.should == "true"
     end
 
-    it "produce different objects for literals with the same content in different files if the other file doesn't have the comment" do
-      frozen_literals_by_default = eval("'test'").frozen?
-      ruby_exe(fixture(__FILE__, "freeze_magic_comment_across_files_no_comment.rb")).chomp.should == (!frozen_literals_by_default).to_s
+    guard -> { !eval("'test'").frozen? } do
+      it "produces different objects for literals with the same content in different files if the other file doesn't have the comment and String literals aren't frozen by default" do
+        frozen_literals_by_default = eval("'test'").frozen?
+        ruby_exe(fixture(__FILE__, "freeze_magic_comment_across_files_no_comment.rb")).chomp.should == "true"
+      end
+    end
+
+    guard -> { eval("'test'").frozen? } do
+      it "produces the same objects for literals with the same content in different files if the other file doesn't have the comment and String literals are frozen by default" do
+        frozen_literals_by_default = eval("'test'").frozen?
+        ruby_exe(fixture(__FILE__, "freeze_magic_comment_across_files_no_comment.rb")).chomp.should == "false"
+      end
     end
 
     it "produce different objects for literals with the same content in different files if they have different encodings" do

--- a/library/net-http/httpresponse/inspect_spec.rb
+++ b/library/net-http/httpresponse/inspect_spec.rb
@@ -8,7 +8,7 @@ describe "Net::HTTPResponse#inspect" do
     res.inspect.should == "#<Net::HTTPUnknownResponse ??? test response readbody=false>"
 
     res = Net::HTTPUnknownResponse.new("1.0", "???", "test response")
-    socket = Net::BufferedIO.new(StringIO.new(+"test body"))
+    socket = Net::BufferedIO.new(StringIO.new("test body"))
     res.reading_body(socket, true) {}
     res.inspect.should == "#<Net::HTTPUnknownResponse ??? test response readbody=true>"
   end

--- a/library/net-http/httpresponse/read_body_spec.rb
+++ b/library/net-http/httpresponse/read_body_spec.rb
@@ -5,7 +5,7 @@ require 'stringio'
 describe "Net::HTTPResponse#read_body" do
   before :each do
     @res = Net::HTTPUnknownResponse.new("1.0", "???", "test response")
-    @socket = Net::BufferedIO.new(StringIO.new(+"test body"))
+    @socket = Net::BufferedIO.new(StringIO.new("test body"))
   end
 
   describe "when passed no arguments" do

--- a/library/net-http/httpresponse/reading_body_spec.rb
+++ b/library/net-http/httpresponse/reading_body_spec.rb
@@ -5,7 +5,7 @@ require "stringio"
 describe "Net::HTTPResponse#reading_body" do
   before :each do
     @res = Net::HTTPUnknownResponse.new("1.0", "???", "test response")
-    @socket = Net::BufferedIO.new(StringIO.new(+"test body"))
+    @socket = Net::BufferedIO.new(StringIO.new("test body"))
   end
 
   describe "when body_allowed is true" do

--- a/library/net-http/httpresponse/shared/body.rb
+++ b/library/net-http/httpresponse/shared/body.rb
@@ -3,7 +3,7 @@ require 'stringio'
 describe :net_httpresponse_body, shared: true do
   before :each do
     @res = Net::HTTPUnknownResponse.new("1.0", "???", "test response")
-    @socket = Net::BufferedIO.new(StringIO.new(+"test body"))
+    @socket = Net::BufferedIO.new(StringIO.new("test body"))
   end
 
   it "returns the read body" do

--- a/library/stringio/fcntl_spec.rb
+++ b/library/stringio/fcntl_spec.rb
@@ -3,6 +3,6 @@ require_relative 'fixtures/classes'
 
 describe "StringIO#fcntl" do
   it "raises a NotImplementedError" do
-    -> { StringIO.new(+"boom").fcntl }.should raise_error(NotImplementedError)
+    -> { StringIO.new("boom").fcntl }.should raise_error(NotImplementedError)
   end
 end

--- a/library/stringio/initialize_spec.rb
+++ b/library/stringio/initialize_spec.rb
@@ -172,7 +172,7 @@ end
 # NOTE: Synchronise with core/io/new_spec.rb (core/io/shared/new.rb)
 describe "StringIO#initialize when passed keyword arguments" do
   it "sets the mode based on the passed :mode option" do
-    io = StringIO.new(+"example", "r")
+    io = StringIO.new("example", "r")
     io.closed_read?.should be_false
     io.closed_write?.should be_true
   end

--- a/library/stringio/read_nonblock_spec.rb
+++ b/library/stringio/read_nonblock_spec.rb
@@ -33,7 +33,7 @@ end
 describe "StringIO#read_nonblock" do
 
   it "accepts an exception option" do
-    stringio = StringIO.new(+'foo')
+    stringio = StringIO.new('foo')
     stringio.read_nonblock(3, exception: false).should == 'foo'
   end
 

--- a/library/stringio/reopen_spec.rb
+++ b/library/stringio/reopen_spec.rb
@@ -3,11 +3,11 @@ require_relative 'fixtures/classes'
 
 describe "StringIO#reopen when passed [Object, Integer]" do
   before :each do
-    @io = StringIO.new(+"example")
+    @io = StringIO.new("example")
   end
 
   it "reopens self with the passed Object in the passed mode" do
-    @io.reopen(+"reopened", IO::RDONLY)
+    @io.reopen("reopened", IO::RDONLY)
     @io.closed_read?.should be_false
     @io.closed_write?.should be_true
     @io.string.should == "reopened"
@@ -51,11 +51,11 @@ end
 
 describe "StringIO#reopen when passed [Object, Object]" do
   before :each do
-    @io = StringIO.new(+"example")
+    @io = StringIO.new("example")
   end
 
   it "reopens self with the passed Object in the passed mode" do
-    @io.reopen(+"reopened", "r")
+    @io.reopen("reopened", "r")
     @io.closed_read?.should be_false
     @io.closed_write?.should be_true
     @io.string.should == "reopened"
@@ -83,7 +83,7 @@ describe "StringIO#reopen when passed [Object, Object]" do
 
   it "tries to convert the passed Object to a String using #to_str" do
     obj = mock("to_str")
-    obj.should_receive(:to_str).and_return(+"to_str")
+    obj.should_receive(:to_str).and_return("to_str")
     @io.reopen(obj, "r")
     @io.string.should == "to_str"
   end
@@ -107,7 +107,7 @@ describe "StringIO#reopen when passed [Object, Object]" do
   it "tries to convert the passed mode Object to an Integer using #to_str" do
     obj = mock("to_str")
     obj.should_receive(:to_str).and_return("r")
-    @io.reopen(+"reopened", obj)
+    @io.reopen("reopened", obj)
     @io.closed_read?.should be_false
     @io.closed_write?.should be_true
     @io.string.should == "reopened"
@@ -128,7 +128,7 @@ end
 
 describe "StringIO#reopen when passed [String]" do
   before :each do
-    @io = StringIO.new(+"example")
+    @io = StringIO.new("example")
   end
 
   it "reopens self with the passed String in read-write mode" do
@@ -157,7 +157,7 @@ end
 
 describe "StringIO#reopen when passed [Object]" do
   before :each do
-    @io = StringIO.new(+"example")
+    @io = StringIO.new("example")
   end
 
   it "raises a TypeError when passed an Object that can't be converted to a StringIO" do
@@ -180,7 +180,7 @@ end
 
 describe "StringIO#reopen when passed no arguments" do
   before :each do
-    @io = StringIO.new(+"example\nsecond line")
+    @io = StringIO.new("example\nsecond line")
   end
 
   it "resets self's mode to read-write" do
@@ -208,7 +208,7 @@ end
 # for details.
 describe "StringIO#reopen" do
   before :each do
-    @io = StringIO.new(+'hello','a')
+    @io = StringIO.new(+'hello', 'a')
   end
 
   # TODO: find out if this is really a bug


### PR DESCRIPTION
Follow-up for #1142 and #1143 (some changes are already made in https://github.com/ruby/ruby/pull/10262).