### PR TITLE
Add error message validation in spec for Encoding.find with unknown encoding

### DIFF
--- a/core/encoding/find_spec.rb
+++ b/core/encoding/find_spec.rb
@@ -50,7 +50,7 @@ describe "Encoding.find" do
   end
 
   it "raises an ArgumentError if the given encoding does not exist" do
-    -> { Encoding.find('dh2dh278d') }.should raise_error(ArgumentError)
+    -> { Encoding.find('dh2dh278d') }.should raise_error(ArgumentError, 'unknown encoding name - dh2dh278d')
   end
 
   # Not sure how to do a better test, since locale depends on weird platform-specific stuff


### PR DESCRIPTION
We were using the quoted name in Natalie, which did result in an error in the recent spec of `CGI.unescapeURIComponent`. Adding this spec to `Encoding.find` seems like the more logical place.