### PR TITLE
[Ruby 3.4] Add test for deprecation warning for Symbol#to_s

### DIFF
--- a/core/symbol/shared/id2name.rb
+++ b/core/symbol/shared/id2name.rb
@@ -13,4 +13,18 @@ describe :symbol_id2name, shared: true do
 
     symbol.send(@method).encoding.should == Encoding::US_ASCII
   end
+
+  ruby_version_is "3.4" do
+    it "warns about mutating returned string" do
+      -> { :bad!.send(@method).upcase! }.should complain(/warning: string returned by :bad!.to_s will be frozen in the future/)
+    end
+
+    it "does not warn about mutation when Warning[:deprecated] is false" do
+      deprecated = Warning[:deprecated]
+      Warning[:deprecated] = false
+      -> { :bad!.send(@method).upcase! }.should_not complain
+    ensure
+      Warning[:deprecated] = deprecated
+    end
+  end
 end


### PR DESCRIPTION
From #1265.

3.4 makes Symbol#to_s return chilled Strings which emit deprecation warnings on mutation.