### PR TITLE
Add specs for Refinement#target

### DIFF
--- a/core/refinement/refined_class_spec.rb
+++ b/core/refinement/refined_class_spec.rb
@@ -1,8 +1,13 @@
-require_relative '../../spec_helper'
+require_relative "../../spec_helper"
+require_relative 'shared/target'
 
 describe "Refinement#refined_class" do
   ruby_version_is "3.2"..."3.3" do
-    it "returns the class refined by the receiver" do
+    it_behaves_like :refinement_target, :refined_class
+  end
+
+  ruby_version_is "3.3"..."3.4" do
+    it "has been deprecated in favour of Refinement#target" do
       refinement_int = nil
 
       Module.new do
@@ -11,7 +16,23 @@ describe "Refinement#refined_class" do
         end
       end
 
-      refinement_int.refined_class.should == Integer
+      -> {
+        refinement_int.refined_class
+      }.should complain(/warning: Refinement#refined_class is deprecated and will be removed in Ruby 3.4; use Refinement#target instead/)
+    end
+  end
+
+  ruby_version_is "3.4" do
+    it "has been removed" do
+      refinement_int = nil
+
+      Module.new do
+        refine Integer do
+          refinement_int = self
+        end
+      end
+
+      refinement_int.should_not.respond_to?(:refined_class)
     end
   end
 end

--- a/core/refinement/shared/target.rb
+++ b/core/refinement/shared/target.rb
@@ -1,0 +1,13 @@
+describe :refinement_target, shared: true do
+  it "returns the class refined by the receiver" do
+    refinement_int = nil
+
+    Module.new do
+      refine Integer do
+        refinement_int = self
+      end
+    end
+
+    refinement_int.send(@method).should == Integer
+  end
+end

--- a/core/refinement/target_spec.rb
+++ b/core/refinement/target_spec.rb
@@ -1,0 +1,8 @@
+require_relative "../../spec_helper"
+require_relative 'shared/target'
+
+describe "Refinement#target" do
+  ruby_version_is "3.3" do
+    it_behaves_like :refinement_target, :target
+  end
+end


### PR DESCRIPTION
This includes some additional updates:

* Move old specs for refined_class to a shared spec, use this shared spec for target
* Add a spec for Ruby 3.3 to check that refinement_target has been deprecated
* Add a spec for Ruby 3.4 to check that refinement_target has been removed

Another checkbox for #1216