### PR TITLE
Add specs for `for` loop with attribute target

### DIFF
--- a/language/for_spec.rb
+++ b/language/for_spec.rb
@@ -162,6 +162,28 @@ describe "The for expression" do
     end
   end
 
+  it "allows an array index writer as an iterator name" do
+    arr = [:a, :b, :c]
+    m = [1,2,3]
+    n = 0
+    for arr[1] in m
+      n += 1
+    end
+    arr.should == [:a, 3, :c]
+    n.should == 3
+  end
+
+  it "allows a hash index writer as an iterator name" do
+    hash = { a: 10, b: 20, c: 30 }
+    m = [1,2,3]
+    n = 0
+    for hash[:b] in m
+      n += 1
+    end
+    hash.should == { a: 10, b: 3, c: 30 }
+    n.should == 3
+  end
+
   # 1.9 behaviour verified by nobu in
   # http://redmine.ruby-lang.org/issues/show/2053
   it "yields only as many values as there are arguments" do

--- a/language/for_spec.rb
+++ b/language/for_spec.rb
@@ -129,6 +129,7 @@ describe "The for expression" do
     n.should == 3
   end
 
+  # Segfault in MRI 3.3 and lower: https://bugs.ruby-lang.org/issues/20468
   ruby_version_is "3.4" do
     it "allows an attribute with safe navigation as an iterator name" do
       class OFor

--- a/language/for_spec.rb
+++ b/language/for_spec.rb
@@ -114,6 +114,53 @@ describe "The for expression" do
     $var = old_global_var
   end
 
+  it "allows an attribute as an iterator name" do
+    class OFor
+      attr_accessor :target
+    end
+
+    ofor = OFor.new
+    m = [1,2,3]
+    n = 0
+    for ofor.target in m
+      n += 1
+    end
+    ofor.target.should == 3
+    n.should == 3
+  end
+
+  ruby_version_is "3.4" do
+    it "allows an attribute with safe navigation as an iterator name" do
+      class OFor
+        attr_accessor :target
+      end
+
+      ofor = OFor.new
+      m = [1,2,3]
+      n = 0
+      eval <<~RUBY
+        for ofor&.target in m
+          n += 1
+        end
+      RUBY
+      ofor.target.should == 3
+      n.should == 3
+    end
+
+    it "allows an attribute with safe navigation on a nil base as an iterator name" do
+      ofor = nil
+      m = [1,2,3]
+      n = 0
+      eval <<~RUBY
+        for ofor&.target in m
+          n += 1
+        end
+      RUBY
+      ofor.should be_nil
+      n.should == 3
+    end
+  end
+
   # 1.9 behaviour verified by nobu in
   # http://redmine.ruby-lang.org/issues/show/2053
   it "yields only as many values as there are arguments" do


### PR DESCRIPTION
The specs with safe navigation require a segfault with MRI until very recent versions (https://bugs.ruby-lang.org/issues/20468), so these had to be wrapped in eval blocks.