### PR TITLE
Update quotes for heredocs with embedded Ruby with \n

### DIFF
--- a/core/binding/shared/clone.rb
+++ b/core/binding/shared/clone.rb
@@ -40,7 +40,7 @@ describe :binding_clone, shared: true do
     end
 
     it "copies the finalizer" do
-      code = <<-RUBY
+      code = <<-'RUBY'
         obj = binding
 
         ObjectSpace.define_finalizer(obj, Proc.new { STDOUT.write "finalized\n" })

--- a/core/method/shared/dup.rb
+++ b/core/method/shared/dup.rb
@@ -16,7 +16,7 @@ describe :method_dup, shared: true do
     end
 
     it "copies the finalizer" do
-      code = <<-RUBY
+      code = <<-'RUBY'
         obj = Object.new.method(:method)
 
         ObjectSpace.define_finalizer(obj, Proc.new { STDOUT.write "finalized\n" })

--- a/core/objectspace/define_finalizer_spec.rb
+++ b/core/objectspace/define_finalizer_spec.rb
@@ -156,7 +156,7 @@ describe "ObjectSpace.define_finalizer" do
   end
 
   it "allows multiple finalizers with different 'callables' to be defined" do
-    code = <<-RUBY
+    code = <<-'RUBY'
       obj = Object.new
 
       ObjectSpace.define_finalizer(obj, Proc.new { STDOUT.write "finalized1\n" })

--- a/core/proc/shared/dup.rb
+++ b/core/proc/shared/dup.rb
@@ -25,7 +25,7 @@ describe :proc_dup, shared: true do
     end
 
     it "copies the finalizer" do
-      code = <<-RUBY
+      code = <<-'RUBY'
         obj = Proc.new { }
 
         ObjectSpace.define_finalizer(obj, Proc.new { STDOUT.write "finalized\n" })

--- a/core/unboundmethod/shared/dup.rb
+++ b/core/unboundmethod/shared/dup.rb
@@ -16,7 +16,7 @@ describe :unboundmethod_dup, shared: true do
     end
 
     it "copies the finalizer" do
-      code = <<-RUBY
+      code = <<-'RUBY'
         obj = Class.instance_method(:instance_method)
 
         ObjectSpace.define_finalizer(obj, Proc.new { STDOUT.write "finalized\n" })


### PR DESCRIPTION
The default behaviour for heredocs is the double quote style of quotes, which means the generated code looks like:

    ObjectSpace.define_finalizer(obj, Proc.new { STDOUT.write "finalized
    " })

It works, but it's ugly.