### PR TITLE
Random formatter alphanumeric improvements

### DIFF
--- a/library/random/formatter/alphanumeric_spec.rb
+++ b/library/random/formatter/alphanumeric_spec.rb
@@ -11,7 +11,7 @@ describe "Random::Formatter#alphanumeric" do
   before :each do
     @object = Object.new
     @object.extend(Random::Formatter)
-    @object.define_singleton_method(:bytes) do |n|
+    def @object.bytes(n)
       "\x00".b * n
     end
   end

--- a/library/random/formatter/alphanumeric_spec.rb
+++ b/library/random/formatter/alphanumeric_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../../spec_helper'
+require_relative 'shared/interface'
 
 ruby_version_is "3.1" do
   require 'random/formatter'
@@ -58,4 +59,6 @@ describe "Random::Formatter#alphanumeric" do
       @object.alphanumeric(1, chars: [to_s, to_s]).should == "[mock to_s]"
     end
   end
+
+  it_behaves_like :random_formatter_interface, :alphanumeric
 end

--- a/library/random/formatter/alphanumeric_spec.rb
+++ b/library/random/formatter/alphanumeric_spec.rb
@@ -2,57 +2,60 @@ require_relative '../../../spec_helper'
 
 ruby_version_is "3.1" do
   require 'random/formatter'
+end
+ruby_version_is ""..."3.1" do
+  require 'securerandom'
+end
 
-  describe "Random::Formatter#alphanumeric" do
-    before :each do
-      @object = Object.new
-      @object.extend(Random::Formatter)
-      @object.define_singleton_method(:bytes) do |n|
-        "\x00".b * n
-      end
+describe "Random::Formatter#alphanumeric" do
+  before :each do
+    @object = Object.new
+    @object.extend(Random::Formatter)
+    @object.define_singleton_method(:bytes) do |n|
+      "\x00".b * n
+    end
+  end
+
+  it "generates a random alphanumeric string" do
+    @object.alphanumeric.should =~ /\A[A-Za-z0-9]+\z/
+  end
+
+  it "has a default size of 16 characters" do
+    @object.alphanumeric.size.should == 16
+  end
+
+  it "accepts a 'size' argument" do
+    @object.alphanumeric(10).size.should == 10
+  end
+
+  it "uses the default size if 'nil' is given as size argument" do
+    @object.alphanumeric(nil).size.should == 16
+  end
+
+  it "raises an ArgumentError if the size is not numeric" do
+    -> {
+      @object.alphanumeric("10")
+    }.should raise_error(ArgumentError)
+  end
+
+  it "does not coerce the size argument with #to_int" do
+    size = mock("size")
+    size.should_not_receive(:to_int)
+    -> {
+      @object.alphanumeric(size)
+    }.should raise_error(ArgumentError)
+  end
+
+  ruby_version_is "3.3" do
+    it "accepts a 'chars' argument with the output alphabet" do
+      @object.alphanumeric(chars: ['a', 'b']).should =~ /\A[ab]+\z/
     end
 
-    it "generates a random alphanumeric string" do
-      @object.alphanumeric.should =~ /\A[A-Za-z0-9]+\z/
-    end
-
-    it "has a default size of 16 characters" do
-      @object.alphanumeric.size.should == 16
-    end
-
-    it "accepts a 'size' argument" do
-      @object.alphanumeric(10).size.should == 10
-    end
-
-    it "uses the default size if 'nil' is given as size argument" do
-      @object.alphanumeric(nil).size.should == 16
-    end
-
-    it "raises an ArgumentError if the size is not numeric" do
-      -> {
-        @object.alphanumeric("10")
-      }.should raise_error(ArgumentError)
-    end
-
-    it "does not coerce the size argument with #to_int" do
-      size = mock("size")
-      size.should_not_receive(:to_int)
-      -> {
-        @object.alphanumeric(size)
-      }.should raise_error(ArgumentError)
-    end
-
-    ruby_version_is "3.3" do
-      it "accepts a 'chars' argument with the output alphabet" do
-        @object.alphanumeric(chars: ['a', 'b']).should =~ /\A[ab]+\z/
-      end
-
-      it "converts the elements of chars using #to_s" do
-        to_s = mock("to_s")
-        to_s.should_receive(:to_s).and_return("[mock to_s]")
-        # Using 1 value in chars results in an infinite loop
-        @object.alphanumeric(1, chars: [to_s, to_s]).should == "[mock to_s]"
-      end
+    it "converts the elements of chars using #to_s" do
+      to_s = mock("to_s")
+      to_s.should_receive(:to_s).and_return("[mock to_s]")
+      # Using 1 value in chars results in an infinite loop
+      @object.alphanumeric(1, chars: [to_s, to_s]).should == "[mock to_s]"
     end
   end
 end

--- a/library/random/formatter/shared/interface.rb
+++ b/library/random/formatter/shared/interface.rb
@@ -1,0 +1,33 @@
+require_relative '../../../../spec_helper'
+
+describe :random_formatter_interface, shared: true do
+  it "calls the method #bytes for 4 blocks of 4 bytes" do
+    bytes = mock('bytes')
+    bytes.extend(Random::Formatter)
+    bytes.should_receive(:bytes).with(4).exactly(4).and_return("\x00".b * 4)
+    bytes.send(@method)
+  end
+
+  it "has the same output if the random byte streams are the same" do
+    bytes = Object.new
+    bytes.extend(Random::Formatter)
+    def bytes.bytes(n)
+      "\x00".b * n
+    end
+    bytes.send(@method).should == bytes.send(@method)
+  end
+
+  it "has different output if the random byte streams are not the same" do
+    lhs = Object.new
+    lhs.extend(Random::Formatter)
+    def lhs.bytes(n)
+      "\x00".b * n
+    end
+    rhs = Object.new
+    rhs.extend(Random::Formatter)
+    def rhs.bytes(n)
+      "\x01".b * n
+    end
+    lhs.send(@method).should != rhs.send(@method)
+  end
+end


### PR DESCRIPTION
This addresses most of the open issues left in #1222. Most relevant is the shared spec to get a definition of what all methods on `Random::Formatter` should behave like. Once this is finished, I will start with moving the relevant specs from `SecureRandom` to this new folder.