### PR TITLE
Add spec for String#unpack raising ArgumentError on unknown directive

### DIFF
--- a/core/string/unpack/shared/basic.rb
+++ b/core/string/unpack/shared/basic.rb
@@ -8,6 +8,15 @@ describe :string_unpack_basic, shared: true do
     d.should_receive(:to_str).and_return("a"+unpack_format)
     "abc".unpack(d).should be_an_instance_of(Array)
   end
+
+  ruby_version_is "3.3" do
+    # https://bugs.ruby-lang.org/issues/19150
+    it 'raise ArgumentError when a directive is unknown' do
+      -> { "abcdefgh".unpack("a R" + unpack_format) }.should raise_error(ArgumentError)
+      -> { "abcdefgh".unpack("a 0" + unpack_format) }.should raise_error(ArgumentError)
+      -> { "abcdefgh".unpack("a :" + unpack_format) }.should raise_error(ArgumentError)
+    end
+  end
 end
 
 describe :string_unpack_no_platform, shared: true do


### PR DESCRIPTION
Adds a shared spec for `String#unpack` for raising an `ArgumentError` on unknown directives, similar to how it was done for `Array#pack`