### PR TITLE
Add specs for Date#yday and DateTime#yday

### DIFF
--- a/core/time/yday_spec.rb
+++ b/core/time/yday_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../spec_helper'
+require_relative '../../shared/time/yday'
 
 describe "Time#yday" do
   it "returns an integer representing the day of the year, 1..366" do
@@ -7,15 +8,5 @@ describe "Time#yday" do
     end
   end
 
-  it 'returns the correct value for each day of each month' do
-    mdays = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-
-    yday = 1
-    mdays.each_with_index do |days, month|
-      days.times do |day|
-        Time.new(2014, month+1, day+1).yday.should == yday
-        yday += 1
-      end
-    end
-  end
+  it_behaves_like :time_yday, -> year, month, day { Time.new(year, month, day).yday }
 end

--- a/library/date/yday_spec.rb
+++ b/library/date/yday_spec.rb
@@ -1,6 +1,7 @@
 require_relative '../../spec_helper'
+require_relative '../../shared/time/yday'
 require 'date'
 
 describe "Date#yday" do
-  it "needs to be reviewed for spec completeness"
+  it_behaves_like :time_yday, -> year, month, day { Date.new(year, month, day).yday }
 end

--- a/library/datetime/yday_spec.rb
+++ b/library/datetime/yday_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../spec_helper'
+require_relative '../../shared/time/yday'
+require 'date'
+
+describe "DateTime#yday" do
+  it_behaves_like :time_yday, -> year, month, day { DateTime.new(year, month, day).yday }
+end

--- a/shared/time/yday.rb
+++ b/shared/time/yday.rb
@@ -1,0 +1,13 @@
+describe :time_yday, shared: true do
+  it 'returns the correct value for each day of each month' do
+    mdays = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+    yday = 1
+    mdays.each_with_index do |days, month|
+      days.times do |day|
+        @method.call(2014, month+1, day+1).should == yday
+        yday += 1
+      end
+    end
+  end
+end

--- a/shared/time/yday.rb
+++ b/shared/time/yday.rb
@@ -10,4 +10,9 @@ describe :time_yday, shared: true do
       end
     end
   end
+
+  it 'supports leap years' do
+    @method.call(2016, 2, 29).should == 31 + 29
+    @method.call(2016, 3, 1).should == 31 + 29 + 1
+  end
 end


### PR DESCRIPTION
This is done by converting the existing specs for `Time#yday` into a shared spec that can be used by the other two classes. An additional spec to cover leap years has been added.