### PR TITLE
[Ruby 3.4] Object#singleton_method now returns methods in modules prepended to or included in the receiver's singleton class

### DIFF
--- a/core/kernel/singleton_method_spec.rb
+++ b/core/kernel/singleton_method_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../spec_helper'
 
 describe "Kernel#singleton_method" do
-  it "find a method defined on the singleton class" do
+  it "finds a method defined on the singleton class" do
     obj = Object.new
     def obj.foo; end
     obj.singleton_method(:foo).should be_an_instance_of(Method)
@@ -37,5 +37,49 @@ describe "Kernel#singleton_method" do
       # a NameError and not a NoMethodError
       e.class.should == NameError
     }
+  end
+
+  ruby_bug "#20620", ""..."3.4" do
+    it "finds a method defined in a module included in the singleton class" do
+      m = Module.new do
+        def foo
+          :foo
+        end
+      end
+
+      obj = Object.new
+      obj.singleton_class.include(m)
+
+      obj.singleton_method(:foo).should be_an_instance_of(Method)
+      obj.singleton_method(:foo).call.should == :foo
+    end
+
+    it "finds a method defined in a module prepended in the singleton class" do
+      m = Module.new do
+        def foo
+          :foo
+        end
+      end
+
+      obj = Object.new
+      obj.singleton_class.prepend(m)
+
+      obj.singleton_method(:foo).should be_an_instance_of(Method)
+      obj.singleton_method(:foo).call.should == :foo
+    end
+
+    it "finds a method defined in a module that an object is extended with" do
+      m = Module.new do
+        def foo
+          :foo
+        end
+      end
+
+      obj = Object.new
+      obj.extend(m)
+
+      obj.singleton_method(:foo).should be_an_instance_of(Method)
+      obj.singleton_method(:foo).call.should == :foo
+    end
   end
 end


### PR DESCRIPTION
Changes:

> Object#singleton_method now returns methods in modules prepended to or included in the
receiver's singleton class. [[Bug #20620](https://bugs.ruby-lang.org/issues/20620)]

  ```rb
  o = Object.new
  o.extend(Module.new{def a = 1})
  o.singleton_method(:a).call #=> 1
  ```