### PR TITLE
Rewrite specs for String#to_c with special float values

### DIFF
--- a/core/string/to_c_spec.rb
+++ b/core/string/to_c_spec.rb
@@ -18,13 +18,17 @@ describe "String#to_c" do
     end
   end
 
-  it "understands Float::INFINITY" do
-    'Infinity'.to_c.should == Complex(0, 1)
-    '-Infinity'.to_c.should == Complex(0, -1)
-  end
+  context "it treats special float value strings as characters" do
+    it "parses any string that starts with 'I' as 1i" do
+      'Infinity'.to_c.should == Complex(0, 1)
+      '-Infinity'.to_c.should == Complex(0, -1)
+      'Insecure'.to_c.should == Complex(0, 1)
+      '-Insecure'.to_c.should == Complex(0, -1)
+    end
 
-  it "understands Float::NAN" do
-    'NaN'.to_c.should == Complex(0, 0)
+    it "does not parse any numeric information in 'NaN'" do
+      'NaN'.to_c.should == Complex(0, 0)
+    end
   end
 
   it "allows null-byte" do


### PR DESCRIPTION
The old description said it understands these values, but this is not true. The only reasons Infinity get parsed as non-zero is because it starts with an "I", which is interpreted as 1i and that's where the parsing stops. Any other word that starts with an "I" behaves the same.

The name "special float values" has been borrowed from the string/to_f_spec.rb