### PR TITLE
Add specs for Comparable#clamp with nil arguments

### DIFF
--- a/core/comparable/clamp_spec.rb
+++ b/core/comparable/clamp_spec.rb
@@ -76,6 +76,26 @@ describe 'Comparable#clamp' do
     -> { c.clamp(one...two) }.should raise_error(ArgumentError)
   end
 
+  context 'with nil as the max argument' do
+    it 'returns min argument if less than it' do
+      one = ComparableSpecs::WithOnlyCompareDefined.new(1)
+      zero = ComparableSpecs::WithOnlyCompareDefined.new(0)
+      c = ComparableSpecs::Weird.new(0)
+
+      c.clamp(one, nil).should equal(one)
+      c.clamp(zero, nil).should equal(c)
+    end
+
+    it 'always returns self if greater than min argument' do
+      one = ComparableSpecs::WithOnlyCompareDefined.new(1)
+      two = ComparableSpecs::WithOnlyCompareDefined.new(2)
+      c = ComparableSpecs::Weird.new(2)
+
+      c.clamp(one, nil).should equal(c)
+      c.clamp(two, nil).should equal(c)
+    end
+  end
+
   context 'with endless range' do
     it 'returns minimum value of the range parameters if less than it' do
       one = ComparableSpecs::WithOnlyCompareDefined.new(1)
@@ -103,6 +123,24 @@ describe 'Comparable#clamp' do
     end
   end
 
+  context 'with nil as the min argument' do
+    it 'returns max argument if greater than it' do
+      one = ComparableSpecs::WithOnlyCompareDefined.new(1)
+      c = ComparableSpecs::Weird.new(2)
+
+      c.clamp(nil, one).should equal(one)
+    end
+
+    it 'always returns self if less than max argument' do
+      one = ComparableSpecs::WithOnlyCompareDefined.new(1)
+      zero = ComparableSpecs::WithOnlyCompareDefined.new(0)
+      c = ComparableSpecs::Weird.new(0)
+
+      c.clamp(nil, one).should equal(c)
+      c.clamp(nil, zero).should equal(c)
+    end
+  end
+
   context 'with beginless range' do
     it 'returns maximum value of the range parameters if greater than it' do
       one = ComparableSpecs::WithOnlyCompareDefined.new(1)
@@ -125,6 +163,14 @@ describe 'Comparable#clamp' do
       c = ComparableSpecs::Weird.new(0)
 
       -> { c.clamp(...one) }.should raise_error(ArgumentError)
+    end
+  end
+
+  context 'with nil as the min and the max argument' do
+    it 'always returns self' do
+      c = ComparableSpecs::Weird.new(1)
+
+      c.clamp(nil, nil).should equal(c)
     end
   end
 


### PR DESCRIPTION
These have been copied from the beginless/endless ranges, since they work pretty much the same way.