### PR TITLE
Fix leaking globals on Windows

### DIFF
--- a/library/win32ole/fixtures/classes.rb
+++ b/library/win32ole/fixtures/classes.rb
@@ -1,9 +1,6 @@
 require 'win32ole'
 
 module WIN32OLESpecs
-  WIN32OLERuntimeError ||= WIN32OLE::RuntimeError
-  WIN32OLE_TYPELIB ||= WIN32OLE::TypeLib
-
   MSXML_AVAILABLE = WIN32OLE_TYPELIB.typelibs.any? { |t| t.name.start_with?('Microsoft XML') }
   SYSTEM_MONITOR_CONTROL_AVAILABLE = WIN32OLE_TYPELIB.typelibs.any? { |t| t.name.start_with?('System Monitor Control') }
 

--- a/library/win32ole/win32ole/_getproperty_spec.rb
+++ b/library/win32ole/win32ole/_getproperty_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require_relative '../fixtures/classes'
 
   describe "WIN32OLE#_getproperty" do
@@ -14,6 +12,4 @@ platform_is :windows do
       @dict._getproperty(0, ['key'], [WIN32OLE::VARIANT::VT_BSTR]).should == 'value'
     end
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole/_invoke_spec.rb
+++ b/library/win32ole/win32ole/_invoke_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require_relative '../fixtures/classes'
 
   describe "WIN32OLE#_invoke" do
@@ -21,6 +19,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole/codepage_spec.rb
+++ b/library/win32ole/win32ole/codepage_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require_relative '../fixtures/classes'
 
   describe "WIN32OLE.codepage=" do
@@ -13,6 +11,4 @@ platform_is :windows do
     end
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole/connect_spec.rb
+++ b/library/win32ole/win32ole/connect_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require_relative '../fixtures/classes'
 
   describe "WIN32OLE.connect" do
@@ -15,6 +13,4 @@ platform_is :windows do
     end
 
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole/const_load_spec.rb
+++ b/library/win32ole/win32ole/const_load_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require_relative '../fixtures/classes'
 
   describe "WIN32OLE.const_load when passed Shell.Application OLE object" do
@@ -32,6 +30,4 @@ platform_is :windows do
     end
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole/constants_spec.rb
+++ b/library/win32ole/win32ole/constants_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require_relative '../fixtures/classes'
 
   describe "WIN32OLE class" do
@@ -42,6 +40,4 @@ platform_is :windows do
     end
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole/create_guid_spec.rb
+++ b/library/win32ole/win32ole/create_guid_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require_relative '../fixtures/classes'
 
   describe "WIN32OLE.create_guid" do
@@ -9,6 +7,4 @@ platform_is :windows do
       WIN32OLE.create_guid.should =~ /^\{[A-Z0-9]{8}\-[A-Z0-9]{4}\-[A-Z0-9]{4}\-[A-Z0-9]{4}\-[A-Z0-9]{12}/
     end
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole/invoke_spec.rb
+++ b/library/win32ole/win32ole/invoke_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require_relative '../fixtures/classes'
 
   describe "WIN32OLE#invoke" do
@@ -14,6 +12,4 @@ platform_is :windows do
       @dict.invoke('Item', 'key').should == 'value'
     end
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole/locale_spec.rb
+++ b/library/win32ole/win32ole/locale_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require_relative '../fixtures/classes'
 
   describe "WIN32OLE.locale" do
@@ -29,6 +27,4 @@ platform_is :windows do
       end
     end
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole/new_spec.rb
+++ b/library/win32ole/win32ole/new_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require_relative '../fixtures/classes'
 
   describe "WIN32OLESpecs.new_ole" do
@@ -25,6 +23,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole/ole_func_methods_spec.rb
+++ b/library/win32ole/win32ole/ole_func_methods_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require_relative '../fixtures/classes'
 
   describe "WIN32OLE#ole_func_methods" do
@@ -21,6 +19,4 @@ platform_is :windows do
       @dict.ole_func_methods.map { |m| m.name }.include?('AddRef').should be_true
     end
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole/ole_get_methods_spec.rb
+++ b/library/win32ole/win32ole/ole_get_methods_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require_relative '../fixtures/classes'
 
   describe "WIN32OLE#ole_get_methods" do
@@ -16,6 +14,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole/ole_method_help_spec.rb
+++ b/library/win32ole/win32ole/ole_method_help_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require_relative '../fixtures/classes'
   require_relative 'shared/ole_method'
 
@@ -10,6 +8,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole/ole_method_spec.rb
+++ b/library/win32ole/win32ole/ole_method_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require_relative '../fixtures/classes'
   require_relative 'shared/ole_method'
 
@@ -10,6 +8,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole/ole_methods_spec.rb
+++ b/library/win32ole/win32ole/ole_methods_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require_relative '../fixtures/classes'
 
   describe "WIN32OLE#ole_methods" do
@@ -21,6 +19,4 @@ platform_is :windows do
       @dict.ole_methods.map { |m| m.name }.include?('AddRef').should be_true
     end
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole/ole_obj_help_spec.rb
+++ b/library/win32ole/win32ole/ole_obj_help_spec.rb
@@ -1,8 +1,6 @@
 require_relative "../../../spec_helper"
 
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require_relative '../fixtures/classes'
 
   describe "WIN32OLE#ole_obj_help" do
@@ -18,6 +16,4 @@ platform_is :windows do
       @dict.ole_obj_help.kind_of?(WIN32OLE_TYPE).should be_true
     end
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole/ole_put_methods_spec.rb
+++ b/library/win32ole/win32ole/ole_put_methods_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require_relative '../fixtures/classes'
 
   describe "WIN32OLE#ole_put_methods" do
@@ -21,6 +19,4 @@ platform_is :windows do
       @dict.ole_put_methods.map { |m| m.name }.include?('Key').should be_true
     end
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole/setproperty_spec.rb
+++ b/library/win32ole/win32ole/setproperty_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require_relative '../fixtures/classes'
   require_relative 'shared/setproperty'
 
@@ -10,6 +8,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_event/new_spec.rb
+++ b/library/win32ole/win32ole_event/new_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require_relative '../fixtures/classes'
 
   guard -> { WIN32OLESpecs::MSXML_AVAILABLE } do
@@ -33,6 +31,4 @@ platform_is :windows do
       end
     end
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_event/on_event_spec.rb
+++ b/library/win32ole/win32ole_event/on_event_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require_relative '../fixtures/classes'
   guard -> { WIN32OLESpecs::MSXML_AVAILABLE } do
 
@@ -70,6 +68,4 @@ platform_is :windows do
       end
     end
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_method/dispid_spec.rb
+++ b/library/win32ole/win32ole_method/dispid_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_METHOD#dispid" do
@@ -20,6 +18,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_method/event_interface_spec.rb
+++ b/library/win32ole/win32ole_method/event_interface_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require_relative '../fixtures/classes'
   guard -> { WIN32OLESpecs::SYSTEM_MONITOR_CONTROL_AVAILABLE } do
 
@@ -28,6 +26,4 @@ platform_is :windows do
     end
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_method/event_spec.rb
+++ b/library/win32ole/win32ole_method/event_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require_relative '../fixtures/classes'
   guard -> { WIN32OLESpecs::SYSTEM_MONITOR_CONTROL_AVAILABLE } do
 
@@ -22,6 +20,4 @@ platform_is :windows do
     end
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_method/helpcontext_spec.rb
+++ b/library/win32ole/win32ole_method/helpcontext_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_METHOD#helpcontext" do
@@ -26,6 +24,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_method/helpfile_spec.rb
+++ b/library/win32ole/win32ole_method/helpfile_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_METHOD#helpfile" do
@@ -20,6 +18,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_method/helpstring_spec.rb
+++ b/library/win32ole/win32ole_method/helpstring_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_METHOD#helpstring" do
@@ -20,6 +18,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_method/invkind_spec.rb
+++ b/library/win32ole/win32ole_method/invkind_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_METHOD#invkind" do
@@ -20,6 +18,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_method/invoke_kind_spec.rb
+++ b/library/win32ole/win32ole_method/invoke_kind_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_METHOD#invoke_kind" do
@@ -20,6 +18,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_method/name_spec.rb
+++ b/library/win32ole/win32ole_method/name_spec.rb
@@ -2,8 +2,6 @@ require_relative "../../../spec_helper"
 require_relative 'shared/name'
 
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_METHOD#name" do
@@ -11,6 +9,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_method/new_spec.rb
+++ b/library/win32ole/win32ole_method/new_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_METHOD.new" do
@@ -33,6 +31,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_method/offset_vtbl_spec.rb
+++ b/library/win32ole/win32ole_method/offset_vtbl_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_METHOD#offset_vtbl" do
@@ -21,6 +19,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_method/params_spec.rb
+++ b/library/win32ole/win32ole_method/params_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_METHOD#params" do
@@ -28,6 +26,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_method/return_type_detail_spec.rb
+++ b/library/win32ole/win32ole_method/return_type_detail_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_METHOD#return_type_detail" do
@@ -21,6 +19,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_method/return_type_spec.rb
+++ b/library/win32ole/win32ole_method/return_type_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_METHOD#return_type" do
@@ -20,6 +18,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_method/return_vtype_spec.rb
+++ b/library/win32ole/win32ole_method/return_vtype_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_METHOD#return_vtype" do
@@ -20,6 +18,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_method/size_opt_params_spec.rb
+++ b/library/win32ole/win32ole_method/size_opt_params_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_METHOD#size_opt_params" do
@@ -20,6 +18,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_method/size_params_spec.rb
+++ b/library/win32ole/win32ole_method/size_params_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_METHOD#size_params" do
@@ -20,6 +18,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_method/to_s_spec.rb
+++ b/library/win32ole/win32ole_method/to_s_spec.rb
@@ -2,8 +2,6 @@ require_relative "../../../spec_helper"
 require_relative 'shared/name'
 
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_METHOD#name" do
@@ -11,6 +9,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_method/visible_spec.rb
+++ b/library/win32ole/win32ole_method/visible_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_METHOD#visible?" do
@@ -20,6 +18,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_param/default_spec.rb
+++ b/library/win32ole/win32ole_param/default_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_PARAM#default" do
@@ -31,6 +29,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_param/input_spec.rb
+++ b/library/win32ole/win32ole_param/input_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_PARAM#input?" do
@@ -21,6 +19,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_param/name_spec.rb
+++ b/library/win32ole/win32ole_param/name_spec.rb
@@ -2,8 +2,6 @@ require_relative "../../../spec_helper"
 require_relative 'shared/name'
 
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_PARAM#name" do
@@ -11,6 +9,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_param/ole_type_detail_spec.rb
+++ b/library/win32ole/win32ole_param/ole_type_detail_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_PARAM#ole_type_detail" do
@@ -21,6 +19,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_param/ole_type_spec.rb
+++ b/library/win32ole/win32ole_param/ole_type_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_PARAM#ole_type" do
@@ -21,6 +19,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_param/optional_spec.rb
+++ b/library/win32ole/win32ole_param/optional_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_PARAM#optional?" do
@@ -21,6 +19,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_param/retval_spec.rb
+++ b/library/win32ole/win32ole_param/retval_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_PARAM#retval?" do
@@ -21,6 +19,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_param/to_s_spec.rb
+++ b/library/win32ole/win32ole_param/to_s_spec.rb
@@ -2,8 +2,6 @@ require_relative "../../../spec_helper"
 require_relative 'shared/name'
 
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_PARAM#to_s" do
@@ -11,6 +9,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_type/guid_spec.rb
+++ b/library/win32ole/win32ole_type/guid_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_TYPE#guid for Shell Controls" do
@@ -18,6 +16,4 @@ platform_is :windows do
     end
 
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_type/helpcontext_spec.rb
+++ b/library/win32ole/win32ole_type/helpcontext_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_TYPE#helpcontext for Shell Controls" do
@@ -18,6 +16,4 @@ platform_is :windows do
     end
 
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_type/helpfile_spec.rb
+++ b/library/win32ole/win32ole_type/helpfile_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_TYPE#helpfile for Shell Controls" do
@@ -18,6 +16,4 @@ platform_is :windows do
     end
 
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_type/helpstring_spec.rb
+++ b/library/win32ole/win32ole_type/helpstring_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_TYPE#helpstring for Shell Controls" do
@@ -18,6 +16,4 @@ platform_is :windows do
     end
 
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_type/major_version_spec.rb
+++ b/library/win32ole/win32ole_type/major_version_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_TYPE#major_version for Shell Controls" do
@@ -18,6 +16,4 @@ platform_is :windows do
     end
 
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_type/minor_version_spec.rb
+++ b/library/win32ole/win32ole_type/minor_version_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_TYPE#minor_version for Shell Controls" do
@@ -18,6 +16,4 @@ platform_is :windows do
     end
 
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_type/name_spec.rb
+++ b/library/win32ole/win32ole_type/name_spec.rb
@@ -2,8 +2,6 @@ require_relative "../../../spec_helper"
 require_relative 'shared/name'
 
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_TYPE#name" do
@@ -11,6 +9,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_type/new_spec.rb
+++ b/library/win32ole/win32ole_type/new_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_TYPE.new" do
@@ -40,6 +38,4 @@ platform_is :windows do
     end
 
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_type/ole_classes_spec.rb
+++ b/library/win32ole/win32ole_type/ole_classes_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_TYPE.ole_classes for Shell Controls" do
@@ -18,6 +16,4 @@ platform_is :windows do
     end
 
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_type/ole_methods_spec.rb
+++ b/library/win32ole/win32ole_type/ole_methods_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_TYPE#ole_methods for Shell Controls" do
@@ -18,6 +16,4 @@ platform_is :windows do
     end
 
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_type/ole_type_spec.rb
+++ b/library/win32ole/win32ole_type/ole_type_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_TYPE#ole_type for Shell Controls" do
@@ -18,6 +16,4 @@ platform_is :windows do
     end
 
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_type/progid_spec.rb
+++ b/library/win32ole/win32ole_type/progid_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_TYPE#progid for Shell Controls" do
@@ -18,6 +16,4 @@ platform_is :windows do
     end
 
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_type/progids_spec.rb
+++ b/library/win32ole/win32ole_type/progids_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_TYPE.progids" do
@@ -14,6 +12,4 @@ platform_is :windows do
     end
 
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_type/src_type_spec.rb
+++ b/library/win32ole/win32ole_type/src_type_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_TYPE#src_type for Shell Controls" do
@@ -18,6 +16,4 @@ platform_is :windows do
     end
 
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_type/to_s_spec.rb
+++ b/library/win32ole/win32ole_type/to_s_spec.rb
@@ -2,8 +2,6 @@ require_relative "../../../spec_helper"
 require_relative 'shared/name'
 
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_TYPE#to_s" do
@@ -11,6 +9,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_type/typekind_spec.rb
+++ b/library/win32ole/win32ole_type/typekind_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_TYPE#typekind for Shell Controls" do
@@ -18,6 +16,4 @@ platform_is :windows do
     end
 
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_type/typelibs_spec.rb
+++ b/library/win32ole/win32ole_type/typelibs_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_TYPE.typelibs for Shell Controls" do
@@ -22,6 +20,4 @@ platform_is :windows do
     end
 
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_type/variables_spec.rb
+++ b/library/win32ole/win32ole_type/variables_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_TYPE#variables for Shell Controls" do
@@ -18,6 +16,4 @@ platform_is :windows do
     end
 
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_type/visible_spec.rb
+++ b/library/win32ole/win32ole_type/visible_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_TYPE#visible? for Shell Controls" do
@@ -18,6 +16,4 @@ platform_is :windows do
     end
 
   end
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_variable/name_spec.rb
+++ b/library/win32ole/win32ole_variable/name_spec.rb
@@ -2,8 +2,6 @@ require_relative "../../../spec_helper"
 require_relative 'shared/name'
 
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_VARIABLE#name" do
@@ -11,6 +9,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_variable/ole_type_detail_spec.rb
+++ b/library/win32ole/win32ole_variable/ole_type_detail_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_VARIABLE#ole_type_detail" do
@@ -19,6 +17,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_variable/ole_type_spec.rb
+++ b/library/win32ole/win32ole_variable/ole_type_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_VARIABLE#ole_type" do
@@ -18,6 +16,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_variable/to_s_spec.rb
+++ b/library/win32ole/win32ole_variable/to_s_spec.rb
@@ -2,8 +2,6 @@ require_relative "../../../spec_helper"
 require_relative 'shared/name'
 
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_VARIABLE#to_s" do
@@ -11,6 +9,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_variable/value_spec.rb
+++ b/library/win32ole/win32ole_variable/value_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_VARIABLE#value" do
@@ -19,6 +17,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_variable/variable_kind_spec.rb
+++ b/library/win32ole/win32ole_variable/variable_kind_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_VARIABLE#variable_kind" do
@@ -19,6 +17,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_variable/varkind_spec.rb
+++ b/library/win32ole/win32ole_variable/varkind_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_VARIABLE#varkind" do
@@ -19,6 +17,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end

--- a/library/win32ole/win32ole_variable/visible_spec.rb
+++ b/library/win32ole/win32ole_variable/visible_spec.rb
@@ -1,7 +1,5 @@
 require_relative "../../../spec_helper"
 platform_is :windows do
-  verbose, $VERBOSE = $VERBOSE, nil
-
   require 'win32ole'
 
   describe "WIN32OLE_VARIABLE#visible?" do
@@ -18,6 +16,4 @@ platform_is :windows do
 
   end
 
-ensure
-  $VERBOSE = verbose
 end


### PR DESCRIPTION
Example of failed spec:

```
An exception occurred during: WIN32OLE#_getproperty gets value
D:/a/spec/spec/library/win32ole/win32ole/_getproperty_spec.rb:12
WIN32OLE#_getproperty gets value ERROR
LeakError: Globals changed: {:verbose=>false, :debug=>false} to {:verbose=>nil, :debug=>false}
D:/a/spec/spec/library/win32ole/win32ole/_getproperty_spec.rb:7:in `block in <top (required)>'
D:/a/spec/spec/library/win32ole/win32ole/_getproperty_spec.rb:2:in `<top (required)>'

```