### PR TITLE
Add tests covering "+00:00" and 0 with Time#localtime and #at

### DIFF
--- a/core/time/utc_spec.rb
+++ b/core/time/utc_spec.rb
@@ -43,10 +43,14 @@ describe "Time#utc?" do
 
   it "does not treat time with +00:00 offset as UTC" do
     Time.new(2022, 1, 1, 0, 0, 0, "+00:00").utc?.should == false
+    Time.now.localtime("+00:00").utc?.should == false
+    Time.at(Time.now, in: "+00:00").utc?.should == false
   end
 
   it "does not treat time with 0 offset as UTC" do
     Time.new(2022, 1, 1, 0, 0, 0, 0).utc?.should == false
+    Time.now.localtime(0).utc?.should == false
+    Time.at(Time.now, in: 0).utc?.should == false
   end
 end
 


### PR DESCRIPTION
`Time#utc?` should return `false` after passing `"+00:00"` or `0` to `Time#localtime` or as the `in` parameter of `Time.at`.

This PR adds additional test cases to cover this. These are similar to the existing test cases for `"-00:00"` (where `Time#utc?` should return `true`).

This recently regressed in JRuby 10.0.2.0 (see jruby/jruby#8998).