### PR TITLE
Add tests for endless ranges to Comparable#clamp

### DIFF
--- a/core/comparable/clamp_spec.rb
+++ b/core/comparable/clamp_spec.rb
@@ -24,7 +24,7 @@ describe 'Comparable#clamp' do
     c.clamp(two, three).should equal(c)
   end
 
-  it 'returns the min parameter if smaller than it' do
+  it 'returns the min parameter if less than it' do
     one = ComparableSpecs::WithOnlyCompareDefined.new(1)
     two = ComparableSpecs::WithOnlyCompareDefined.new(2)
     c = ComparableSpecs::Weird.new(0)
@@ -52,7 +52,7 @@ describe 'Comparable#clamp' do
     c.clamp(two..three).should equal(c)
   end
 
-  it 'returns the minimum value of the range parameters if smaller than it' do
+  it 'returns the minimum value of the range parameters if less than it' do
     one = ComparableSpecs::WithOnlyCompareDefined.new(1)
     two = ComparableSpecs::WithOnlyCompareDefined.new(2)
     c = ComparableSpecs::Weird.new(0)
@@ -74,5 +74,71 @@ describe 'Comparable#clamp' do
     c = ComparableSpecs::Weird.new(3)
 
     -> { c.clamp(one...two) }.should raise_error(ArgumentError)
+  end
+
+  context 'with endless range' do
+    it 'returns minimum value of the range parameters if less than it' do
+      one = ComparableSpecs::WithOnlyCompareDefined.new(1)
+      zero = ComparableSpecs::WithOnlyCompareDefined.new(0)
+      c = ComparableSpecs::Weird.new(0)
+
+      c.clamp(one..).should equal(one)
+      c.clamp(zero..).should equal(c)
+    end
+
+    it 'always returns self if greater than minimum value of the range parameters' do
+      one = ComparableSpecs::WithOnlyCompareDefined.new(1)
+      two = ComparableSpecs::WithOnlyCompareDefined.new(2)
+      c = ComparableSpecs::Weird.new(2)
+
+      c.clamp(one..).should equal(c)
+      c.clamp(two..).should equal(c)
+    end
+
+    it 'works with exclusive range' do
+      one = ComparableSpecs::WithOnlyCompareDefined.new(1)
+      c = ComparableSpecs::Weird.new(2)
+
+      c.clamp(one...).should equal(c)
+    end
+  end
+
+  context 'with beginless range' do
+    it 'returns maximum value of the range parameters if greater than it' do
+      one = ComparableSpecs::WithOnlyCompareDefined.new(1)
+      c = ComparableSpecs::Weird.new(2)
+
+      c.clamp(..one).should equal(one)
+    end
+
+    it 'always returns self if less than maximum value of the range parameters' do
+      one = ComparableSpecs::WithOnlyCompareDefined.new(1)
+      zero = ComparableSpecs::WithOnlyCompareDefined.new(0)
+      c = ComparableSpecs::Weird.new(0)
+
+      c.clamp(..one).should equal(c)
+      c.clamp(..zero).should equal(c)
+    end
+
+    it 'raises an Argument error if the range parameter is exclusive' do
+      one = ComparableSpecs::WithOnlyCompareDefined.new(1)
+      c = ComparableSpecs::Weird.new(0)
+
+      -> { c.clamp(...one) }.should raise_error(ArgumentError)
+    end
+  end
+
+  context 'with beginless-and-endless range' do
+    it 'always returns self' do
+      c = ComparableSpecs::Weird.new(1)
+
+      c.clamp(nil..nil).should equal(c)
+    end
+
+    it 'works with exclusive range' do
+      c = ComparableSpecs::Weird.new(2)
+
+      c.clamp(nil...nil).should equal(c)
+    end
   end
 end


### PR DESCRIPTION
Follow-up to my report in TruffleRuby https://github.com/truffleruby/truffleruby/issues/3945. `Comparable#clamp` has been accepting endless ranges (of all varieties) since 2.7. 

Note how only beginless ranges cause errors with exclusive end.