### PR TITLE
Add specs for lookarounds in regexp in linear time

### DIFF
--- a/core/regexp/linear_time_spec.rb
+++ b/core/regexp/linear_time_spec.rb
@@ -24,4 +24,10 @@ describe "Regexp.linear_time?" do
       Regexp.linear_time?(/a/, Regexp::IGNORECASE)
     }.should complain(/warning: flags ignored/)
   end
+
+  ruby_version_is "3.3" do
+    it "returns true for positive lookarounds" do
+      Regexp.linear_time?(/(?:(?=a*)a)*/).should == true
+    end
+  end
 end


### PR DESCRIPTION
This is an attempt at a fix for #1216, but I feel like this is more of an MRI internal property and I'm not sure if this does even belong in the specs. If this should be added, we should probably extend the test cases with the other optimizations.
(I used https://github.com/ruby/ruby/pull/7931/files#diff-f12a6f58c06015b85739069cde86a0921a8f12fb9c66e05e6643f6dbcebb1a29 to even find a test case)