### PR TITLE
Improve specs of SecureRandom.random_number

### DIFF
--- a/library/securerandom/random_number_spec.rb
+++ b/library/securerandom/random_number_spec.rb
@@ -11,8 +11,8 @@ describe "SecureRandom.random_number" do
     (1..64).each do |idx|
       num = SecureRandom.random_number(idx)
       num.should be_kind_of(Integer)
-      (0 <= num).should == true
-      (num < idx).should == true
+      0.should <= num
+      num.should < idx
     end
   end
 
@@ -21,8 +21,8 @@ describe "SecureRandom.random_number" do
     11.times do
       num = SecureRandom.random_number max
       num.should be_kind_of(Integer)
-      (0 <= num).should == true
-      (num < max).should == true
+      0.should <= num
+      num.should < max
     end
   end
 
@@ -30,8 +30,8 @@ describe "SecureRandom.random_number" do
     64.times do
       num = SecureRandom.random_number
       num.should be_kind_of(Float)
-      (0.0 <= num).should == true
-      (num < 1.0).should == true
+      0.0.should <= num
+      num.should < 1.0
     end
   end
 
@@ -39,8 +39,8 @@ describe "SecureRandom.random_number" do
     64.times do
       num = SecureRandom.random_number 11...13
       num.should be_kind_of(Integer)
-      (11 <= num).should == true
-      (num < 13).should == true
+      11.should <= num
+      num.should < 13
     end
   end
 
@@ -50,8 +50,8 @@ describe "SecureRandom.random_number" do
     32.times do
       num = SecureRandom.random_number lower..upper
       num.should be_kind_of(Integer)
-      (lower <= num).should == true
-      (num <= upper).should == true
+      lower.should <= num
+      num.should <= upper
     end
   end
 
@@ -59,23 +59,23 @@ describe "SecureRandom.random_number" do
     64.times do
       num = SecureRandom.random_number 0.6..0.9
       num.should be_kind_of(Float)
-      (0.6 <= num).should == true
-      (num <= 0.9).should == true
+      0.6.should <= num
+      num.should <= 0.9
     end
   end
 
   it "generates a random float number between 0.0 and 1.0 if argument is negative" do
     num = SecureRandom.random_number(-10)
     num.should be_kind_of(Float)
-    (0.0 <= num).should == true
-    (num < 1.0).should == true
+    0.0.should <= num
+    num.should < 1.0
   end
 
   it "generates a random float number between 0.0 and 1.0 if argument is negative float" do
     num = SecureRandom.random_number(-11.1)
     num.should be_kind_of(Float)
-    (0.0 <= num).should == true
-    (num < 1.0).should == true
+    0.0.should <= num
+    num.should < 1.0
   end
 
   it "generates different float numbers with subsequent invocations" do
@@ -84,7 +84,7 @@ describe "SecureRandom.random_number" do
     256.times do
       val = SecureRandom.random_number
       # make sure the random values are not repeating
-      values.include?(val).should == false
+      values.should_not include(val)
       values << val
     end
   end


### PR DESCRIPTION
Don't test with `should == true` or `should == false`, but use the comparison directly. This improves the error message in case of failures.