### PR TITLE
Add test for rescue with safe navigator setter on nil

### DIFF
--- a/language/rescue_spec.rb
+++ b/language/rescue_spec.rb
@@ -52,6 +52,16 @@ describe "The rescue keyword" do
       RescueSpecs::SafeNavigationSetterCaptor.should_capture_exception
     end
 
+    it 'using a safely navigated setter method on a nil target' do
+      target = nil
+      begin
+        raise SpecificExampleException, "Raising this to be handled below"
+      rescue SpecificExampleException => target&.captured_error
+        :caught
+      end.should == :caught
+      target.should be_nil
+    end
+
     it 'using a setter method' do
       RescueSpecs::SetterCaptor.should_capture_exception
     end


### PR DESCRIPTION
There was a test with the safe navigator setter, but only in the case where the target is not nil.

I tested this with the latest version of JRuby and TruffleRuby as well, and both look to be working fine.