### PR TITLE
Cleanup for Regexp.new and Regexp.compile

### DIFF
--- a/core/regexp/compile_spec.rb
+++ b/core/regexp/compile_spec.rb
@@ -14,6 +14,6 @@ describe "Regexp.compile given a Regexp" do
   it_behaves_like :regexp_new_regexp, :compile
 end
 
-describe "Regexp.new given a non-String/Regexp" do
+describe "Regexp.compile given a non-String/Regexp" do
   it_behaves_like :regexp_new_non_string_or_regexp, :compile
 end

--- a/core/regexp/new_spec.rb
+++ b/core/regexp/new_spec.rb
@@ -7,11 +7,11 @@ end
 
 describe "Regexp.new given a String" do
   it_behaves_like :regexp_new_string, :new
+  it_behaves_like :regexp_new_string_binary, :new
 end
 
 describe "Regexp.new given a Regexp" do
   it_behaves_like :regexp_new_regexp, :new
-  it_behaves_like :regexp_new_string_binary, :new
 end
 
 describe "Regexp.new given a non-String/Regexp" do


### PR DESCRIPTION
* Fix copy-paste error for Regexp.compile that said Regexp.new
* Move regexp_new_string_binary spec for Regexp.new to correct section