### PR TITLE
Add parse.y to specs runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
           - os: ubuntu
             ruby: 3.4.2
             rubyopt: "--enable-frozen-string-literal"
+          - os: ubuntu
+            ruby: 3.4.2
+            rubyopt: "--parser=parse.y"
 
     runs-on: ${{ matrix.os }}-latest
     steps:


### PR DESCRIPTION
Some tests check for syntax errors, we should run those with both official supported parsers.

I kept this on Ruby 3.4.2 instead of the latest 3.4.4 for consistency, we should probably update all CI jobs to the latest minor releases, but I kept that out of scope for this case.