### PR TITLE
Update shared specs for Process.fork/Kernel.fork/Kernel#fork

### DIFF
--- a/shared/process/fork.rb
+++ b/shared/process/fork.rb
@@ -23,31 +23,31 @@ describe :process_fork, shared: true do
     end
 
     it "returns status zero" do
-      pid = Process.fork { exit! 0 }
+      pid = @object.fork { exit! 0 }
       _, result = Process.wait2(pid)
       result.exitstatus.should == 0
     end
 
     it "returns status zero" do
-      pid = Process.fork { exit 0 }
+      pid = @object.fork { exit 0 }
       _, result = Process.wait2(pid)
       result.exitstatus.should == 0
     end
 
     it "returns status zero" do
-      pid = Process.fork {}
+      pid = @object.fork {}
       _, result = Process.wait2(pid)
       result.exitstatus.should == 0
     end
 
     it "returns status non-zero" do
-      pid = Process.fork { exit! 42 }
+      pid = @object.fork { exit! 42 }
       _, result = Process.wait2(pid)
       result.exitstatus.should == 42
     end
 
     it "returns status non-zero" do
-      pid = Process.fork { exit 42 }
+      pid = @object.fork { exit 42 }
       _, result = Process.wait2(pid)
       result.exitstatus.should == 42
     end


### PR DESCRIPTION
A number of tests called `Process.fork`, so the specs for Kernel were mostly calling the wrong method.