### PR TITLE
Switch to Ruby 3.4.2 and 3.2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu, macos, windows ]
-        ruby: [ 3.1.6, 3.2.6, 3.3.7, 3.4.1 ]
+        ruby: [ 3.1.6, 3.2.7, 3.3.7, 3.4.2 ]
         rubyopt: [""]
         include:
           - os: ubuntu

--- a/optional/capi/ext/finalizer_spec.c
+++ b/optional/capi/ext/finalizer_spec.c
@@ -10,13 +10,7 @@ static VALUE define_finalizer(VALUE self, VALUE obj, VALUE finalizer) {
 }
 
 static VALUE undefine_finalizer(VALUE self, VALUE obj) {
-// Ruby 3.4.0 and 3.4.1 have a bug where rb_undefine_finalizer is missing
-// See: https://bugs.ruby-lang.org/issues/20981
-#if RUBY_API_VERSION_CODE == 30400 && (RUBY_VERSION_TEENY == 0 || RUBY_VERSION_TEENY == 1)
-  return Qnil;
-#else
   return rb_undefine_finalizer(obj);
-#endif
 }
 
 void Init_finalizer_spec(void) {


### PR DESCRIPTION
Please take extra note of the second commit: the function `rb_undefine_finalizer` should have been enabled again in Ruby 3.4.2 (it was missing in 3.4.0/3.4.1), but I could not find a way to determine this compile time. If someone more familiar with the MRI internals could take a look at it, please do.