### PR TITLE
Remove parenthesis for it_behaves_like calls

### DIFF
--- a/core/enumerable/filter_spec.rb
+++ b/core/enumerable/filter_spec.rb
@@ -3,5 +3,5 @@ require_relative 'fixtures/classes'
 require_relative 'shared/find_all'
 
 describe "Enumerable#filter" do
-  it_behaves_like(:enumerable_find_all, :filter)
+  it_behaves_like :enumerable_find_all, :filter
 end


### PR DESCRIPTION
These were only added once, remove them to keep the code consistent.