### PR TITLE
Fix CROSS_COMPILING guard and RUBYOPT=-v spec

### DIFF
--- a/command_line/rubyopt_spec.rb
+++ b/command_line/rubyopt_spec.rb
@@ -22,15 +22,15 @@ describe "Processing RUBYOPT" do
     result.should =~ /value of \$DEBUG is true/
   end
 
-  guard -> { not CROSS_COMPILING } do
+  guard -> { RbConfig::CONFIG["CROSS_COMPILING"] != "yes" } do
     it "prints the version number for '-v'" do
       ENV["RUBYOPT"] = '-v'
-      ruby_exe("")[/\A.*/].should == RUBY_DESCRIPTION.sub("+PRISM ", "")
+      ruby_exe("").sub("+PRISM ", "")[/\A.*/].should == RUBY_DESCRIPTION.sub("+PRISM ", "")
     end
 
     it "ignores whitespace around the option" do
       ENV["RUBYOPT"] = ' -v '
-      ruby_exe("")[/\A.*/].should == RUBY_DESCRIPTION.sub("+PRISM ", "")
+      ruby_exe("").sub("+PRISM ", "")[/\A.*/].should == RUBY_DESCRIPTION.sub("+PRISM ", "")
     end
   end
 


### PR DESCRIPTION
The spec about `RUBYOPT=-v` fails since the point in time when the parser was switched to PRISM. But this wasn't noticed since the guard around it switched the two specs off, when executed from the ruby/ruby repository by `make test-spec`.

This is because the constant `CROSS_COMPILING` is set by the `$(arch)-fake.rb` to `RUBY_PLATFORM` and mspec is executed with `-r $(arch)-fake.rb` on the command line of `make test-spec`. It is defined here: https://github.com/ruby/ruby/blob/98fce00cab460be81cb1f5e4cf8c0d66e006a35b/template/fake.rb.in#L40

This patch changes the guard to use `RbConfig` variable `CROSS_COMPILING` which is either "no" for a native build or "yes" when the ruby has been built per cross compiler.

When the guard is fixed or when mspec is executed out of tree, the specs fail like so: https://github.com/oneclick/rubyinstaller2/actions/runs/11308579444/job/31451561785#step:32:78

To fix the failing specs the `PRISM` flag is removed from both sides before equality check. This is a leftover from the incomplete commit https://github.com/ruby/spec/commit/76c1fef01a7deb50fb84dbd478d4675542dce74a or https://github.com/ruby/spec/commit/5320f88116ea832a2ccb5c5bb1a6999062658c7a .