### PR TITLE
Add specs for SyntaxError when rest/kwrest and block parameters are forwarded within a block

### DIFF
--- a/language/block_spec.rb
+++ b/language/block_spec.rb
@@ -999,6 +999,7 @@ describe "Post-args" do
   end
 end
 
+# tested more thoroughly in language/delegation_spec.rb
 describe "Anonymous block forwarding" do
   ruby_version_is "3.1" do
     it "forwards blocks to other method that formally declares anonymous block" do

--- a/language/delegation_spec.rb
+++ b/language/delegation_spec.rb
@@ -1,6 +1,7 @@
 require_relative '../spec_helper'
 require_relative 'fixtures/delegation'
 
+# Forwarding anonymous parameters
 describe "delegation with def(...)" do
   it "delegates rest and kwargs" do
     a = Class.new(DelegationSpecs::Target)
@@ -10,10 +11,10 @@ describe "delegation with def(...)" do
       end
     RUBY
 
-    a.new.delegate(1, b: 2).should == [[1], {b: 2}]
+    a.new.delegate(1, b: 2).should == [[1], {b: 2}, nil]
   end
 
-  it "delegates block" do
+  it "delegates a block literal" do
     a = Class.new(DelegationSpecs::Target)
     a.class_eval(<<-RUBY)
       def delegate_block(...)
@@ -22,6 +23,18 @@ describe "delegation with def(...)" do
     RUBY
 
     a.new.delegate_block(1, b: 2) { |x| x }.should == [{b: 2}, [1]]
+  end
+
+  it "delegates a block argument" do
+    a = Class.new(DelegationSpecs::Target)
+    a.class_eval(<<-RUBY)
+      def delegate(...)
+        target(...)
+      end
+    RUBY
+
+    block = proc {}
+    a.new.delegate(1, b: 2, &block).should == [[1], {b: 2}, block]
   end
 
   it "parses as open endless Range when brackets are omitted" do
@@ -34,7 +47,7 @@ describe "delegation with def(...)" do
       RUBY
     end
 
-    a.new.delegate(1, b: 2).should == Range.new([[], {}], nil, true)
+    a.new.delegate(1, b: 2).should == Range.new([[], {}, nil], nil, true)
   end
 end
 
@@ -47,10 +60,10 @@ describe "delegation with def(x, ...)" do
       end
     RUBY
 
-    a.new.delegate(0, 1, b: 2).should == [[1], {b: 2}]
+    a.new.delegate(0, 1, b: 2).should == [[1], {b: 2}, nil]
   end
 
-  it "delegates block" do
+  it "delegates a block literal" do
     a = Class.new(DelegationSpecs::Target)
     a.class_eval(<<-RUBY)
       def delegate_block(x, ...)
@@ -59,6 +72,18 @@ describe "delegation with def(x, ...)" do
     RUBY
 
     a.new.delegate_block(0, 1, b: 2) { |x| x }.should == [{b: 2}, [1]]
+  end
+
+  it "delegates a block argument" do
+    a = Class.new(DelegationSpecs::Target)
+    a.class_eval(<<-RUBY)
+      def delegate(...)
+        target(...)
+      end
+    RUBY
+
+    block = proc {}
+    a.new.delegate(1, b: 2, &block).should == [[1], {b: 2}, block]
   end
 end
 
@@ -70,9 +95,19 @@ ruby_version_is "3.2" do
       def delegate(*)
         target(*)
       end
-    RUBY
+      RUBY
 
-      a.new.delegate(0, 1).should == [[0, 1], {}]
+      a.new.delegate(0, 1).should == [[0, 1], {}, nil]
+    end
+
+    ruby_version_is "3.3" do
+      context "within a block that accepts anonymous rest within a method that accepts anonymous rest" do
+        it "does not allow delegating rest" do
+          -> {
+            eval "def m(*); proc { |*| n(*) } end"
+          }.should raise_error(SyntaxError, /anonymous rest parameter is also used within block/)
+        end
+      end
     end
   end
 end
@@ -85,9 +120,45 @@ ruby_version_is "3.2" do
       def delegate(**)
         target(**)
       end
-    RUBY
+      RUBY
 
-      a.new.delegate(a: 1) { |x| x }.should == [[], {a: 1}]
+      a.new.delegate(a: 1) { |x| x }.should == [[], {a: 1}, nil]
+    end
+
+    ruby_version_is "3.3" do
+      context "within a block that accepts anonymous kwargs within a method that accepts anonymous kwargs" do
+        it "does not allow delegating kwargs" do
+          -> {
+            eval "def m(**); proc { |**| n(**) } end"
+          }.should raise_error(SyntaxError, /anonymous keyword rest parameter is also used within block/)
+        end
+      end
+    end
+  end
+end
+
+ruby_version_is "3.1" do
+  describe "delegation with def(&)" do
+    it "delegates an anonymous block parameter" do
+      a = Class.new(DelegationSpecs::Target)
+      a.class_eval(<<-RUBY)
+      def delegate(&)
+        target(&)
+      end
+      RUBY
+
+      block = proc {}
+      a.new.delegate(&block).should == [[], {}, block]
+    end
+
+    ruby_version_is "3.3" do
+      context "within a block that accepts anonymous block within a method that accepts anonymous block" do
+        it "does not allow delegating a block" do
+          -> {
+            eval "def m(&); proc { |&| n(&) } end"
+          }.should raise_error(SyntaxError, /anonymous block parameter is also used within block/)
+        end
+      end
     end
   end
 end

--- a/language/fixtures/delegation.rb
+++ b/language/fixtures/delegation.rb
@@ -1,7 +1,7 @@
 module DelegationSpecs
   class Target
-    def target(*args, **kwargs)
-      [args, kwargs]
+    def target(*args, **kwargs, &block)
+      [args, kwargs, block]
     end
 
     def target_block(*args, **kwargs)


### PR DESCRIPTION
Ruby 3.3 compatibility issue - https://github.com/ruby/spec/issues/1216

> Now anonymous parameters forwarding is disallowed inside a block
> that uses anonymous parameters. [[Feature #19370](https://bugs.ruby-lang.org/issues/19370)]