### PR TITLE
Fix variable name for value of Warning[:strict_unused_block]

### DIFF
--- a/core/warning/warn_spec.rb
+++ b/core/warning/warn_spec.rb
@@ -99,14 +99,14 @@ describe "Warning.warn" do
 
   ruby_version_is "3.4" do
     it "warns when category is :strict_unused_block but Warning[:strict_unused_block] is false" do
-      warn_experimental = Warning[:strict_unused_block]
+      warn_strict_unused_block = Warning[:strict_unused_block]
       Warning[:strict_unused_block] = true
       begin
         -> {
           Warning.warn("foo", category: :strict_unused_block)
         }.should complain("foo")
       ensure
-        Warning[:strict_unused_block] = warn_experimental
+        Warning[:strict_unused_block] = warn_strict_unused_block
       end
     end
   end
@@ -137,14 +137,14 @@ describe "Warning.warn" do
 
   ruby_version_is "3.4" do
     it "doesn't print message when category is :strict_unused_block but Warning[:strict_unused_block] is false" do
-      warn_experimental = Warning[:strict_unused_block]
+      warn_strict_unused_block = Warning[:strict_unused_block]
       Warning[:strict_unused_block] = false
       begin
         -> {
           Warning.warn("foo", category: :strict_unused_block)
         }.should_not complain
       ensure
-        Warning[:strict_unused_block] = warn_experimental
+        Warning[:strict_unused_block] = warn_strict_unused_block
       end
     end
   end

--- a/language/method_spec.rb
+++ b/language/method_spec.rb
@@ -1621,12 +1621,12 @@ describe "warning about not used block argument" do
       # ensure that warning is emitted
       -> { m_that_does_not_use_block { } }.should complain(verbose: true)
 
-      warn_experimental = Warning[:strict_unused_block]
+      warn_strict_unused_block = Warning[:strict_unused_block]
       Warning[:strict_unused_block] = false
       begin
         -> { m_that_does_not_use_block { } }.should_not complain(verbose: true)
       ensure
-        Warning[:strict_unused_block] = warn_experimental
+        Warning[:strict_unused_block] = warn_strict_unused_block
       end
     end
 
@@ -1635,14 +1635,14 @@ describe "warning about not used block argument" do
         42
       end
 
-      warn_experimental = Warning[:strict_unused_block]
+      warn_strict_unused_block = Warning[:strict_unused_block]
       Warning[:strict_unused_block] = true
       begin
         -> {
           m_that_does_not_use_block { }
       }.should complain(/the block passed to 'm_that_does_not_use_block' defined at .+ may be ignored/)
       ensure
-        Warning[:strict_unused_block] = warn_experimental
+        Warning[:strict_unused_block] = warn_strict_unused_block
       end
     end
   end


### PR DESCRIPTION
This was probably copy-pasted from Warning[:experimental]