### PR TITLE
Add specs for hash key ends with `!` or `?`

### DIFF
--- a/language/hash_spec.rb
+++ b/language/hash_spec.rb
@@ -86,6 +86,30 @@ describe "Hash literal" do
     -> { eval("{:a ==> 1}") }.should raise_error(SyntaxError)
   end
 
+  it "recognizes '!' at the end of the key" do
+    eval("{:a! =>1}").should == {:"a!" => 1}
+    eval("{:a! => 1}").should == {:"a!" => 1}
+
+    eval("{a!:1}").should == {:"a!" => 1}
+    eval("{a!: 1}").should == {:"a!" => 1}
+  end
+
+  it "raises a SyntaxError if there is no space between `!` and `=>`" do
+    -> { eval("{:a!=> 1}") }.should raise_error(SyntaxError)
+  end
+
+  it "recognizes '?' at the end of the key" do
+    eval("{:a? =>1}").should == {:"a?" => 1}
+    eval("{:a? => 1}").should == {:"a?" => 1}
+
+    eval("{a?:1}").should == {:"a?" => 1}
+    eval("{a?: 1}").should == {:"a?" => 1}
+  end
+
+  it "raises a SyntaxError if there is no space between `?` and `=>`" do
+    -> { eval("{:a?=> 1}") }.should raise_error(SyntaxError)
+  end
+
   it "constructs a new hash with the given elements" do
     {foo: 123}.should == {foo: 123}
     h = {rbx: :cool, specs: 'fail_sometimes'}
@@ -270,6 +294,14 @@ describe "The ** operator" do
         RUBY
 
         a.new.foo(1).should == {bar: "baz", val: 1}
+      end
+
+      it "raises a SyntaxError when the hash key ends with `!`" do
+        -> { eval("{a!:}") }.should raise_error(SyntaxError, /identifier a! is not valid to get/)
+      end
+
+      it "raises a SyntaxError when the hash key ends with `?`" do
+        -> { eval("{a?:}") }.should raise_error(SyntaxError, /identifier a\? is not valid to get/)
       end
     end
   end


### PR DESCRIPTION
This PR adds several spec for the following syntax errors:

```console
$ ruby -cve '{a!:}'
ruby 3.4.0dev (2024-04-18T03:46:51Z master b3c59370ca) [x86_64-darwin23]
-e:1: identifier a! is not valid to get
ruby: compile error (SyntaxError)

$ ruby -cve '{a?:}'
ruby 3.4.0dev (2024-04-18T03:46:51Z master b3c59370ca) [x86_64-darwin23]
-e:1: identifier a? is not valid to get
ruby: compile error (SyntaxError)
```

This addition supplements some specs for the non-omitting value hash notation.