### PR TITLE
[Ruby 3.4] Add specs for splatting **nil

### DIFF
--- a/language/hash_spec.rb
+++ b/language/hash_spec.rb
@@ -149,6 +149,26 @@ describe "Hash literal" do
     {a: 1, **h, c: 4}.should == {a: 1, b: 2, c: 4}
   end
 
+  ruby_version_is ""..."3.4" do
+    it "does not expand nil using ** into {} and raises TypeError" do
+      h = nil
+      -> { {a: 1, **h} }.should raise_error(TypeError, "no implicit conversion of nil into Hash")
+
+      -> { {a: 1, **nil} }.should raise_error(TypeError, "no implicit conversion of nil into Hash")
+    end
+  end
+
+  ruby_version_is "3.4" do
+    it "expands nil using ** into {}" do
+      h = nil
+      {**h}.should == {}
+      {a: 1, **h}.should == {a: 1}
+
+      {**nil}.should == {}
+      {a: 1, **nil}.should == {a: 1}
+    end
+  end
+
   it "expands an '**{}' or '**obj' element with the last key/value pair taking precedence" do
     -> {
       @h = eval "{a: 1, **{a: 2, b: 3, c: 1}, c: 3}"

--- a/language/method_spec.rb
+++ b/language/method_spec.rb
@@ -1175,6 +1175,31 @@ describe "A method" do
   end
 end
 
+context "when passing **nil into a method that accepts keyword arguments" do
+  ruby_version_is ""..."3.4" do
+    it "raises TypeError" do
+      def m(**kw) kw; end
+
+      h = nil
+      -> { m(a: 1, **h) }.should raise_error(TypeError, "no implicit conversion of nil into Hash")
+      -> { m(a: 1, **nil) }.should raise_error(TypeError, "no implicit conversion of nil into Hash")
+    end
+  end
+
+  ruby_version_is "3.4" do
+    it "expands nil using ** into {}" do
+      def m(**kw) kw; end
+
+      h = nil
+      m(**h).should == {}
+      m(a: 1, **h).should == {a: 1}
+
+      m(**nil).should == {}
+      m(a: 1, **nil).should == {a: 1}
+    end
+  end
+end
+
 describe "A method call with a space between method name and parentheses" do
   before(:each) do
     def m(*args)


### PR DESCRIPTION
Changes in Ruby 3.4:

> Keyword splatting nil when calling methods is now supported.
**nil is treated similarly to **{}, passing no keywords,
and not calling any conversion methods. [[Bug #20064](https://bugs.ruby-lang.org/issues/20064)]

https://github.com/ruby/spec/issues/1265