### PR TITLE
Move the extensions for `Time` to the corresponding locations

### DIFF
--- a/library/date/time/to_date_spec.rb
+++ b/library/date/time/to_date_spec.rb
@@ -1,5 +1,5 @@
 
-require_relative '../../spec_helper'
+require_relative '../../../spec_helper'
 require 'time'
 
 describe "Time#to_date" do

--- a/library/datetime/time/to_datetime_spec.rb
+++ b/library/datetime/time/to_datetime_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../spec_helper'
+require_relative '../../../spec_helper'
 require 'time'
 require 'date'
 date_version = defined?(Date::VERSION) ? Date::VERSION : '3.1.0'


### PR DESCRIPTION
Although `Time#to_date` and `Time#to_datetime` are defined in `Time`, they belong to the "date" library and should be placed in the corresponding locations for each class.

Fix #1146.