### PR TITLE
Fix shared spec of Time.iso8601/Time.xmlschema

### DIFF
--- a/library/time/shared/rfc2822.rb
+++ b/library/time/shared/rfc2822.rb
@@ -1,33 +1,33 @@
 describe :time_rfc2822, shared: true do
   it "parses RFC-822 strings" do
     t1 = (Time.utc(1976, 8, 26, 14, 30) + 4 * 3600)
-    t2 = Time.rfc2822("26 Aug 76 14:30 EDT")
+    t2 = Time.send(@method, "26 Aug 76 14:30 EDT")
     t1.should == t2
 
     t3 = Time.utc(1976, 8, 27, 9, 32) + 7 * 3600
-    t4 = Time.rfc2822("27 Aug 76 09:32 PDT")
+    t4 = Time.send(@method, "27 Aug 76 09:32 PDT")
     t3.should == t4
   end
 
   it "parses RFC-2822 strings" do
     t1 = Time.utc(1997, 11, 21, 9, 55, 6) + 6 * 3600
-    t2 = Time.rfc2822("Fri, 21 Nov 1997 09:55:06 -0600")
+    t2 = Time.send(@method, "Fri, 21 Nov 1997 09:55:06 -0600")
     t1.should == t2
 
     t3 = Time.utc(2003, 7, 1, 10, 52, 37) - 2 * 3600
-    t4 = Time.rfc2822("Tue, 1 Jul 2003 10:52:37 +0200")
+    t4 = Time.send(@method, "Tue, 1 Jul 2003 10:52:37 +0200")
     t3.should == t4
 
     t5 = Time.utc(1997, 11, 21, 10, 1, 10) + 6 * 3600
-    t6 = Time.rfc2822("Fri, 21 Nov 1997 10:01:10 -0600")
+    t6 = Time.send(@method, "Fri, 21 Nov 1997 10:01:10 -0600")
     t5.should == t6
 
     t7 = Time.utc(1997, 11, 21, 11, 0, 0) + 6 * 3600
-    t8 = Time.rfc2822("Fri, 21 Nov 1997 11:00:00 -0600")
+    t8 = Time.send(@method, "Fri, 21 Nov 1997 11:00:00 -0600")
     t7.should == t8
 
     t9 = Time.utc(1997, 11, 24, 14, 22, 1) + 8 * 3600
-    t10 = Time.rfc2822("Mon, 24 Nov 1997 14:22:01 -0800")
+    t10 = Time.send(@method, "Mon, 24 Nov 1997 14:22:01 -0800")
     t9.should == t10
 
     begin
@@ -36,11 +36,11 @@ describe :time_rfc2822, shared: true do
       # ignore
     else
       t11 = Time.utc(1969, 2, 13, 23, 32, 54) + 3 * 3600 + 30 * 60
-      t12 = Time.rfc2822("Thu, 13 Feb 1969 23:32:54 -0330")
+      t12 = Time.send(@method, "Thu, 13 Feb 1969 23:32:54 -0330")
       t11.should == t12
 
       t13 = Time.utc(1969, 2, 13, 23, 32, 0) + 3 * 3600 + 30 * 60
-      t14 = Time.rfc2822(" Thu,
+      t14 = Time.send(@method, " Thu,
       13
         Feb
           1969
@@ -50,16 +50,16 @@ describe :time_rfc2822, shared: true do
     end
 
     t15 = Time.utc(1997, 11, 21, 9, 55, 6)
-    t16 = Time.rfc2822("21 Nov 97 09:55:06 GMT")
+    t16 = Time.send(@method, "21 Nov 97 09:55:06 GMT")
     t15.should == t16
 
     t17 = Time.utc(1997, 11, 21, 9, 55, 6) + 6 * 3600
-    t18 = Time.rfc2822("Fri, 21 Nov 1997 09 :   55  :  06 -0600")
+    t18 = Time.send(@method, "Fri, 21 Nov 1997 09 :   55  :  06 -0600")
     t17.should == t18
 
     -> {
       # inner comment is not supported.
-      Time.rfc2822("Fri, 21 Nov 1997 09(comment):   55  :  06 -0600")
+      Time.send(@method, "Fri, 21 Nov 1997 09(comment):   55  :  06 -0600")
     }.should raise_error(ArgumentError)
   end
 end

--- a/library/time/shared/xmlschema.rb
+++ b/library/time/shared/xmlschema.rb
@@ -2,23 +2,23 @@ describe :time_xmlschema, shared: true do
   it "parses ISO-8601 strings" do
     t = Time.utc(1985, 4, 12, 23, 20, 50, 520000)
     s = "1985-04-12T23:20:50.52Z"
-    t.should == Time.xmlschema(s)
-    #s.should == t.xmlschema(2)
+    t.should == Time.send(@method, s)
+    #s.should == t.send(@method, 2)
 
     t = Time.utc(1996, 12, 20, 0, 39, 57)
     s = "1996-12-19T16:39:57-08:00"
-    t.should == Time.xmlschema(s)
+    t.should == Time.send(@method, s)
     # There is no way to generate time string with arbitrary timezone.
     s = "1996-12-20T00:39:57Z"
-    t.should == Time.xmlschema(s)
-    #assert_equal(s, t.xmlschema)
+    t.should == Time.send(@method, s)
+    #assert_equal(s, t.send(@method))
 
     t = Time.utc(1990, 12, 31, 23, 59, 60)
     s = "1990-12-31T23:59:60Z"
-    t.should == Time.xmlschema(s)
+    t.should == Time.send(@method, s)
     # leap second is representable only if timezone file has it.
     s = "1990-12-31T15:59:60-08:00"
-    t.should == Time.xmlschema(s)
+    t.should == Time.send(@method, s)
 
     begin
       Time.at(-1)
@@ -27,27 +27,27 @@ describe :time_xmlschema, shared: true do
     else
       t = Time.utc(1937, 1, 1, 11, 40, 27, 870000)
       s = "1937-01-01T12:00:27.87+00:20"
-      t.should == Time.xmlschema(s)
+      t.should == Time.send(@method, s)
     end
 
     # more
 
-    # (Time.utc(1999, 5, 31, 13, 20, 0) + 5 * 3600).should == Time.xmlschema("1999-05-31T13:20:00-05:00")
-    # (Time.local(2000, 1, 20, 12, 0, 0)).should == Time.xmlschema("2000-01-20T12:00:00")
-    # (Time.utc(2000, 1, 20, 12, 0, 0)).should == Time.xmlschema("2000-01-20T12:00:00Z")
-    # (Time.utc(2000, 1, 20, 12, 0, 0) - 12 * 3600).should == Time.xmlschema("2000-01-20T12:00:00+12:00")
-    # (Time.utc(2000, 1, 20, 12, 0, 0) + 13 * 3600).should == Time.xmlschema("2000-01-20T12:00:00-13:00")
-    # (Time.utc(2000, 3, 4, 23, 0, 0) - 3 * 3600).should == Time.xmlschema("2000-03-04T23:00:00+03:00")
-    # (Time.utc(2000, 3, 4, 20, 0, 0)).should == Time.xmlschema("2000-03-04T20:00:00Z")
-    # (Time.local(2000, 1, 15, 0, 0, 0)).should == Time.xmlschema("2000-01-15T00:00:00")
-    # (Time.local(2000, 2, 15, 0, 0, 0)).should == Time.xmlschema("2000-02-15T00:00:00")
-    # (Time.local(2000, 1, 15, 12, 0, 0)).should == Time.xmlschema("2000-01-15T12:00:00")
-    # (Time.utc(2000, 1, 16, 12, 0, 0)).should == Time.xmlschema("2000-01-16T12:00:00Z")
-    # (Time.local(2000, 1, 1, 12, 0, 0)).should == Time.xmlschema("2000-01-01T12:00:00")
-    # (Time.utc(1999, 12, 31, 23, 0, 0)).should == Time.xmlschema("1999-12-31T23:00:00Z")
-    # (Time.local(2000, 1, 16, 12, 0, 0)).should == Time.xmlschema("2000-01-16T12:00:00")
-    # (Time.local(2000, 1, 16, 0, 0, 0)).should == Time.xmlschema("2000-01-16T00:00:00")
-    # (Time.utc(2000, 1, 12, 12, 13, 14)).should == Time.xmlschema("2000-01-12T12:13:14Z")
-    # (Time.utc(2001, 4, 17, 19, 23, 17, 300000)).should == Time.xmlschema("2001-04-17T19:23:17.3Z")
+    # (Time.utc(1999, 5, 31, 13, 20, 0) + 5 * 3600).should == Time.send(@method, "1999-05-31T13:20:00-05:00")
+    # (Time.local(2000, 1, 20, 12, 0, 0)).should == Time.send(@method, "2000-01-20T12:00:00")
+    # (Time.utc(2000, 1, 20, 12, 0, 0)).should == Time.send(@method, "2000-01-20T12:00:00Z")
+    # (Time.utc(2000, 1, 20, 12, 0, 0) - 12 * 3600).should == Time.send(@method, "2000-01-20T12:00:00+12:00")
+    # (Time.utc(2000, 1, 20, 12, 0, 0) + 13 * 3600).should == Time.send(@method, "2000-01-20T12:00:00-13:00")
+    # (Time.utc(2000, 3, 4, 23, 0, 0) - 3 * 3600).should == Time.send(@method, "2000-03-04T23:00:00+03:00")
+    # (Time.utc(2000, 3, 4, 20, 0, 0)).should == Time.send(@method, "2000-03-04T20:00:00Z")
+    # (Time.local(2000, 1, 15, 0, 0, 0)).should == Time.send(@method, "2000-01-15T00:00:00")
+    # (Time.local(2000, 2, 15, 0, 0, 0)).should == Time.send(@method, "2000-02-15T00:00:00")
+    # (Time.local(2000, 1, 15, 12, 0, 0)).should == Time.send(@method, "2000-01-15T12:00:00")
+    # (Time.utc(2000, 1, 16, 12, 0, 0)).should == Time.send(@method, "2000-01-16T12:00:00Z")
+    # (Time.local(2000, 1, 1, 12, 0, 0)).should == Time.send(@method, "2000-01-01T12:00:00")
+    # (Time.utc(1999, 12, 31, 23, 0, 0)).should == Time.send(@method, "1999-12-31T23:00:00Z")
+    # (Time.local(2000, 1, 16, 12, 0, 0)).should == Time.send(@method, "2000-01-16T12:00:00")
+    # (Time.local(2000, 1, 16, 0, 0, 0)).should == Time.send(@method, "2000-01-16T00:00:00")
+    # (Time.utc(2000, 1, 12, 12, 13, 14)).should == Time.send(@method, "2000-01-12T12:13:14Z")
+    # (Time.utc(2001, 4, 17, 19, 23, 17, 300000)).should == Time.send(@method, "2001-04-17T19:23:17.3Z")
   end
 end


### PR DESCRIPTION
Use the @method variable for method calls, don't hardcode the name. The specs for Time.iso8601 did not test the method.