### PR TITLE
Fix specs for Kernel.select

### DIFF
--- a/core/kernel/select_spec.rb
+++ b/core/kernel/select_spec.rb
@@ -10,9 +10,9 @@ end
 describe "Kernel.select" do
   it 'does not block when timeout is 0' do
     IO.pipe do |read, write|
-      IO.select([read], [], [], 0).should == nil
+      select([read], [], [], 0).should == nil
       write.write 'data'
-      IO.select([read], [], [], 0).should == [[read], [], []]
+      select([read], [], [], 0).should == [[read], [], []]
     end
   end
 end


### PR DESCRIPTION
This one should not test IO.select.

It's a bit confusing, since even the [docs](https://ruby-doc.org/3.2.2/Kernel.html#method-i-select) uses `IO.select` in the description and examples.