### PR TITLE
Cleanup of afamily/pfamily specs for Addrinfo#initialize

### DIFF
--- a/library/socket/addrinfo/initialize_spec.rb
+++ b/library/socket/addrinfo/initialize_spec.rb
@@ -17,7 +17,7 @@ describe "Addrinfo#initialize" do
         @addrinfo.ip_port.should == 25
       end
 
-      it "returns the Socket::UNSPEC pfamily" do
+      it "returns the UNSPEC pfamily" do
         @addrinfo.pfamily.should == Socket::PF_UNSPEC
       end
 
@@ -53,7 +53,7 @@ describe "Addrinfo#initialize" do
         @addrinfo.ip_port.should == 25
       end
 
-      it "returns the Socket::UNSPEC pfamily" do
+      it "returns the INET6 pfamily" do
         @addrinfo.pfamily.should == Socket::PF_INET6
       end
 
@@ -83,7 +83,7 @@ describe "Addrinfo#initialize" do
         @addrinfo.ip_port.should == 25
       end
 
-      it "returns the Socket::UNSPEC pfamily" do
+      it "returns the INET6 pfamily" do
         @addrinfo.pfamily.should == Socket::PF_INET6
       end
 
@@ -113,7 +113,7 @@ describe "Addrinfo#initialize" do
         @addrinfo.ip_port.should == 25
       end
 
-      it "returns the Socket::UNSPEC pfamily" do
+      it "returns the INET6 pfamily" do
         @addrinfo.pfamily.should == Socket::PF_INET6
       end
 
@@ -147,11 +147,11 @@ describe "Addrinfo#initialize" do
         @addrinfo.ip_port.should == 46102
       end
 
-      it "returns the Socket::PF_INET pfamily" do
+      it "returns the INET pfamily" do
         @addrinfo.pfamily.should == Socket::PF_INET
       end
 
-      it "returns the INET6 afamily" do
+      it "returns the INET afamily" do
         @addrinfo.afamily.should == Socket::AF_INET
       end
 
@@ -217,11 +217,11 @@ describe "Addrinfo#initialize" do
         @addrinfo.ip_port.should == 46102
       end
 
-      it "returns the Socket::UNSPEC pfamily" do
+      it "returns the INET pfamily" do
         @addrinfo.pfamily.should == Socket::PF_INET
       end
 
-      it "returns the INET6 afamily" do
+      it "returns the INET afamily" do
         @addrinfo.afamily.should == Socket::AF_INET
       end
 
@@ -247,11 +247,11 @@ describe "Addrinfo#initialize" do
         @addrinfo.ip_port.should == 46102
       end
 
-      it "returns the Socket::UNSPEC pfamily" do
+      it "returns the INET pfamily" do
         @addrinfo.pfamily.should == Socket::PF_INET
       end
 
-      it "returns the INET6 afamily" do
+      it "returns the INET afamily" do
         @addrinfo.afamily.should == Socket::AF_INET
       end
 
@@ -311,11 +311,11 @@ describe "Addrinfo#initialize" do
         @addrinfo.ip_port.should == 46102
       end
 
-      it "returns the Socket::UNSPEC pfamily" do
+      it "returns the INET pfamily" do
         @addrinfo.pfamily.should == Socket::PF_INET
       end
 
-      it "returns the INET6 afamily" do
+      it "returns the INET afamily" do
         @addrinfo.afamily.should == Socket::AF_INET
       end
 
@@ -514,13 +514,13 @@ describe "Addrinfo#initialize" do
       @sockaddr = Socket.sockaddr_in(80, '127.0.0.1')
     end
 
-    it 'returns an Addrinfo with :PF_INET  family' do
+    it 'returns an Addrinfo with :PF_INET family' do
       addr = Addrinfo.new(@sockaddr, :PF_INET)
 
       addr.pfamily.should == Socket::PF_INET
     end
 
-    it 'returns an Addrinfo with :INET  family' do
+    it 'returns an Addrinfo with :INET family' do
       addr = Addrinfo.new(@sockaddr, :INET)
 
       addr.pfamily.should == Socket::PF_INET
@@ -544,13 +544,13 @@ describe "Addrinfo#initialize" do
       @sockaddr = Socket.sockaddr_in(80, '127.0.0.1')
     end
 
-    it 'returns an Addrinfo with "PF_INET"  family' do
+    it 'returns an Addrinfo with "PF_INET" family' do
       addr = Addrinfo.new(@sockaddr, 'PF_INET')
 
       addr.pfamily.should == Socket::PF_INET
     end
 
-    it 'returns an Addrinfo with "INET"  family' do
+    it 'returns an Addrinfo with "INET" family' do
       addr = Addrinfo.new(@sockaddr, 'INET')
 
       addr.pfamily.should == Socket::PF_INET


### PR DESCRIPTION
It looks like there was a lot of copy-paste in this one, often the description did not match the actual test.
The descriptions have been updated to use the shortest human readable syntax, so no `Socket::` namespace and no `PF_` prefix to the name. This matches the afamily specs (or: most of them).

Additionally, a few additional spaces in the descriptions have been removed.