### PR TITLE
Fix empty hash fixture not returning self

### DIFF
--- a/core/enumerable/fixtures/classes.rb
+++ b/core/enumerable/fixtures/classes.rb
@@ -38,12 +38,14 @@ module EnumerableSpecs
   class Empty
     include Enumerable
     def each
+      self
     end
   end
 
   class EmptyWithSize
     include Enumerable
     def each
+      self
     end
     def size
       0


### PR DESCRIPTION
The return value of `each` was the same as the expected value for calls to `#first`, `#last`, etc.