### PR TITLE
Remove Solaris platform

### DIFF
--- a/core/dir/home_spec.rb
+++ b/core/dir/home_spec.rb
@@ -60,13 +60,7 @@ describe "Dir.home" do
   end
 
   describe "when called with the current user name" do
-    platform_is :solaris do
-      it "returns the named user's home directory from the user database" do
-        Dir.home(ENV['USER']).should == `getent passwd #{ENV['USER']}|cut -d: -f6`.chomp
-      end
-    end
-
-    platform_is_not :windows, :solaris, :android, :wasi do
+    platform_is_not :windows, :android, :wasi do
       it "returns the named user's home directory, from the user database" do
         Dir.home(ENV['USER']).should == `echo ~#{ENV['USER']}`.chomp
       end

--- a/core/dir/shared/delete.rb
+++ b/core/dir/shared/delete.rb
@@ -17,20 +17,10 @@ describe :dir_delete, shared: true do
     Dir.send(@method, p)
   end
 
-  platform_is_not :solaris do
-    it "raises an Errno::ENOTEMPTY when trying to remove a nonempty directory" do
-      -> do
-        Dir.send @method, DirSpecs.mock_rmdir("nonempty")
-      end.should raise_error(Errno::ENOTEMPTY)
-    end
-  end
-
-  platform_is :solaris do
-    it "raises an Errno::EEXIST when trying to remove a nonempty directory" do
-      -> do
-        Dir.send @method, DirSpecs.mock_rmdir("nonempty")
-      end.should raise_error(Errno::EEXIST)
-    end
+  it "raises an Errno::ENOTEMPTY when trying to remove a nonempty directory" do
+    -> do
+      Dir.send @method, DirSpecs.mock_rmdir("nonempty")
+    end.should raise_error(Errno::ENOTEMPTY)
   end
 
   it "raises an Errno::ENOENT when trying to remove a non-existing directory" do

--- a/core/file/empty_spec.rb
+++ b/core/file/empty_spec.rb
@@ -4,10 +4,4 @@ require_relative '../../shared/file/zero'
 describe "File.empty?" do
   it_behaves_like :file_zero, :empty?, File
   it_behaves_like :file_zero_missing, :empty?, File
-
-  platform_is :solaris do
-    it "returns false for /dev/null" do
-      File.empty?('/dev/null').should == true
-    end
-  end
 end

--- a/core/file/flock_spec.rb
+++ b/core/file/flock_spec.rb
@@ -72,35 +72,3 @@ describe "File#flock" do
     end
   end
 end
-
-platform_is :solaris do
-  describe "File#flock on Solaris" do
-    before :each do
-      @name = tmp("flock_test")
-      touch(@name)
-
-      @read_file = File.open @name, "r"
-      @write_file = File.open @name, "w"
-    end
-
-    after :each do
-      @read_file.flock File::LOCK_UN
-      @read_file.close
-      @write_file.flock File::LOCK_UN
-      @write_file.close
-      rm_r @name
-    end
-
-    it "fails with EBADF acquiring exclusive lock on read-only File" do
-      -> do
-        @read_file.flock File::LOCK_EX
-      end.should raise_error(Errno::EBADF)
-    end
-
-    it "fails with EBADF acquiring shared lock on read-only File" do
-      -> do
-        @write_file.flock File::LOCK_SH
-      end.should raise_error(Errno::EBADF)
-    end
-  end
-end

--- a/core/file/lchmod_spec.rb
+++ b/core/file/lchmod_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../spec_helper'
 
 describe "File.lchmod" do
-  platform_is_not :linux, :windows, :openbsd, :solaris, :aix do
+  platform_is_not :linux, :windows, :openbsd, :aix do
     before :each do
       @fname = tmp('file_chmod_test')
       @lname = @fname + '.lnk'

--- a/core/file/setuid_spec.rb
+++ b/core/file/setuid_spec.rb
@@ -26,10 +26,6 @@ describe "File.setuid?" do
 
   platform_is_not :windows do
     it "returns true when the gid bit is set" do
-      platform_is :solaris do
-        # Solaris requires execute bit before setting suid
-        system "chmod u+x #{@name}"
-      end
       system "chmod u+s #{@name}"
 
       File.setuid?(@name).should == true

--- a/core/file/stat/rdev_major_spec.rb
+++ b/core/file/stat/rdev_major_spec.rb
@@ -2,19 +2,12 @@ require_relative '../../../spec_helper'
 
 describe "File::Stat#rdev_major" do
   before :each do
-    platform_is :solaris do
-      @name = "/dev/zfs"
-    end
-    platform_is_not :solaris do
-      @name = tmp("file.txt")
-      touch(@name)
-    end
+    @name = tmp("file.txt")
+    touch(@name)
   end
 
   after :each do
-    platform_is_not :solaris do
-      rm_r @name
-    end
+    rm_r @name
   end
 
   platform_is_not :windows do

--- a/core/file/stat/rdev_minor_spec.rb
+++ b/core/file/stat/rdev_minor_spec.rb
@@ -2,19 +2,12 @@ require_relative '../../../spec_helper'
 
 describe "File::Stat#rdev_minor" do
   before :each do
-    platform_is :solaris do
-      @name = "/dev/zfs"
-    end
-    platform_is_not :solaris do
-      @name = tmp("file.txt")
-      touch(@name)
-    end
+    @name = tmp("file.txt")
+    touch(@name)
   end
 
   after :each do
-    platform_is_not :solaris do
-      rm_r @name
-    end
+    rm_r @name
   end
 
   platform_is_not :windows do

--- a/core/file/zero_spec.rb
+++ b/core/file/zero_spec.rb
@@ -4,10 +4,4 @@ require_relative '../../shared/file/zero'
 describe "File.zero?" do
   it_behaves_like :file_zero, :zero?, File
   it_behaves_like :file_zero_missing, :zero?, File
-
-  platform_is :solaris do
-    it "returns false for /dev/null" do
-      File.zero?('/dev/null').should == true
-    end
-  end
 end

--- a/core/filetest/zero_spec.rb
+++ b/core/filetest/zero_spec.rb
@@ -4,10 +4,4 @@ require_relative '../../shared/file/zero'
 describe "FileTest.zero?" do
   it_behaves_like :file_zero, :zero?, FileTest
   it_behaves_like :file_zero_missing, :zero?, FileTest
-
-  platform_is :solaris do
-    it "returns false for /dev/null" do
-      File.zero?('/dev/null').should == true
-    end
-  end
 end

--- a/core/process/fixtures/clocks.rb
+++ b/core/process/fixtures/clocks.rb
@@ -2,7 +2,7 @@ module ProcessSpecs
   def self.clock_constants
     clocks = []
 
-    platform_is_not :windows, :solaris do
+    platform_is_not :windows do
       clocks += Process.constants.select { |c| c.to_s.start_with?('CLOCK_') }
 
       # These require CAP_WAKE_ALARM and are not documented in

--- a/core/process/setrlimit_spec.rb
+++ b/core/process/setrlimit_spec.rb
@@ -73,20 +73,18 @@ describe "Process.setrlimit" do
         Process.setrlimit(:STACK, *Process.getrlimit(Process::RLIMIT_STACK)).should be_nil
       end
 
-      platform_is_not :solaris, :aix do
+      platform_is_not :aix do
         it "coerces :MEMLOCK into RLIMIT_MEMLOCK" do
           Process.setrlimit(:MEMLOCK, *Process.getrlimit(Process::RLIMIT_MEMLOCK)).should be_nil
         end
       end
 
-      platform_is_not :solaris do
-        it "coerces :NPROC into RLIMIT_NPROC" do
-          Process.setrlimit(:NPROC, *Process.getrlimit(Process::RLIMIT_NPROC)).should be_nil
-        end
+      it "coerces :NPROC into RLIMIT_NPROC" do
+        Process.setrlimit(:NPROC, *Process.getrlimit(Process::RLIMIT_NPROC)).should be_nil
+      end
 
-        it "coerces :RSS into RLIMIT_RSS" do
-          Process.setrlimit(:RSS, *Process.getrlimit(Process::RLIMIT_RSS)).should be_nil
-        end
+      it "coerces :RSS into RLIMIT_RSS" do
+        Process.setrlimit(:RSS, *Process.getrlimit(Process::RLIMIT_RSS)).should be_nil
       end
 
       platform_is :netbsd, :freebsd do
@@ -155,20 +153,18 @@ describe "Process.setrlimit" do
         Process.setrlimit("STACK", *Process.getrlimit(Process::RLIMIT_STACK)).should be_nil
       end
 
-      platform_is_not :solaris, :aix do
+      platform_is_not :aix do
         it "coerces 'MEMLOCK' into RLIMIT_MEMLOCK" do
           Process.setrlimit("MEMLOCK", *Process.getrlimit(Process::RLIMIT_MEMLOCK)).should be_nil
         end
       end
 
-      platform_is_not :solaris do
-        it "coerces 'NPROC' into RLIMIT_NPROC" do
-          Process.setrlimit("NPROC", *Process.getrlimit(Process::RLIMIT_NPROC)).should be_nil
-        end
+      it "coerces 'NPROC' into RLIMIT_NPROC" do
+        Process.setrlimit("NPROC", *Process.getrlimit(Process::RLIMIT_NPROC)).should be_nil
+      end
 
-        it "coerces 'RSS' into RLIMIT_RSS" do
-          Process.setrlimit("RSS", *Process.getrlimit(Process::RLIMIT_RSS)).should be_nil
-        end
+      it "coerces 'RSS' into RLIMIT_RSS" do
+        Process.setrlimit("RSS", *Process.getrlimit(Process::RLIMIT_RSS)).should be_nil
       end
 
       platform_is :netbsd, :freebsd do

--- a/core/rational/exponent_spec.rb
+++ b/core/rational/exponent_spec.rb
@@ -228,11 +228,9 @@ describe "Rational#**" do
     -> { Rational(0, 1) ** Rational(-3, 2) }.should raise_error(ZeroDivisionError, "divided by 0")
   end
 
-  platform_is_not :solaris do # See https://github.com/ruby/spec/issues/134
-    it "returns Infinity for Rational(0, 1) passed a negative Float" do
-      [-1.0, -3.0, -3.14].each do |exponent|
-        (Rational(0, 1) ** exponent).infinite?.should == 1
-      end
+  it "returns Infinity for Rational(0, 1) passed a negative Float" do
+    [-1.0, -3.0, -3.14].each do |exponent|
+      (Rational(0, 1) ** exponent).infinite?.should == 1
     end
   end
 end

--- a/library/socket/addrinfo/getaddrinfo_spec.rb
+++ b/library/socket/addrinfo/getaddrinfo_spec.rb
@@ -73,19 +73,15 @@ describe 'Addrinfo.getaddrinfo' do
     end
   end
 
-  platform_is_not :'solaris2.10' do # i386-solaris
-    it 'sets a custom socket protocol of the Addrinfo instances' do
-      array = Addrinfo.getaddrinfo('127.0.0.1', 80, nil, nil, Socket::IPPROTO_UDP)
+  it 'sets a custom socket protocol of the Addrinfo instances' do
+    array = Addrinfo.getaddrinfo('127.0.0.1', 80, nil, nil, Socket::IPPROTO_UDP)
 
-      array[0].protocol.should == Socket::IPPROTO_UDP
-    end
+    array[0].protocol.should == Socket::IPPROTO_UDP
   end
 
-  platform_is_not :solaris do
-    it 'sets the canonical name when AI_CANONNAME is given as a flag' do
-      array = Addrinfo.getaddrinfo('localhost', 80, nil, nil, nil, Socket::AI_CANONNAME)
+  it 'sets the canonical name when AI_CANONNAME is given as a flag' do
+    array = Addrinfo.getaddrinfo('localhost', 80, nil, nil, nil, Socket::AI_CANONNAME)
 
-      array[0].canonname.should be_an_instance_of(String)
-    end
+    array[0].canonname.should be_an_instance_of(String)
   end
 end

--- a/library/socket/addrinfo/initialize_spec.rb
+++ b/library/socket/addrinfo/initialize_spec.rb
@@ -362,7 +362,7 @@ describe "Addrinfo#initialize" do
           end
         end
 
-        platform_is_not :windows, :aix, :solaris do
+        platform_is_not :windows, :aix do
           (Socket.constants.grep(/^IPPROTO/) - valid).each do |type|
             it "raises SocketError when using #{type}" do
               value = Socket.const_get(type)
@@ -390,7 +390,7 @@ describe "Addrinfo#initialize" do
           end
         end
 
-        platform_is_not :windows, :aix, :solaris do
+        platform_is_not :windows, :aix do
           (Socket.constants.grep(/^IPPROTO/) - valid).each do |type|
             it "raises SocketError when using #{type}" do
               value = Socket.const_get(type)
@@ -495,7 +495,7 @@ describe "Addrinfo#initialize" do
           end
         end
 
-        platform_is_not :windows, :aix, :solaris do
+        platform_is_not :windows, :aix do
           (Socket.constants.grep(/^IPPROTO/) - valid).each do |type|
             it "raises SocketError when using #{type}" do
               value = Socket.const_get(type)

--- a/library/socket/addrinfo/marshal_dump_spec.rb
+++ b/library/socket/addrinfo/marshal_dump_spec.rb
@@ -32,10 +32,8 @@ describe 'Addrinfo#marshal_dump' do
         @array[3].should == 'SOCK_STREAM'
       end
 
-      platform_is_not :'solaris2.10' do # i386-solaris
-        it 'includes the protocol as the 5th value' do
-          @array[4].should == 'IPPROTO_TCP'
-        end
+      it 'includes the protocol as the 5th value' do
+        @array[4].should == 'IPPROTO_TCP'
       end
 
       it 'includes the canonical name as the 6th value' do

--- a/library/socket/addrinfo/udp_spec.rb
+++ b/library/socket/addrinfo/udp_spec.rb
@@ -27,10 +27,8 @@ describe 'Addrinfo.udp' do
       Addrinfo.udp(ip_address, 80).socktype.should == Socket::SOCK_DGRAM
     end
 
-    platform_is_not :solaris do
-      it 'sets the socket protocol' do
-        Addrinfo.udp(ip_address, 80).protocol.should == Socket::IPPROTO_UDP
-      end
+    it 'sets the socket protocol' do
+      Addrinfo.udp(ip_address, 80).protocol.should == Socket::IPPROTO_UDP
     end
   end
 end

--- a/library/socket/ancillarydata/initialize_spec.rb
+++ b/library/socket/ancillarydata/initialize_spec.rb
@@ -106,7 +106,7 @@ with_feature :ancillary_data do
         Socket::AncillaryData.new(:INET, :SOCKET, :RIGHTS, '').type.should == Socket::SCM_RIGHTS
       end
 
-      platform_is_not :"solaris2.10", :aix do
+      platform_is_not :aix do
         it 'sets the type to SCM_TIMESTAMP when using :TIMESTAMP as the type argument' do
           Socket::AncillaryData.new(:INET, :SOCKET, :TIMESTAMP, '').type.should == Socket::SCM_TIMESTAMP
         end

--- a/library/socket/ancillarydata/unix_rights_spec.rb
+++ b/library/socket/ancillarydata/unix_rights_spec.rb
@@ -50,7 +50,7 @@ with_feature :ancillary_data do
       -> { data.unix_rights }.should raise_error(TypeError)
     end
 
-    platform_is_not :"solaris2.10", :aix do
+    platform_is_not :aix do
       it 'raises TypeError when the type is not SCM_RIGHTS' do
         data = Socket::AncillaryData.new(:INET, :SOCKET, :TIMESTAMP, '')
 

--- a/library/socket/basicsocket/recv_spec.rb
+++ b/library/socket/basicsocket/recv_spec.rb
@@ -32,28 +32,26 @@ describe "BasicSocket#recv" do
     ScratchPad.recorded.should == 'hello'
   end
 
-  platform_is_not :solaris do
-    it "accepts flags to specify unusual receiving behaviour" do
-      t = Thread.new do
-        client = @server.accept
+  it "accepts flags to specify unusual receiving behaviour" do
+    t = Thread.new do
+      client = @server.accept
 
-        # in-band data (TCP), doesn't receive the flag.
-        ScratchPad.record client.recv(10)
+      # in-band data (TCP), doesn't receive the flag.
+      ScratchPad.record client.recv(10)
 
-        # this recv is important (TODO: explain)
-        client.recv(10)
-        client.close
-      end
-      Thread.pass while t.status and t.status != "sleep"
-      t.status.should_not be_nil
-
-      socket = TCPSocket.new('127.0.0.1', @port)
-      socket.send('helloU', Socket::MSG_OOB)
-      socket.shutdown(1)
-      t.join
-      socket.close
-      ScratchPad.recorded.should == 'hello'
+      # this recv is important (TODO: explain)
+      client.recv(10)
+      client.close
     end
+    Thread.pass while t.status and t.status != "sleep"
+    t.status.should_not be_nil
+
+    socket = TCPSocket.new('127.0.0.1', @port)
+    socket.send('helloU', Socket::MSG_OOB)
+    socket.shutdown(1)
+    t.join
+    socket.close
+    ScratchPad.recorded.should == 'hello'
   end
 
   it "gets lines delimited with a custom separator"  do

--- a/library/socket/basicsocket/send_spec.rb
+++ b/library/socket/basicsocket/send_spec.rb
@@ -38,7 +38,7 @@ describe "BasicSocket#send" do
     data.should == 'hello'
   end
 
-  platform_is_not :solaris, :windows do
+  platform_is_not :windows do
     it "accepts flags to specify unusual sending behaviour" do
       data = nil
       peek_data = nil

--- a/library/socket/constants/constants_spec.rb
+++ b/library/socket/constants/constants_spec.rb
@@ -68,7 +68,7 @@ describe "Socket::Constants" do
     end
   end
 
-  platform_is_not :solaris, :windows, :aix, :android do
+  platform_is_not :windows, :aix, :android do
     it "defines multicast options" do
       consts = ["IP_MAX_MEMBERSHIPS"]
       consts.each do |c|

--- a/library/socket/shared/pack_sockaddr.rb
+++ b/library/socket/shared/pack_sockaddr.rb
@@ -22,11 +22,9 @@ describe :socket_pack_sockaddr_in, shared: true do
     Socket.unpack_sockaddr_in(sockaddr_in).should == [80, '0.0.0.0']
   end
 
-  platform_is_not :solaris do
-    it 'resolves the service name to a port' do
-      sockaddr_in = Socket.public_send(@method, 'http', '127.0.0.1')
-      Socket.unpack_sockaddr_in(sockaddr_in).should == [80, '127.0.0.1']
-    end
+  it 'resolves the service name to a port' do
+    sockaddr_in = Socket.public_send(@method, 'http', '127.0.0.1')
+    Socket.unpack_sockaddr_in(sockaddr_in).should == [80, '127.0.0.1']
   end
 
   describe 'using an IPv4 address' do
@@ -38,25 +36,12 @@ describe :socket_pack_sockaddr_in, shared: true do
     end
   end
 
-  platform_is_not :solaris do
-    describe 'using an IPv6 address' do
-      it 'returns a String of 28 bytes' do
-        str = Socket.public_send(@method, 80, '::1')
+  describe 'using an IPv6 address' do
+    it 'returns a String of 28 bytes' do
+      str = Socket.public_send(@method, 80, '::1')
 
-        str.should be_an_instance_of(String)
-        str.bytesize.should == 28
-      end
-    end
-  end
-
-  platform_is :solaris do
-    describe 'using an IPv6 address' do
-      it 'returns a String of 32 bytes' do
-        str = Socket.public_send(@method, 80, '::1')
-
-        str.should be_an_instance_of(String)
-        str.bytesize.should == 32
-      end
+      str.should be_an_instance_of(String)
+      str.bytesize.should == 28
     end
   end
 end

--- a/library/socket/socket/connect_nonblock_spec.rb
+++ b/library/socket/socket/connect_nonblock_spec.rb
@@ -16,42 +16,40 @@ describe "Socket#connect_nonblock" do
     @thread.join if @thread
   end
 
-  platform_is_not :solaris do
-    it "connects the socket to the remote side" do
-      port = nil
-      accept = false
-      @thread = Thread.new do
-        server = TCPServer.new(@hostname, 0)
-        port = server.addr[1]
-        Thread.pass until accept
-        conn = server.accept
-        conn << "hello!"
-        conn.close
-        server.close
-      end
-
-      Thread.pass until port
-
-      addr = Socket.sockaddr_in(port, @hostname)
-      begin
-        @socket.connect_nonblock(addr)
-      rescue Errno::EINPROGRESS
-      end
-
-      accept = true
-      IO.select nil, [@socket]
-
-      begin
-        @socket.connect_nonblock(addr)
-      rescue Errno::EISCONN
-        # Not all OS's use this errno, so we trap and ignore it
-      end
-
-      @socket.read(6).should == "hello!"
+  it "connects the socket to the remote side" do
+    port = nil
+    accept = false
+    @thread = Thread.new do
+      server = TCPServer.new(@hostname, 0)
+      port = server.addr[1]
+      Thread.pass until accept
+      conn = server.accept
+      conn << "hello!"
+      conn.close
+      server.close
     end
+
+    Thread.pass until port
+
+    addr = Socket.sockaddr_in(port, @hostname)
+    begin
+      @socket.connect_nonblock(addr)
+    rescue Errno::EINPROGRESS
+    end
+
+    accept = true
+    IO.select nil, [@socket]
+
+    begin
+      @socket.connect_nonblock(addr)
+    rescue Errno::EISCONN
+      # Not all OS's use this errno, so we trap and ignore it
+    end
+
+    @socket.read(6).should == "hello!"
   end
 
-  platform_is_not :freebsd, :solaris, :aix do
+  platform_is_not :freebsd, :aix do
     it "raises Errno::EINPROGRESS when the connect would block" do
       -> do
         @socket.connect_nonblock(@addr)
@@ -135,7 +133,7 @@ describe 'Socket#connect_nonblock' do
         end
       end
 
-      platform_is_not :freebsd, :solaris do
+      platform_is_not :freebsd do
         it 'raises IO:EINPROGRESSWaitWritable when the connection would block' do
           @server.bind(@sockaddr)
 

--- a/library/socket/socket/getaddrinfo_spec.rb
+++ b/library/socket/socket/getaddrinfo_spec.rb
@@ -11,7 +11,7 @@ describe "Socket.getaddrinfo" do
     BasicSocket.do_not_reverse_lookup = @do_not_reverse_lookup
   end
 
-  platform_is_not :solaris, :windows do
+  platform_is_not :windows do
     it "gets the address information" do
       expected = []
       # The check for AP_INET6's class is needed because ipaddr.rb adds

--- a/library/socket/socket/gethostbyaddr_spec.rb
+++ b/library/socket/socket/gethostbyaddr_spec.rb
@@ -18,11 +18,8 @@ describe 'Socket.gethostbyaddr' do
           @array = suppress_warning { Socket.gethostbyaddr(@addr) }
         end
 
-        # RubyCI Solaris 11x defines 127.0.0.1 as unstable11x
-        platform_is_not :"solaris2.11" do
-          it 'includes the hostname as the first value' do
-            @array[0].should == SocketSpecs.hostname_reverse_lookup
-          end
+        it 'includes the hostname as the first value' do
+          @array[0].should == SocketSpecs.hostname_reverse_lookup
         end
 
         it 'includes the aliases as the 2nd value' do

--- a/library/socket/socket/getifaddrs_spec.rb
+++ b/library/socket/socket/getifaddrs_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../spec_helper'
 
-platform_is_not :aix, :"solaris2.10" do
+platform_is_not :aix do
 describe 'Socket.getifaddrs' do
   before do
     @ifaddrs = Socket.getifaddrs

--- a/library/syslog/constants_spec.rb
+++ b/library/syslog/constants_spec.rb
@@ -4,7 +4,7 @@ platform_is_not :windows do
   require 'syslog'
 
   describe "Syslog::Constants" do
-    platform_is_not :windows, :solaris, :aix do
+    platform_is_not :windows, :aix do
       before :all do
         @constants = %w(LOG_AUTHPRIV LOG_USER LOG_LOCAL2 LOG_NOTICE LOG_NDELAY
                       LOG_SYSLOG LOG_ALERT LOG_FTP LOG_LOCAL5 LOG_ERR LOG_AUTH

--- a/library/syslog/log_spec.rb
+++ b/library/syslog/log_spec.rb
@@ -4,7 +4,7 @@ platform_is_not :windows do
   require 'syslog'
 
   describe "Syslog.log" do
-    platform_is_not :windows, :darwin, :solaris, :aix, :android do
+    platform_is_not :windows, :darwin, :aix, :android do
 
       before :each do
         Syslog.opened?.should be_false

--- a/library/syslog/shared/log.rb
+++ b/library/syslog/shared/log.rb
@@ -1,5 +1,5 @@
 describe :syslog_log, shared: true do
-  platform_is_not :windows, :darwin, :solaris, :aix, :android do
+  platform_is_not :windows, :darwin, :aix, :android do
     before :each do
       Syslog.opened?.should be_false
     end

--- a/optional/capi/kernel_spec.rb
+++ b/optional/capi/kernel_spec.rb
@@ -242,10 +242,8 @@ describe "C-API Kernel function" do
       @s.rb_yield(1) { break 73 }.should == 73
     end
 
-    platform_is_not :"solaris2.10" do # NOTE: i386-pc-solaris2.10
-      it "rb_yield through a callback to a block that breaks with a value returns the value" do
-        @s.rb_yield_indirected(1) { break 73 }.should == 73
-      end
+    it "rb_yield through a callback to a block that breaks with a value returns the value" do
+      @s.rb_yield_indirected(1) { break 73 }.should == 73
     end
 
     it "rb_yield to block passed to enumerator" do

--- a/shared/file/sticky.rb
+++ b/shared/file/sticky.rb
@@ -8,7 +8,7 @@ describe :file_sticky, shared: true do
     Dir.rmdir(@dir) if File.exist?(@dir)
   end
 
-  platform_is_not :windows, :darwin, :freebsd, :netbsd, :openbsd, :solaris, :aix do
+  platform_is_not :windows, :darwin, :freebsd, :netbsd, :openbsd, :aix do
     it "returns true if the named file has the sticky bit, otherwise false" do
       Dir.mkdir @dir, 01755
 


### PR DESCRIPTION
from https://github.com/ruby/ruby/pull/13037

Ruby CI is no longer support Solaris platform today. We don't need to maintain related code.