### PR TITLE
Add spec for failed Hash pattern match

### DIFF
--- a/language/pattern_matching_spec.rb
+++ b/language/pattern_matching_spec.rb
@@ -214,6 +214,12 @@ describe "Pattern matching" do
       in [0]
       end
     }.should raise_error(NoMatchingPatternError, /\[0, 1\]/)
+
+    -> {
+      case {a: 0, b: 1}
+      in a: 1, b: 1
+      end
+    }.should raise_error(NoMatchingPatternError, /\{:a=>0, :b=>1\}/)
   end
 
   it "raises NoMatchingPatternError if no pattern matches and evaluates the expression only once" do


### PR DESCRIPTION
This is the case reported in jruby/jruby#8283 and is not tested elsewhere in the file. The bug in JRuby was specific to a failed Hash pattern.

Note this depends on #1153 because without that it will never be exercised by JRuby's JIT.