### PR TITLE
Add spec for `Pathname{#,.}glob` with missing directory

### DIFF
--- a/library/pathname/glob_spec.rb
+++ b/library/pathname/glob_spec.rb
@@ -21,6 +21,10 @@ describe 'Pathname.glob' do
     Pathname.glob(@dir + 'lib/*.js').should == []
   end
 
+  it 'returns [] when the pathname does not exist' do
+    Pathname.glob('i_dont_exist/lib/*.js').should == []
+  end
+
   it 'returns matching file paths' do
     Pathname.glob(@dir + 'lib/*i*.rb').sort.should == [Pathname.new(@file_1), Pathname.new(@file_2)].sort
   end
@@ -65,6 +69,10 @@ describe 'Pathname#glob' do
 
   it 'returns [] for no match' do
     Pathname.new(@dir).glob('lib/*.js').should == []
+  end
+
+  it 'returns [] when the pathname does not exist' do
+    Pathname.new('./i_dont_exist').glob('lib/*.js').should == []
   end
 
   it 'returns matching file paths' do


### PR DESCRIPTION
I have found a difference in `Pathname.glob` between jruby and ruby when the folder to grep for doesn't exist: https://github.com/jruby/jruby/issues/8358 Since there are no specs, I though why not add some.

Note: I don't know if it is bad manners to add tests that are known to fail on other implementations. If so, sorry!