### PR TITLE
Add specs for rescue even in TracePoint

### DIFF
--- a/core/tracepoint/raised_exception_spec.rb
+++ b/core/tracepoint/raised_exception_spec.rb
@@ -17,4 +17,22 @@ describe 'TracePoint#raised_exception' do
       raised_exception.should equal(error_result)
     end
   end
+
+  ruby_version_is "3.3" do
+    it 'returns value from exception rescued on the :rescue event' do
+      raised_exception, error_result = nil
+      trace = TracePoint.new(:rescue) { |tp|
+        next unless TracePointSpec.target_thread?
+        raised_exception = tp.raised_exception
+      }
+      trace.enable do
+        begin
+          raise StandardError
+        rescue => e
+          error_result = e
+        end
+        raised_exception.should equal(error_result)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Another for #1216. The code is pretty much the same as the raise event.