### PR TITLE
Add `expect_syntax_error` spec helper

### DIFF
--- a/language/BEGIN_spec.rb
+++ b/language/BEGIN_spec.rb
@@ -15,7 +15,7 @@ describe "The BEGIN keyword" do
   end
 
   it "must appear in a top-level context" do
-    -> { eval "1.times { BEGIN { 1 } }" }.should raise_error(SyntaxError)
+    expect_syntax_error("1.times { BEGIN { 1 } }")
   end
 
   it "uses top-level for self" do

--- a/language/block_spec.rb
+++ b/language/block_spec.rb
@@ -731,9 +731,9 @@ describe "A block" do
 
   describe "taking identically-named arguments" do
     it "raises a SyntaxError for standard arguments" do
-      -> { eval "lambda { |x,x| }" }.should raise_error(SyntaxError)
-      -> { eval "->(x,x) {}" }.should raise_error(SyntaxError)
-      -> { eval "Proc.new { |x,x| }" }.should raise_error(SyntaxError)
+      expect_syntax_error("lambda { |x,x| }")
+      expect_syntax_error("->(x,x) {}")
+      expect_syntax_error("Proc.new { |x,x| }")
     end
 
     it "accepts unnamed arguments" do
@@ -790,29 +790,23 @@ describe "Block-local variables" do
   end
 
   it "can not have the same name as one of the standard parameters" do
-    -> { eval "[1].each {|foo; foo| }" }.should raise_error(SyntaxError)
-    -> { eval "[1].each {|foo, bar; glark, bar| }" }.should raise_error(SyntaxError)
+    expect_syntax_error("[1].each {|foo; foo| }")
+    expect_syntax_error("[1].each {|foo, bar; glark, bar| }")
   end
 
   it "can not be prefixed with an asterisk" do
-    -> { eval "[1].each {|foo; *bar| }" }.should raise_error(SyntaxError)
-    -> do
-      eval "[1].each {|foo, bar; glark, *fnord| }"
-    end.should raise_error(SyntaxError)
+    expect_syntax_error("[1].each {|foo; *bar| }")
+    expect_syntax_error("[1].each {|foo, bar; glark, *fnord| }")
   end
 
   it "can not be prefixed with an ampersand" do
-    -> { eval "[1].each {|foo; &bar| }" }.should raise_error(SyntaxError)
-    -> do
-      eval "[1].each {|foo, bar; glark, &fnord| }"
-    end.should raise_error(SyntaxError)
+    expect_syntax_error("[1].each {|foo; &bar| }")
+    expect_syntax_error("[1].each {|foo, bar; glark, &fnord| }")
   end
 
   it "can not be assigned default values" do
-    -> { eval "[1].each {|foo; bar=1| }" }.should raise_error(SyntaxError)
-    -> do
-      eval "[1].each {|foo, bar; glark, fnord=:fnord| }"
-    end.should raise_error(SyntaxError)
+    expect_syntax_error("[1].each {|foo; bar=1| }")
+    expect_syntax_error("[1].each {|foo, bar; glark, fnord=:fnord| }")
   end
 
   it "need not be preceded by standard parameters" do
@@ -821,8 +815,8 @@ describe "Block-local variables" do
   end
 
   it "only allow a single semi-colon in the parameter list" do
-    -> { eval "[1].each {|foo; bar; glark| }" }.should raise_error(SyntaxError)
-    -> { eval "[1].each {|; bar; glark| }" }.should raise_error(SyntaxError)
+    expect_syntax_error("[1].each {|foo; bar; glark| }")
+    expect_syntax_error("[1].each {|; bar; glark| }")
   end
 
   it "override shadowed variables from the outer scope" do
@@ -963,9 +957,7 @@ describe "Post-args" do
       ruby_version_is ""..."3.4" do
         it "raises a SyntaxError if using the argument in its default value" do
           a = 1
-          -> {
-            eval "proc { |a=a| a }"
-          }.should raise_error(SyntaxError)
+          expect_syntax_error "proc { |a=a| a }"
         end
       end
 
@@ -1011,7 +1003,7 @@ describe "Anonymous block forwarding" do
     end
 
     it "requires the anonymous block parameter to be declared if directly passing a block" do
-      -> { eval "def a; b(&); end; def b; end" }.should raise_error(SyntaxError)
+      expect_syntax_error("def a; b(&); end; def b; end")
     end
 
     it "works when it's the only declared parameter" do

--- a/language/break_spec.rb
+++ b/language/break_spec.rb
@@ -254,21 +254,17 @@ end
 
 describe "The break statement in a method" do
   it "is invalid and raises a SyntaxError" do
-    -> {
-      eval("def m; break; end")
-    }.should raise_error(SyntaxError)
+    expect_syntax_error("def m; break; end")
   end
 end
 
 describe "The break statement in a module literal" do
   it "is invalid and raises a SyntaxError" do
-    code = <<~RUBY
+    expect_syntax_error <<~RUBY
       module BreakSpecs:ModuleWithBreak
         break
       end
     RUBY
-
-    -> { eval(code) }.should raise_error(SyntaxError)
   end
 end
 

--- a/language/case_spec.rb
+++ b/language/case_spec.rb
@@ -261,26 +261,22 @@ describe "The 'case'-construct" do
   end
 
   it "raises a SyntaxError when 'else' is used when no 'when' is given" do
-    -> {
-      eval <<-CODE
+    expect_syntax_error <<-CODE
       case 4
       else
         true
       end
-      CODE
-    }.should raise_error(SyntaxError)
+    CODE
   end
 
   it "raises a SyntaxError when 'else' is used before a 'when' was given" do
-    -> {
-      eval <<-CODE
+    expect_syntax_error <<-CODE
       case 4
       else
         true
       when 4; false
       end
-      CODE
-    }.should raise_error(SyntaxError)
+    CODE
   end
 
   it "supports nested case statements" do

--- a/language/def_spec.rb
+++ b/language/def_spec.rb
@@ -133,7 +133,7 @@ describe "An instance method definition with a splat" do
   end
 
   it "allows only a single * argument" do
-    -> { eval 'def foo(a, *b, *c); end' }.should raise_error(SyntaxError)
+    expect_syntax_error('def foo(a, *b, *c); end')
   end
 
   it "requires the presence of any arguments that precede the *" do
@@ -199,11 +199,11 @@ describe "An instance method with a default argument" do
 
   ruby_version_is ""..."3.4" do
     it "raises a SyntaxError if using the argument in its default value" do
-      -> {
-        eval "def foo(bar = bar)
+      expect_syntax_error <<~RUBY
+        def foo(bar = bar)
           bar
-        end"
-      }.should raise_error(SyntaxError)
+        end
+      RUBY
     end
   end
 

--- a/language/encoding_spec.rb
+++ b/language/encoding_spec.rb
@@ -31,6 +31,6 @@ describe "The __ENCODING__ pseudo-variable" do
   end
 
   it "raises a SyntaxError if assigned to" do
-    -> { eval("__ENCODING__ = 1") }.should raise_error(SyntaxError)
+    expect_syntax_error("__ENCODING__ = 1")
   end
 end

--- a/language/ensure_spec.rb
+++ b/language/ensure_spec.rb
@@ -240,14 +240,12 @@ end
 
 describe "An ensure block inside {} block" do
   it "is not allowed" do
-    -> {
-      eval <<-ruby
-        lambda {
-          raise
-        ensure
-        }
-      ruby
-    }.should raise_error(SyntaxError)
+    expect_syntax_error <<-ruby
+      lambda {
+        raise
+      ensure
+      }
+    ruby
   end
 end
 

--- a/language/file_spec.rb
+++ b/language/file_spec.rb
@@ -4,7 +4,7 @@ require_relative 'shared/__FILE__'
 
 describe "The __FILE__ pseudo-variable" do
   it "raises a SyntaxError if assigned to" do
-    -> { eval("__FILE__ = 1") }.should raise_error(SyntaxError)
+    expect_syntax_error("__FILE__ = 1")
   end
 
   ruby_version_is ""..."3.3" do

--- a/language/hash_spec.rb
+++ b/language/hash_spec.rb
@@ -83,7 +83,7 @@ describe "Hash literal" do
   end
 
   it "with '==>' in the middle raises SyntaxError" do
-    -> { eval("{:a ==> 1}") }.should raise_error(SyntaxError)
+    expect_syntax_error("{:a ==> 1}")
   end
 
   it "recognizes '!' at the end of the key" do
@@ -95,7 +95,7 @@ describe "Hash literal" do
   end
 
   it "raises a SyntaxError if there is no space between `!` and `=>`" do
-    -> { eval("{:a!=> 1}") }.should raise_error(SyntaxError)
+    expect_syntax_error("{:a!=> 1}")
   end
 
   it "recognizes '?' at the end of the key" do
@@ -107,7 +107,7 @@ describe "Hash literal" do
   end
 
   it "raises a SyntaxError if there is no space between `?` and `=>`" do
-    -> { eval("{:a?=> 1}") }.should raise_error(SyntaxError)
+    expect_syntax_error("{:a?=> 1}")
   end
 
   it "constructs a new hash with the given elements" do

--- a/language/heredoc_spec.rb
+++ b/language/heredoc_spec.rb
@@ -60,9 +60,7 @@ HERE
   end
 
   it 'raises SyntaxError if quoted HEREDOC identifier is ending not on same line' do
-    -> {
-      eval %{<<"HERE\n"\nraises syntax error\nHERE}
-    }.should raise_error(SyntaxError)
+    expect_syntax_error %{<<"HERE\n"\nraises syntax error\nHERE}
   end
 
   it "allows HEREDOC with <<~'identifier', allowing to indent identifier and content" do

--- a/language/lambda_spec.rb
+++ b/language/lambda_spec.rb
@@ -266,9 +266,7 @@ describe "A lambda literal -> () { }" do
       ruby_version_is ""..."3.4" do
         it "raises a SyntaxError if using the argument in its default value" do
           a = 1
-          -> {
-            eval "-> (a=a) { a }"
-          }.should raise_error(SyntaxError)
+          expect_syntax_error("-> (a=a) { a }")
         end
       end
 

--- a/language/line_spec.rb
+++ b/language/line_spec.rb
@@ -4,7 +4,7 @@ require_relative 'shared/__LINE__'
 
 describe "The __LINE__ pseudo-variable" do
   it "raises a SyntaxError if assigned to" do
-    -> { eval("__LINE__ = 1") }.should raise_error(SyntaxError)
+    expect_syntax_error("__LINE__ = 1")
   end
 
   before :each do

--- a/language/method_spec.rb
+++ b/language/method_spec.rb
@@ -1230,13 +1230,8 @@ describe "A method call with a space between method name and parentheses" do
 
   context "when the argument looks like an argument list" do
     it "raises a syntax error" do
-      -> {
-        eval("m (1, 2)")
-      }.should raise_error(SyntaxError)
-
-      -> {
-        eval("m (1, 2, 3)")
-      }.should raise_error(SyntaxError)
+      expect_syntax_error("m (1, 2)")
+      expect_syntax_error("m (1, 2, 3)")
     end
   end
 

--- a/language/next_spec.rb
+++ b/language/next_spec.rb
@@ -109,9 +109,7 @@ end
 describe "The next statement" do
   describe "in a method" do
     it "is invalid and raises a SyntaxError" do
-      -> {
-        eval("def m; next; end")
-      }.should raise_error(SyntaxError)
+      expect_syntax_error("def m; next; end")
     end
   end
 end

--- a/language/numbers_spec.rb
+++ b/language/numbers_spec.rb
@@ -20,8 +20,8 @@ describe "A number literal" do
 
   it "must have a digit before the decimal point" do
     0.75.should == 0.75
-    -> { eval(".75")  }.should raise_error(SyntaxError)
-    -> { eval("-.75") }.should raise_error(SyntaxError)
+    expect_syntax_error(".75")
+    expect_syntax_error("-.75")
   end
 
   it "can have an exponent" do

--- a/language/precedence_spec.rb
+++ b/language/precedence_spec.rb
@@ -251,12 +251,12 @@ describe "Operators" do
   end
 
   it "<=> == === != =~ !~ are non-associative" do
-    -> { eval("1 <=> 2 <=> 3")  }.should raise_error(SyntaxError)
-    -> { eval("1 == 2 == 3")  }.should raise_error(SyntaxError)
-    -> { eval("1 === 2 === 3")  }.should raise_error(SyntaxError)
-    -> { eval("1 != 2 != 3")  }.should raise_error(SyntaxError)
-    -> { eval("1 =~ 2 =~ 3")  }.should raise_error(SyntaxError)
-    -> { eval("1 !~ 2 !~ 3")  }.should raise_error(SyntaxError)
+    expect_syntax_error("1 <=> 2 <=> 3")
+    expect_syntax_error("1 == 2 == 3")
+    expect_syntax_error("1 === 2 === 3")
+    expect_syntax_error("1 != 2 != 3")
+    expect_syntax_error("1 =~ 2 =~ 3")
+    expect_syntax_error("1 !~ 2 !~ 3")
   end
 
   it "<=> == === != =~ !~ have higher precedence than &&" do
@@ -290,8 +290,8 @@ describe "Operators" do
   end
 
   it ".. ... are non-associative" do
-    -> { eval("1..2..3")  }.should raise_error(SyntaxError)
-    -> { eval("1...2...3")  }.should raise_error(SyntaxError)
+    expect_syntax_error("1..2..3")
+    expect_syntax_error("1...2...3")
   end
 
  it ".. ... have higher precedence than ? :" do

--- a/language/predefined_spec.rb
+++ b/language/predefined_spec.rb
@@ -1100,7 +1100,7 @@ describe "The predefined standard object nil" do
   end
 
   it "raises a SyntaxError if assigned to" do
-    -> { eval("nil = true") }.should raise_error(SyntaxError)
+    expect_syntax_error("nil = true")
   end
 end
 
@@ -1110,7 +1110,7 @@ describe "The predefined standard object true" do
   end
 
   it "raises a SyntaxError if assigned to" do
-    -> { eval("true = false") }.should raise_error(SyntaxError)
+    expect_syntax_error("true = false")
   end
 end
 
@@ -1120,13 +1120,13 @@ describe "The predefined standard object false" do
   end
 
   it "raises a SyntaxError if assigned to" do
-    -> { eval("false = nil") }.should raise_error(SyntaxError)
+    expect_syntax_error("false = nil")
   end
 end
 
 describe "The self pseudo-variable" do
   it "raises a SyntaxError if assigned to" do
-    -> { eval("self = 1") }.should raise_error(SyntaxError)
+    expect_syntax_error("self = 1")
   end
 end
 

--- a/language/redo_spec.rb
+++ b/language/redo_spec.rb
@@ -58,9 +58,7 @@ describe "The redo statement" do
 
   describe "in a method" do
     it "is invalid and raises a SyntaxError" do
-      -> {
-        eval("def m; redo; end")
-      }.should raise_error(SyntaxError)
+      expect_syntax_error("def m; redo; end")
     end
   end
 end

--- a/language/regexp/character_classes_spec.rb
+++ b/language/regexp/character_classes_spec.rb
@@ -89,7 +89,7 @@ describe "Regexp with character classes" do
     /[^[:lower:]A-C]+/.match("abcABCDEF123def").to_a.should == ["DEF123"] # negated character class
     /[:alnum:]+/.match("a:l:n:u:m").to_a.should == ["a:l:n:u:m"] # should behave like regular character class composed of the individual letters
     /[\[:alnum:]+/.match("[:a:l:n:u:m").to_a.should == ["[:a:l:n:u:m"] # should behave like regular character class composed of the individual letters
-    -> { eval('/[[:alpha:]-[:digit:]]/') }.should raise_error(SyntaxError) # can't use character class as a start value of range
+    expect_syntax_error('/[[:alpha:]-[:digit:]]/')
   end
 
   it "matches ASCII characters with [[:ascii:]]" do

--- a/language/regexp/escapes_spec.rb
+++ b/language/regexp/escapes_spec.rb
@@ -120,7 +120,7 @@ describe "Regexps with escape characters" do
     /\x0AA/.match("\nA").to_a.should == ["\nA"]
     /\xAG/.match("\nG").to_a.should == ["\nG"]
     # Non-matches
-    -> { eval('/\xG/') }.should raise_error(SyntaxError)
+    expect_syntax_error('/\xG/')
 
     # \x{7HHHHHHH} wide hexadecimal char (character code point value)
   end
@@ -141,9 +141,9 @@ describe "Regexps with escape characters" do
     # Parsing precedence
     /\cJ+/.match("\n\n").to_a.should == ["\n\n"] # Quantifiers apply to entire escape sequence
     /\\cJ/.match("\\cJ").to_a.should == ["\\cJ"]
-    -> { eval('/[abc\x]/') }.should raise_error(SyntaxError) # \x is treated as a escape sequence even inside a character class
+    expect_syntax_error('/[abc\x]/') # \x is treated as a escape sequence even inside a character class
     # Syntax error
-    -> { eval('/\c/') }.should raise_error(SyntaxError)
+    expect_syntax_error('/\c/')
 
     # \cx          control char          (character code point value)
     # \C-x         control char          (character code point value)

--- a/language/regexp/modifiers_spec.rb
+++ b/language/regexp/modifiers_spec.rb
@@ -36,7 +36,7 @@ describe "Regexps with modifiers" do
     /foo/imox.match("foo").to_a.should == ["foo"]
     /foo/imoximox.match("foo").to_a.should == ["foo"]
 
-    -> { eval('/foo/a') }.should raise_error(SyntaxError)
+    expect_syntax_error('/foo/a')
   end
 
   it "supports (?~) (absent operator)" do
@@ -76,7 +76,7 @@ describe "Regexps with modifiers" do
     /(?i-i)foo/.match("FOO").should be_nil
     /(?ii)foo/.match("FOO").to_a.should == ["FOO"]
     /(?-)foo/.match("foo").to_a.should == ["foo"]
-    -> { eval('/(?o)/') }.should raise_error(SyntaxError)
+    expect_syntax_error('/(?o)/')
   end
 
   it "supports (?imx-imx:expr) (scoped inline modifiers)" do
@@ -96,7 +96,7 @@ describe "Regexps with modifiers" do
     /(?i-i:foo)/.match("FOO").should be_nil
     /(?ii:foo)/.match("FOO").to_a.should == ["FOO"]
     /(?-:)foo/.match("foo").to_a.should == ["foo"]
-    -> { eval('/(?o:)/') }.should raise_error(SyntaxError)
+    expect_syntax_error('/(?o:)/')
   end
 
   it "supports . with /m" do

--- a/language/regexp_spec.rb
+++ b/language/regexp_spec.rb
@@ -31,7 +31,7 @@ describe "Literal Regexps" do
   end
 
   it "throws SyntaxError for malformed literals" do
-    -> { eval('/(/') }.should raise_error(SyntaxError)
+    expect_syntax_error('/(/')
   end
 
   #############################################################################
@@ -58,7 +58,7 @@ describe "Literal Regexps" do
 
   it "disallows first part of paired delimiters to be used as non-paired delimiters" do
     LanguageSpecs.paired_delimiters.each do |p0, p1|
-      -> { eval("%r#{p0} foo #{p0}") }.should raise_error(SyntaxError)
+      expect_syntax_error("%r#{p0} foo #{p0}")
     end
   end
 
@@ -69,11 +69,11 @@ describe "Literal Regexps" do
   end
 
   it "disallows alphabets as non-paired delimiter with %r" do
-    -> { eval('%ra foo a') }.should raise_error(SyntaxError)
+    expect_syntax_error('%ra foo a')
   end
 
   it "disallows spaces after %r and delimiter" do
-    -> { eval('%r !foo!') }.should raise_error(SyntaxError)
+    expect_syntax_error('%r !foo!')
   end
 
   it "allows unescaped / to be used with %r" do

--- a/language/rescue_spec.rb
+++ b/language/rescue_spec.rb
@@ -530,15 +530,13 @@ describe "The rescue keyword" do
   end
 
   it "does not allow rescue in {} block" do
-    -> {
-      eval <<-ruby
-        lambda {
-          raise SpecificExampleException
-        rescue SpecificExampleException
-          :caught
-        }
-      ruby
-    }.should raise_error(SyntaxError)
+    expect_syntax_error <<-ruby
+      lambda {
+        raise SpecificExampleException
+      rescue SpecificExampleException
+        :caught
+      }
+    ruby
   end
 
   it "allows rescue in 'do end' block" do
@@ -559,7 +557,7 @@ describe "The rescue keyword" do
   end
 
   it "requires the 'rescue' in method arguments to be wrapped in parens" do
-    -> { eval '1.+(1 rescue 1)' }.should raise_error(SyntaxError)
+    expect_syntax_error '1.+(1 rescue 1)'
     eval('1.+((1 rescue 1))').should == 2
   end
 
@@ -587,11 +585,9 @@ describe "The rescue keyword" do
     end
 
     it "doesn't except rescue expression" do
-      -> {
-        eval <<-ruby
-          a = 1 rescue RuntimeError 2
-        ruby
-      }.should raise_error(SyntaxError)
+      expect_syntax_error <<-ruby
+        a = 1 rescue RuntimeError 2
+      ruby
     end
 
     it "rescues only StandardError and its subclasses" do

--- a/language/retry_spec.rb
+++ b/language/retry_spec.rb
@@ -32,10 +32,10 @@ describe "The retry statement" do
   end
 
   it "raises a SyntaxError when used outside of a rescue statement" do
-    -> { eval 'retry' }.should raise_error(SyntaxError)
-    -> { eval 'begin; retry; end' }.should raise_error(SyntaxError)
-    -> { eval 'def m; retry; end' }.should raise_error(SyntaxError)
-    -> { eval 'module RetrySpecs; retry; end' }.should raise_error(SyntaxError)
+    expect_syntax_error('retry')
+    expect_syntax_error('begin; retry; end')
+    expect_syntax_error('def m; retry; end')
+    expect_syntax_error('module RetrySpecs; retry; end')
   end
 end
 

--- a/language/safe_navigator_spec.rb
+++ b/language/safe_navigator_spec.rb
@@ -2,7 +2,7 @@ require_relative '../spec_helper'
 
 describe "Safe navigator" do
   it "requires a method name to be provided" do
-    -> { eval("obj&. {}") }.should raise_error(SyntaxError)
+    expect_syntax_error("obj&. {}")
   end
 
   context "when context is nil" do

--- a/language/send_spec.rb
+++ b/language/send_spec.rb
@@ -107,9 +107,7 @@ describe "Invoking a method" do
   end
 
   it "raises a SyntaxError with both a literal block and an object as block" do
-    -> {
-      eval "specs.oneb(10, &l){ 42 }"
-    }.should raise_error(SyntaxError)
+    expect_syntax_error "specs.oneb(10, &l){ 42 }"
   end
 
   it "with same names as existing variables is ok" do

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -36,3 +36,7 @@ unless ENV['MSPEC_RUNNER'] # Running directly with ruby some_spec.rb
   ARGV.unshift $0
   MSpecRun.main
 end
+
+def expect_syntax_error(ruby_src)
+  -> { eval(ruby_src) }.should raise_error(SyntaxError)
+end


### PR DESCRIPTION
This was a really common pattern that I needed to repeat several times in #1187.

I noticed it repeated a bunch (69 times), and could be simplified really nicely with this little helper method.