### PR TITLE
Add shared specs when precision is passed in for Integer#floor, Float#floor and Integer#ceil, Float#ceil

### DIFF
--- a/core/float/ceil_spec.rb
+++ b/core/float/ceil_spec.rb
@@ -1,6 +1,11 @@
 require_relative '../../spec_helper'
+require_relative '../integer/shared/integer_ceil_precision'
 
 describe "Float#ceil" do
+  context "with precision" do
+    it_behaves_like :integer_ceil_precision, :Float
+  end
+
   it "returns the smallest Integer greater than or equal to self" do
     -1.2.ceil.should eql( -1)
     -1.0.ceil.should eql( -1)

--- a/core/float/floor_spec.rb
+++ b/core/float/floor_spec.rb
@@ -1,6 +1,11 @@
 require_relative '../../spec_helper'
+require_relative '../integer/shared/integer_floor_precision'
 
 describe "Float#floor" do
+  context "with precision" do
+    it_behaves_like :integer_floor_precision, :Float
+  end
+
   it "returns the largest Integer less than or equal to self" do
     -1.2.floor.should eql( -2)
     -1.0.floor.should eql( -1)

--- a/core/integer/ceil_spec.rb
+++ b/core/integer/ceil_spec.rb
@@ -1,10 +1,15 @@
 require_relative '../../spec_helper'
 require_relative 'shared/to_i'
 require_relative 'shared/integer_rounding'
+require_relative 'shared/integer_ceil_precision'
 
 describe "Integer#ceil" do
   it_behaves_like :integer_to_i, :ceil
   it_behaves_like :integer_rounding_positive_precision, :ceil
+
+  context "with precision" do
+    it_behaves_like :integer_ceil_precision, :Integer
+  end
 
   context "precision argument specified as part of the ceil method is negative" do
     it "returns the smallest integer greater than self with at least precision.abs trailing zeros" do

--- a/core/integer/floor_spec.rb
+++ b/core/integer/floor_spec.rb
@@ -1,19 +1,13 @@
 require_relative '../../spec_helper'
 require_relative 'shared/to_i'
 require_relative 'shared/integer_rounding'
+require_relative 'shared/integer_floor_precision'
 
 describe "Integer#floor" do
   it_behaves_like :integer_to_i, :floor
   it_behaves_like :integer_rounding_positive_precision, :floor
 
-  context "precision argument specified as part of the floor method is negative" do
-    it "returns the largest integer less than self with at least precision.abs trailing zeros" do
-      1832.floor(-1).should eql(1830)
-      1832.floor(-2).should eql(1800)
-      1832.floor(-3).should eql(1000)
-      -1832.floor(-1).should eql(-1840)
-      -1832.floor(-2).should eql(-1900)
-      -1832.floor(-3).should eql(-2000)
-    end
+  context "with precision" do
+    it_behaves_like :integer_floor_precision, :Integer
   end
 end

--- a/core/integer/shared/integer_ceil_precision.rb
+++ b/core/integer/shared/integer_ceil_precision.rb
@@ -32,5 +32,12 @@ describe :integer_ceil_precision, shared: true do
       send(@method, -123).ceil(-2).should.eql?(-100)
       send(@method, -123).ceil(-3).should.eql?(0)
     end
+
+    ruby_bug "#20654", ""..."3.4" do
+      it "returns 10**precision.abs when precision.abs is larger than the number digits of self" do
+        send(@method, 123).ceil(-20).should.eql?(100000000000000000000)
+        send(@method, 123).ceil(-50).should.eql?(100000000000000000000000000000000000000000000000000)
+      end
+    end
   end
 end

--- a/core/integer/shared/integer_ceil_precision.rb
+++ b/core/integer/shared/integer_ceil_precision.rb
@@ -1,0 +1,36 @@
+describe :integer_ceil_precision, shared: true do
+  context "precision is zero" do
+    it "returns integer self" do
+      send(@method, 0).ceil(0).should.eql?(0)
+      send(@method, 123).ceil(0).should.eql?(123)
+      send(@method, -123).ceil(0).should.eql?(-123)
+    end
+  end
+
+  context "precision is positive" do
+    it "returns self" do
+      send(@method, 0).ceil(1).should.eql?(send(@method, 0))
+      send(@method, 0).ceil(10).should.eql?(send(@method, 0))
+
+      send(@method, 123).ceil(10).should.eql?(send(@method, 123))
+      send(@method, -123).ceil(10).should.eql?(send(@method, -123))
+    end
+  end
+
+  context "precision is negative" do
+    it "always returns 0 when self is 0" do
+      send(@method, 0).ceil(-1).should.eql?(0)
+      send(@method, 0).ceil(-10).should.eql?(0)
+    end
+
+    it "returns largest integer less than self with at least precision.abs trailing zeros" do
+      send(@method, 123).ceil(-1).should.eql?(130)
+      send(@method, 123).ceil(-2).should.eql?(200)
+      send(@method, 123).ceil(-3).should.eql?(1000)
+
+      send(@method, -123).ceil(-1).should.eql?(-120)
+      send(@method, -123).ceil(-2).should.eql?(-100)
+      send(@method, -123).ceil(-3).should.eql?(0)
+    end
+  end
+end

--- a/core/integer/shared/integer_floor_precision.rb
+++ b/core/integer/shared/integer_floor_precision.rb
@@ -32,5 +32,12 @@ describe :integer_floor_precision, shared: true do
       send(@method, -123).floor(-2).should.eql?(-200)
       send(@method, -123).floor(-3).should.eql?(-1000)
     end
+
+    ruby_bug "#20654", ""..."3.4" do
+      it "returns -(10**precision.abs) when self is negative and precision.abs is larger than the number digits of self" do
+        send(@method, -123).floor(-20).should.eql?(-100000000000000000000)
+        send(@method, -123).floor(-50).should.eql?(-100000000000000000000000000000000000000000000000000)
+      end
+    end
   end
 end

--- a/core/integer/shared/integer_floor_precision.rb
+++ b/core/integer/shared/integer_floor_precision.rb
@@ -1,0 +1,36 @@
+describe :integer_floor_precision, shared: true do
+  context "precision is zero" do
+    it "returns integer self" do
+      send(@method, 0).floor(0).should.eql?(0)
+      send(@method, 123).floor(0).should.eql?(123)
+      send(@method, -123).floor(0).should.eql?(-123)
+    end
+  end
+
+  context "precision is positive" do
+    it "returns self" do
+      send(@method, 0).floor(1).should.eql?(send(@method, 0))
+      send(@method, 0).floor(10).should.eql?(send(@method, 0))
+
+      send(@method, 123).floor(10).should.eql?(send(@method, 123))
+      send(@method, -123).floor(10).should.eql?(send(@method, -123))
+    end
+  end
+
+  context "precision is negative" do
+    it "always returns 0 when self is 0" do
+      send(@method, 0).floor(-1).should.eql?(0)
+      send(@method, 0).floor(-10).should.eql?(0)
+    end
+
+    it "returns largest integer less than self with at least precision.abs trailing zeros" do
+      send(@method, 123).floor(-1).should.eql?(120)
+      send(@method, 123).floor(-2).should.eql?(100)
+      send(@method, 123).floor(-3).should.eql?(0)
+
+      send(@method, -123).floor(-1).should.eql?(-130)
+      send(@method, -123).floor(-2).should.eql?(-200)
+      send(@method, -123).floor(-3).should.eql?(-1000)
+    end
+  end
+end


### PR DESCRIPTION
There is poor spec coverage of when precision is passed into Integer#floor, Float#floor, Integer#ceil, Float#ceil. This PR adds some specs for when precision is passed in.