### PR TITLE
Remove some additional version guards for Ruby 3.0.x

### DIFF
--- a/core/hash/transform_keys_spec.rb
+++ b/core/hash/transform_keys_spec.rb
@@ -76,24 +76,12 @@ describe "Hash#transform_keys!" do
     @hash.should == { b: 1, c: 2, d: 3, e: 4 }
   end
 
-  ruby_version_is ""..."3.0.2" do # https://bugs.ruby-lang.org/issues/17735
-    it "returns the processed keys if we break from the block" do
-      @hash.transform_keys! do |v|
-        break if v == :c
-        v.succ
-      end
-      @hash.should == { b: 1, c: 2 }
+  it "returns the processed keys and non evaluated keys if we break from the block" do
+    @hash.transform_keys! do |v|
+      break if v == :c
+      v.succ
     end
-  end
-
-  ruby_version_is "3.0.2" do
-    it "returns the processed keys and non evaluated keys if we break from the block" do
-      @hash.transform_keys! do |v|
-        break if v == :c
-        v.succ
-      end
-      @hash.should == { b: 1, c: 2, d: 4 }
-    end
+    @hash.should == { b: 1, c: 2, d: 4 }
   end
 
   it "keeps later pair if new keys conflict" do

--- a/core/io/readpartial_spec.rb
+++ b/core/io/readpartial_spec.rb
@@ -93,12 +93,10 @@ describe "IO#readpartial" do
     @rd.readpartial(0).should == ""
   end
 
-  ruby_bug "#18421", ""..."3.0.4" do
-    it "clears and returns the given buffer if the length argument is 0" do
-      buffer = +"existing content"
-      @rd.readpartial(0, buffer).should == buffer
-      buffer.should == ""
-    end
+  it "clears and returns the given buffer if the length argument is 0" do
+    buffer = +"existing content"
+    @rd.readpartial(0, buffer).should == buffer
+    buffer.should == ""
   end
 
   it "preserves the encoding of the given buffer" do


### PR DESCRIPTION
These were specific subversions, I guess the grep regex did not match those.