### PR TITLE
[Ruby 3.4] String#to_f now accepts a decimal string with decimal part omitted

### DIFF
--- a/core/kernel/Float_spec.rb
+++ b/core/kernel/Float_spec.rb
@@ -163,6 +163,7 @@ describe :kernel_float, shared: true do
       -> { @object.send(:Float, "+1.") }.should raise_error(ArgumentError)
       -> { @object.send(:Float, "-1.") }.should raise_error(ArgumentError)
       -> { @object.send(:Float, "1.e+0") }.should raise_error(ArgumentError)
+      -> { @object.send(:Float, "1.e-2") }.should raise_error(ArgumentError)
     end
   end
 
@@ -172,6 +173,7 @@ describe :kernel_float, shared: true do
       @object.send(:Float, "+1.").should == 1.0
       @object.send(:Float, "-1.").should == -1.0
       @object.send(:Float, "1.e+0").should == 1.0
+      @object.send(:Float, "1.e-2").should be_close(0.01, TOLERANCE)
     end
   end
 

--- a/core/string/to_f_spec.rb
+++ b/core/string/to_f_spec.rb
@@ -127,4 +127,16 @@ describe "String#to_f" do
       }.should raise_error(Encoding::CompatibilityError, "ASCII incompatible encoding: UTF-16")
     end
   end
+
+  it "allows String representation without a fractional part" do
+    "1.".to_f.should == 1.0
+    "+1.".to_f.should == 1.0
+    "-1.".to_f.should == -1.0
+    "1.e+0".to_f.should == 1.0
+    "1.e+0".to_f.should == 1.0
+
+    ruby_bug "#20705", ""..."3.4" do
+      "1.e-2".to_f.should be_close(0.01, TOLERANCE)
+    end
+  end
 end


### PR DESCRIPTION
Changes:

> String#to_f now accepts a decimal string with decimal part omitted. [[Feature #20705](https://bugs.ruby-lang.org/issues/20705)]
Note that the result changes when an exponent is specified.

Actually the only case that was missing is a one for fixed bug in `String#to_f` - `'1.e-9'.to_f` returned 1.0.