### PR TITLE
[DOC] Add syntax highlighting to MarkDown code blocks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,9 +113,9 @@ Also `have_constant`, `have_private_instance_method`, `have_singleton_method`, e
 }
 ```
 
-##### should_not raise_error
+##### `should_not raise_error`
 
-**To avoid!** Instead, use an expectation testing what the code in the lambda does.
+**Avoid this!** Instead, use an expectation testing what the code in the lambda does.
 If an exception is raised, it will fail the example anyway.
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For *testing* the development version of a Ruby implementation, one should alway
 Also, this repository doesn't always contain the latest spec changes from MRI (it's synchronized monthly), and does not contain tags (specs marked as failing on that Ruby implementation).
 Running specs on a Ruby implementation can be done with:
 
-```
+```console
 $ cd ruby_implementation/spec/ruby
 # Add ../ruby_implementation/bin in PATH, or pass -t /path/to/bin/ruby
 $ ../mspec/bin/mspec


### PR DESCRIPTION
Split off from https://github.com/ruby/ruby/pull/12322