### PR TITLE
Fix curry_spec

### DIFF
--- a/core/proc/curry_spec.rb
+++ b/core/proc/curry_spec.rb
@@ -159,15 +159,14 @@ describe "Proc#curry with arity argument" do
   end
 
   it "can be passed more than _arity_ arguments if created from a proc" do
-    -> { @proc_add.curry(3)[1,2,3,4].should == 6 }.should_not
-      raise_error(ArgumentError)
-    -> { @proc_add.curry(1)[1,2].curry(3)[3,4,5,6].should == 6 }.should_not
-      raise_error(ArgumentError)
+    @proc_add.curry(3)[1,2,3,4].should == 6
+
+    @proc_add.curry(3)[1,2].curry(3)[3,4,5,6].should == 6
   end
 
   it "raises an ArgumentError if passed more than _arity_ arguments when created from a lambda" do
     -> { @lambda_add.curry(3)[1,2,3,4] }.should raise_error(ArgumentError)
-    -> { @lambda_add.curry(1)[1,2].curry(3)[3,4,5,6] }.should raise_error(ArgumentError)
+    -> { @lambda_add.curry(3)[1,2].curry(3)[3,4,5,6] }.should raise_error(ArgumentError)
   end
 
   it "returns Procs with arities of -1 regardless of the value of _arity_" do


### PR DESCRIPTION
This effectively ran the following code:

```ruby
    @proc_add = Proc.new {|x,y,z| (x||0) + (y||0) + (z||0) }
    tmp = @proc_add.curry(1)[1,2]
    tmp.curry(3)[3,4,5,6].should == 6
```

The optional argument to `Proc#curry` is the arity of the curried proc. In other words: if the curried proc gets called with at least 1 argument, which means the value of `tmp` in this example will be equal to `@proc_add[1,2]`, the result is an Integer and not a new proc object.

The example with a lambda would raise the error in the `curry(1)[1,2]` part, so the second test was pretty much the same as the first test.

The old code did pass, because the failing spec was wrapped in a block that should not raise an error. This was indented with a new line after the `should_not`, which is then seen by Ruby as two separate statements. The block with the failing spec then never gets executed. This looks like the only location in the specs where `should` or `should_not` is the last code on a line.