### PR TITLE
[Ruby 3.4] Add specs for Socket::ResolutionError

### DIFF
--- a/library/socket/socket/getaddrinfo_spec.rb
+++ b/library/socket/socket/getaddrinfo_spec.rb
@@ -106,6 +106,24 @@ describe "Socket.getaddrinfo" do
       ]
       res.each { |a| expected.should include(a) }
     end
+
+    ruby_version_is ""..."3.3" do
+      it "raises SocketError when fails to resolve address" do
+        -> {
+          Socket.getaddrinfo("www.kame.net", 80, "AF_UNIX")
+        }.should raise_error(SocketError)
+      end
+    end
+
+    ruby_version_is "3.3" do
+      it "raises ResolutionError when fails to resolve address" do
+        -> {
+          Socket.getaddrinfo("www.kame.net", 80, "AF_UNIX")
+        }.should raise_error(Socket::ResolutionError) { |e|
+          e.error_code.should == Socket::EAI_FAMILY
+        }
+      end
+    end
   end
 end
 

--- a/library/socket/socket/getnameinfo_spec.rb
+++ b/library/socket/socket/getnameinfo_spec.rb
@@ -60,6 +60,24 @@ describe "Socket.getnameinfo" do
     name_info = Socket.getnameinfo ["AF_INET", 9, 'foo', '127.0.0.1']
     name_info[1].should == 'discard'
   end
+
+  ruby_version_is ""..."3.3" do
+    it "raises SocketError when fails to resolve address" do
+      -> {
+        Socket.getnameinfo(["AF_UNIX", 80, "0.0.0.0"])
+      }.should raise_error(SocketError)
+    end
+  end
+
+  ruby_version_is "3.3" do
+    it "raises ResolutionError when fails to resolve address" do
+      -> {
+        Socket.getnameinfo(["AF_UNIX", 80, "0.0.0.0"])
+      }.should raise_error(Socket::ResolutionError) { |e|
+        e.error_code.should == Socket::EAI_FAMILY
+      }
+    end
+  end
 end
 
 describe 'Socket.getnameinfo' do


### PR DESCRIPTION
Changes:

> Socket::ResolutionError and Socket::ResolutionError#error_code was added.
[[Feature #20018](https://bugs.ruby-lang.org/issues/20018)]