### PR TITLE
Remove Gemfile, add script for Rubocop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,5 +72,4 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.0'
-    - run: bundle install
-    - run: bundle exec rubocop --parallel
+    - run: bin/rubocop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,5 +71,5 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.0'
+        ruby-version: '3.3'
     - run: bin/rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'rubocop', '= 1.66.1'

--- a/bin/rubocop
+++ b/bin/rubocop
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/inline'
+
+gemfile do
+  source 'https://rubygems.org'
+
+  gem 'rubocop', '=  1.66.1'
+end
+
+exec(Gem.bin_path('rubocop', 'rubocop'), *ARGV)

--- a/bin/rubocop
+++ b/bin/rubocop
@@ -6,7 +6,7 @@ require 'bundler/inline'
 gemfile do
   source 'https://rubygems.org'
 
-  gem 'rubocop', '=  1.66.1'
+  gem 'rubocop', '1.66.1'
 end
 
 exec(Gem.bin_path('rubocop', 'rubocop'), *ARGV)


### PR DESCRIPTION
This addresses the issues from #1180.
I've opted for using `bundler/inline`, so we can still force a specific version. The script itself is fully compatible with Rubocop, so we can things like `bin/rubocop --autocorrect` work too.
I've also updated the CI job to Ruby 3.3, it was still using 3.0. It should probably work with every supported Ruby version.