### PR TITLE
Add some specs for bitwise operators in Process::Status

### DIFF
--- a/core/process/status/bit_and_spec.rb
+++ b/core/process/status/bit_and_spec.rb
@@ -1,5 +1,35 @@
 require_relative '../../../spec_helper'
 
 describe "Process::Status#&" do
-  it "needs to be reviewed for spec completeness"
+  it "returns a bitwise and of the integer status of an exited child" do
+    suppress_warning do
+      ruby_exe("exit(29)", exit_status: 29)
+      ($? & 0).should == 0
+      ($? & $?.to_i).should == $?.to_i
+
+      # Actual value is implementation specific
+      platform_is :linux do
+        # 29 == 0b11101
+        ($? & 0b1011100000000).should == 0b1010100000000
+      end
+    end
+  end
+
+  ruby_version_is "3.3" do
+    it "raises an ArgumentError if mask is negative" do
+      suppress_warning do
+        ruby_exe("exit(0)")
+        -> {
+          $? & -1
+        }.should raise_error(ArgumentError, 'negative mask value: -1')
+      end
+    end
+
+    it "shows a deprecation warning" do
+      ruby_exe("exit(0)")
+      -> {
+        $? & 0
+      }.should complain(/warning: Process::Status#& is deprecated and will be removed .*use other Process::Status predicates instead/)
+    end
+  end
 end

--- a/core/process/status/right_shift_spec.rb
+++ b/core/process/status/right_shift_spec.rb
@@ -1,5 +1,34 @@
 require_relative '../../../spec_helper'
 
 describe "Process::Status#>>" do
-  it "needs to be reviewed for spec completeness"
+  it "returns a right shift of the integer status of an exited child" do
+    suppress_warning do
+      ruby_exe("exit(29)", exit_status: 29)
+      ($? >> 0).should == $?.to_i
+      ($? >> 1).should == $?.to_i >> 1
+
+      # Actual value is implementation specific
+      platform_is :linux do
+        ($? >> 8).should == 29
+      end
+    end
+  end
+
+  ruby_version_is "3.3" do
+    it "raises an ArgumentError if shift value is negative" do
+      suppress_warning do
+        ruby_exe("exit(0)")
+        -> {
+          $? >> -1
+        }.should raise_error(ArgumentError, 'negative shift value: -1')
+      end
+    end
+
+    it "shows a deprecation warning" do
+      ruby_exe("exit(0)")
+      -> {
+        $? >> 0
+      }.should complain(/warning: Process::Status#>> is deprecated and will be removed .*use other Process::Status attributes instead/)
+    end
+  end
 end


### PR DESCRIPTION
Specifically `Process:Status#&` and `Process::Status#>>`. These methods have been deprecated in Ruby 3.3, and are planned to be removed (the warning of Ruby 3.3 says removed in 3.4, but today's version of Ruby 3.4-dev still has them and says it will be removed in 3.5).

I kept the specs pretty basic, so there's no spec to test if we call `to_int` on the argument, or what happens if the argument is not an integer, since these methods are deprecated I would say we can do without it.