### PR TITLE
Specs for StringIO#sysread and StringIO#read_nonblock

### DIFF
--- a/library/stringio/shared/sysread.rb
+++ b/library/stringio/shared/sysread.rb
@@ -10,6 +10,6 @@ describe :stringio_sysread_length, shared: true do
 
   it "raises an EOFError when passed length > 0 and no data remains" do
     @io.read.should == "example"
-    -> { @io.sysread(1) }.should raise_error(EOFError)
+    -> { @io.send(@method, 1) }.should raise_error(EOFError)
   end
 end

--- a/library/stringio/sysread_spec.rb
+++ b/library/stringio/sysread_spec.rb
@@ -1,6 +1,7 @@
 require_relative '../../spec_helper'
 require "stringio"
 require_relative 'shared/read'
+require_relative 'shared/sysread'
 
 describe "StringIO#sysread when passed length, buffer" do
   it_behaves_like :stringio_read, :sysread
@@ -30,6 +31,10 @@ describe "StringIO#sysread when passed nil" do
     @io.sysread(nil).should == "example"
     @io.sysread(nil).should == ""
   end
+end
+
+describe "StringIO#sysread when passed length" do
+  it_behaves_like :stringio_sysread_length, :sysread
 end
 
 describe "StringIO#sysread when passed [length]" do


### PR DESCRIPTION
Marking this as a draft for now, since this whole setup is weird. There is a shared spec `:stringio_sysread_length`, but this one is only used by `StringIO#read_nonblock`, not by `StringIO#sysread`. There is probably some duplication or some missing specs.