### PR TITLE
Rubocop: disable Lint/RescueException

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,6 +61,9 @@ Lint/RedundantSafeNavigation:
 Lint/RedundantSplatExpansion:
   Enabled: false
 
+Lint/RescueException:
+  Enabled: false
+
 Lint/UnifiedInteger:
   Enabled: false
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -85,23 +85,6 @@ Lint/RedundantStringCoercion:
   Exclude:
     - 'core/io/print_spec.rb'
 
-# Offense count: 25
-Lint/RescueException:
-  Exclude:
-    - 'command_line/fixtures/debug_info.rb'
-    - 'core/dir/fileno_spec.rb'
-    - 'core/exception/cause_spec.rb'
-    - 'core/exception/no_method_error_spec.rb'
-    - 'core/fiber/kill_spec.rb'
-    - 'core/kernel/fixtures/autoload_frozen.rb'
-    - 'core/kernel/raise_spec.rb'
-    - 'core/module/autoload_spec.rb'
-    - 'core/mutex/sleep_spec.rb'
-    - 'core/thread/abort_on_exception_spec.rb'
-    - 'core/thread/shared/exit.rb'
-    - 'language/rescue_spec.rb'
-    - 'library/erb/filename_spec.rb'
-
 # Offense count: 1
 Lint/SelfAssignment:
   Exclude:


### PR DESCRIPTION
This cop tries to stop `rescue Exception`. This is generally a good idea in regular Ruby code, but we actually need this pretty often in the specs. Disable it to get it out of the way in this repo.

This is a reaction to #1210, where some extra offenses for this cop are introduced.