### PR TITLE
Improve checks for actual duration in sleep specs

### DIFF
--- a/core/kernel/sleep_spec.rb
+++ b/core/kernel/sleep_spec.rb
@@ -60,8 +60,8 @@ describe "Kernel#sleep" do
       end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
       actual_duration = end_time - start_time
-      (actual_duration > 0.01).should == true # 100 * 0.0001 => 0.01
-      (actual_duration < 0.03).should == true
+      actual_duration.should > 0.01 # 100 * 0.0001 => 0.01
+      actual_duration.should < 0.03
     end
   end
 


### PR DESCRIPTION
Use `should <` instead of trying to match the boolean itself. This way, the output on failures show the actual duration instead of just a true/false error.

Example error message with this change:

    Expected 0.15368436999779078 < 0.03

Just happened to spot this in #1212. I'm leaving this as draft for now, to prevent it from clashing with those changes.