### PR TITLE
Add specs for IO#autoclose? and IO#autoclose= (take 2)

### DIFF
--- a/core/io/autoclose_spec.rb
+++ b/core/io/autoclose_spec.rb
@@ -11,19 +11,36 @@ describe "IO#autoclose" do
     @io.close unless @io.closed?
   end
 
+  it "is set to true by default" do
+    @io.should.autoclose?
+  end
+
   it "can be set to true" do
+    @io.autoclose = false
     @io.autoclose = true
     @io.should.autoclose?
   end
 
   it "can be set to false" do
+    @io.autoclose = true
     @io.autoclose = false
     @io.should_not.autoclose?
   end
 
   it "can be set to any truthy value" do
+    @io.autoclose = false
     @io.autoclose = 42
     @io.should.autoclose?
+
+    @io.autoclose = false
+    @io.autoclose = Object.new
+    @io.should.autoclose?
+  end
+
+  it "can be set to any falsy value" do
+    @io.autoclose = true
+    @io.autoclose = nil
+    @io.should_not.autoclose?
   end
 
   it "can be set multple times" do

--- a/core/io/autoclose_spec.rb
+++ b/core/io/autoclose_spec.rb
@@ -1,0 +1,49 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "IO#autoclose" do
+  before :each do
+    @io = IOSpecs.io_fixture "lines.txt"
+  end
+
+  after :each do
+    @io.autoclose = true unless @io.closed?
+    @io.close unless @io.closed?
+  end
+
+  it "can be set to true" do
+    @io.autoclose = true
+    @io.should.autoclose?
+  end
+
+  it "can be set to false" do
+    @io.autoclose = false
+    @io.should_not.autoclose?
+  end
+
+  it "can be set to any truthy value" do
+    @io.autoclose = 42
+    @io.should.autoclose?
+  end
+
+  it "can be set multple times" do
+    @io.autoclose = true
+    @io.should.autoclose?
+
+    @io.autoclose = false
+    @io.should_not.autoclose?
+
+    @io.autoclose = true
+    @io.should.autoclose?
+  end
+
+  it "cannot be queried on a closed IO object" do
+    @io.close
+    -> { @io.autoclose? }.should raise_error(IOError, /closed stream/)
+  end
+
+  it "cannot be set on a closed IO object" do
+    @io.close
+    -> { @io.autoclose = false }.should raise_error(IOError, /closed stream/)
+  end
+end

--- a/core/io/autoclose_spec.rb
+++ b/core/io/autoclose_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-describe "IO#autoclose" do
+describe "IO#autoclose?" do
   before :each do
     @io = IOSpecs.io_fixture "lines.txt"
   end
@@ -13,6 +13,22 @@ describe "IO#autoclose" do
 
   it "is set to true by default" do
     @io.should.autoclose?
+  end
+
+  it "cannot be queried on a closed IO object" do
+    @io.close
+    -> { @io.autoclose? }.should raise_error(IOError, /closed stream/)
+  end
+end
+
+describe "IO#autoclose=" do
+  before :each do
+    @io = IOSpecs.io_fixture "lines.txt"
+  end
+
+  after :each do
+    @io.autoclose = true unless @io.closed?
+    @io.close unless @io.closed?
   end
 
   it "can be set to true" do
@@ -52,11 +68,6 @@ describe "IO#autoclose" do
 
     @io.autoclose = true
     @io.should.autoclose?
-  end
-
-  it "cannot be queried on a closed IO object" do
-    @io.close
-    -> { @io.autoclose? }.should raise_error(IOError, /closed stream/)
   end
 
   it "cannot be set on a closed IO object" do


### PR DESCRIPTION
I took a stab at separating the specs given the feedback in #1077. This PR would supersede that one, given it is accepted.

/cc @andrykonchin Let me know if this isn't what you meant exactly or you have another preferred way to group them. Thanks!