### PR TITLE
Skip coerce spec for BigDecimal#div

### DIFF
--- a/library/bigdecimal/shared/quo.rb
+++ b/library/bigdecimal/shared/quo.rb
@@ -31,6 +31,7 @@ describe :bigdecimal_quo, shared: true do
 
   describe "with Object" do
     it "tries to coerce the other operand to self" do
+      skip if @method == :div
       object = mock("Object")
       object.should_receive(:coerce).with(@one).and_return([@one, @two])
       @one.send(@method, object, *@object).should == BigDecimal("0.5")


### PR DESCRIPTION
In bigdecimal < 3.2.0, `bigdecimal.div(x, 0)` called `x.coerce` but `bigdecimal.div(x, nonzero)` doesn't call `coerce`.
`bigdecimal.div(x,0)` was implemented by `bigdecimal/x`, and calling coerce was just a side effect.
It's not a specification.


```ruby
obj = Object.new
def obj.coerce(*) = [1, 2r]

BigDecimal(1) / obj
#=> (1/2) # This is OK

BigDecimal(1).div(obj, 10)
#=> Object can't be coerced into BigDecimal # This error is expected

BigDecimal(1).div(obj, 0)
#=> (1/2) # (bigdecimal < 3.2.0) This might be a bug. Calling coerce does not make sense
```
