### PR TITLE
Add spec for `defined?` on constant with const_missing

### DIFF
--- a/language/defined_spec.rb
+++ b/language/defined_spec.rb
@@ -900,6 +900,10 @@ describe "The defined? keyword for a scoped constant" do
     defined?(DefinedSpecs::Undefined).should be_nil
   end
 
+  it "returns nil when the constant is not defined and the outer module implements .const_missing" do
+    defined?(DefinedSpecs::ModuleWithConstMissing::Undefined).should be_nil
+  end
+
   it "does not call .const_missing if the constant is not defined" do
     DefinedSpecs.should_not_receive(:const_missing)
     defined?(DefinedSpecs::UnknownChild).should be_nil

--- a/language/fixtures/defined.rb
+++ b/language/fixtures/defined.rb
@@ -285,6 +285,12 @@ module DefinedSpecs
     end
   end
 
+  module ModuleWithConstMissing
+    def self.const_missing(const)
+      const
+    end
+  end
+
   class SuperWithIntermediateModules
     include IntermediateModule1
     include IntermediateModule2


### PR DESCRIPTION
Make sure that `defined?` returns nil even if `const_missing` is implemented in the parent.

We noticed this while implementing `defined?` in Natalie (see https://github.com/natalie-lang/natalie/pull/2289, https://github.com/natalie-lang/natalie/issues/1734)