### PR TITLE
Split multibyte class names from Marshal fixtures into their own file

### DIFF
--- a/core/marshal/fixtures/marshal_data.rb
+++ b/core/marshal/fixtures/marshal_data.rb
@@ -1,4 +1,7 @@
 # -*- encoding: binary -*-
+
+require_relative 'marshal_multibyte_data'
+
 class UserDefined
   class Nested
     def ==(other)
@@ -266,17 +269,6 @@ module MarshalSpec
       "Foo"
     end
   end
-
-  module_eval(<<~ruby.dup.force_encoding(Encoding::UTF_8))
-    class MultibyteぁあぃいClass
-    end
-
-    module MultibyteけげこごModule
-    end
-
-    class MultibyteぁあぃいTime < Time
-    end
-  ruby
 
   class ObjectWithFreezeRaisingException < Object
     def freeze

--- a/core/marshal/fixtures/marshal_multibyte_data.rb
+++ b/core/marshal/fixtures/marshal_multibyte_data.rb
@@ -1,0 +1,12 @@
+# -*- encoding: utf-8 -*-
+
+module MarshalSpec
+  class MultibyteぁあぃいClass
+  end
+
+  module MultibyteけげこごModule
+  end
+
+  class MultibyteぁあぃいTime < Time
+  end
+end


### PR DESCRIPTION
This removes the dependency on module_eval. It does use the magic comment to force the file encoding, but that one is present in the main fixture as well.