### PR TITLE
Add Ruby 3.4 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu, macos, windows ]
-        ruby: [ 3.0.6, 3.1.4, 3.2.2, 3.3.0 ]
+        ruby: [ 3.0.6, 3.1.4, 3.2.2, 3.3.0, 3.4.1 ]
         rubyopt: [""]
         include:
           - os: ubuntu

--- a/core/fiber/storage_spec.rb
+++ b/core/fiber/storage_spec.rb
@@ -90,6 +90,13 @@ ruby_version_is "3.2" do
         key = :"#{self.class.name}#.#{self.object_id}"
         Fiber.new { Fiber[key] = 42; Fiber[key] }.resume.should == 42
       end
+
+      it "can't use invalid keys" do
+        invalid_keys = [Object.new, 12]
+        invalid_keys.each do |key|
+          -> { Fiber[key] }.should raise_error(TypeError)
+        end
+      end
     end
 
     ruby_bug "#20978", "3.2"..."3.4" do
@@ -98,6 +105,23 @@ ruby_version_is "3.2" do
         def key.to_str; "Foo"; end
         Fiber.new { Fiber[key] = 42; Fiber["Foo"] }.resume.should == 42
       end
+
+      it "converts a String key into a Symbol" do
+        Fiber.new { Fiber["key"] = 42; Fiber[:key] }.resume.should == 42
+        Fiber.new { Fiber[:key] = 42; Fiber["key"] }.resume.should == 42
+      end
+
+      it "can use any object that responds to #to_str as a key" do
+        key = mock("key")
+        key.should_receive(:to_str).twice.and_return("key")
+        Fiber.new { Fiber[key] = 42; Fiber[key] }.resume.should == 42
+      end
+    end
+
+    it "does not call #to_sym on the key" do
+      key = mock("key")
+      key.should_not_receive(:to_sym)
+      -> { Fiber[key] }.should raise_error(TypeError)
     end
 
     it "can access the storage of the parent fiber" do

--- a/core/fiber/storage_spec.rb
+++ b/core/fiber/storage_spec.rb
@@ -96,8 +96,7 @@ ruby_version_is "3.2" do
       it "can use keys as strings" do
         key = Object.new
         def key.to_str; "Foo"; end
-        Fiber[key] = 42
-        Fiber["Foo"].should == 42
+        Fiber.new { Fiber[key] = 42; Fiber["Foo"] }.resume.should == 42
       end
     end
 

--- a/library/net-ftp/fixtures/server.rb
+++ b/library/net-ftp/fixtures/server.rb
@@ -9,7 +9,7 @@ module NetFTPSpecs
     attr_reader :server_port
 
     def initialize
-      @hostname = "localhost"
+      @hostname = "127.0.0.1"
       @server = TCPServer.new(@hostname, 0)
       @server_port = @server.addr[1]
 


### PR DESCRIPTION
Most of it is rather straightforward, except for the changes to `fiber/storage_spec`. This has been a very recent change (https://bugs.ruby-lang.org/issues/20978), and is not mentioned in the changelog (nor in the documentation). This file differed on two locations from this version. I made a total of three changes:

1. commit 98b8557fc19e95c3bf3a5b968891503c5fb64299 just copies the file from MRI over our local file
2. commit b1431f9587ed0b6860070cf36e7ce0fd842c9d4e updates this new version: There was a ruby_bug statement with the version constraint `"3.2.3"..."3.4"`, but it failed at 3.2.2 too (and coincidentally the ruby/spec CI uses Ruby 3.2.2). The lower bound on the version constraint was superfluous, I removed that one and tested it with 3.2.2 and 3.2.3. (This feature has been introduced in Ruby 3.2, so 3.1 and 3.0 skip this file completely). It also updates the test to keep the Fiber variables locally, so they don't leak to the other tests.
3. commit 697c22e18bb225a84d5dcf9302643362ea900bfa expands upon those tests

I am not sure how this will interact with the periodic sync between this repo and the MRI repo, so if this will cause any conflicts in the sync, just let me know how to prevent that.