### PR TITLE
Add spec for StringScanner#pos with multi-byte character

### DIFF
--- a/library/stringscanner/shared/pos.rb
+++ b/library/stringscanner/shared/pos.rb
@@ -22,6 +22,13 @@ describe :strscan_pos, shared: true do
     @s.terminate
     @s.send(@method).should == @s.string.length
   end
+
+  it "is not multi-byte character sensitive" do
+    s = StringScanner.new("abcädeföghi")
+
+    s.scan_until(/ö/)
+    s.pos.should == 10
+  end
 end
 
 describe :strscan_pos_set, shared: true do


### PR DESCRIPTION
This is where this method differentiates from charpos.