### PR TITLE
Update examples for it_behave_like with lambda and arguments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -277,13 +277,13 @@ describe :kernel_sprintf, shared: true do
 end
 
 describe "Kernel#sprintf" do
-  it_behaves_like :kernel_sprintf, -> (format, *args) {
+  it_behaves_like :kernel_sprintf, -> format, *args {
     sprintf(format, *args)
   }
 end
 
 describe "Kernel.sprintf" do
-  it_behaves_like :kernel_sprintf, -> (format, *args) {
+  it_behaves_like :kernel_sprintf, -> format, *args {
     Kernel.sprintf(format, *args)
   }
 end


### PR DESCRIPTION
The setting for `Style/StabbyLambdaParentheses` requires us to omit the parentheses, so remove them from the example as well.