### PR TITLE
[Ruby 3.4] Add spec for GC.config

### DIFF
--- a/core/gc/config_spec.rb
+++ b/core/gc/config_spec.rb
@@ -51,9 +51,9 @@ ruby_version_is "3.4" do
       end
 
       it "raises ArgumentError for all other arguments" do
-        -> { GC.config([]) }.should raise_error(ArgumentError, "ArgumentError")
-        -> { GC.config("default") }.should raise_error(ArgumentError, "ArgumentError")
-        -> { GC.config(1) }.should raise_error(ArgumentError, "ArgumentError")
+        -> { GC.config([]) }.should raise_error(ArgumentError)
+        -> { GC.config("default") }.should raise_error(ArgumentError)
+        -> { GC.config(1) }.should raise_error(ArgumentError)
       end
     end
 


### PR DESCRIPTION
From #1265
> GC.config added to allow setting configuration variables on the Garbage
Collector. [[Feature #20443](https://bugs.ruby-lang.org/issues/20443)]

Includes generic tests and tests for MRI's default implementation of GC.

If a Ruby implementation does not want to expose implementation or configuration, a minimal method can be this:
```ruby
def GC.config(options = nil)
  return { implementation: "none" } if options.nil?

  raise ArgumentError unless Hash === options
  if options.key?(:implementation)
    raise ArgumentError, 'Attempting to set read-only key "Implementation"'
  end

  {}
end
```

EDIT: but also see https://github.com/ruby/spec/pull/1307#issue-3655937279

This is the reference: https://github.com/ruby/ruby/blob/2289961b485b1cbf7b1012693722c16a6cdb4cda/gc.rb#L445