### PR TITLE
Impove tests for error messages in Array#pack, String#unpack

### DIFF
--- a/core/array/pack/shared/basic.rb
+++ b/core/array/pack/shared/basic.rb
@@ -33,19 +33,15 @@ describe :array_pack_basic_non_float, shared: true do
   end
 
   ruby_version_is ""..."3.3" do
-    # https://bugs.ruby-lang.org/issues/19150
-    # NOTE: it's just a plan of the Ruby core team
     it "warns that a directive is unknown" do
       # additional directive ('a') is required for the X directive
-      -> { [@obj, @obj].pack("a R" + pack_format) }.should complain(/unknown pack directive 'R'/)
-      -> { [@obj, @obj].pack("a 0" + pack_format) }.should complain(/unknown pack directive '0'/)
-      -> { [@obj, @obj].pack("a :" + pack_format) }.should complain(/unknown pack directive ':'/)
+      -> { [@obj, @obj].pack("a R" + pack_format) }.should complain(/unknown pack directive 'R' in 'a R#{pack_format}'/)
+      -> { [@obj, @obj].pack("a 0" + pack_format) }.should complain(/unknown pack directive '0' in 'a 0#{pack_format}'/)
+      -> { [@obj, @obj].pack("a :" + pack_format) }.should complain(/unknown pack directive ':' in 'a :#{pack_format}'/)
     end
   end
 
   ruby_version_is "3.3" do
-    # https://bugs.ruby-lang.org/issues/19150
-    # NOTE: Added this case just to not forget about the decision in the ticket
     it "raise ArgumentError when a directive is unknown" do
       # additional directive ('a') is required for the X directive
       -> { [@obj, @obj].pack("a R" + pack_format) }.should raise_error(ArgumentError, /unknown pack directive 'R'/)

--- a/core/string/unpack/shared/basic.rb
+++ b/core/string/unpack/shared/basic.rb
@@ -9,12 +9,19 @@ describe :string_unpack_basic, shared: true do
     "abc".unpack(d).should be_an_instance_of(Array)
   end
 
+  ruby_version_is ""..."3.3" do
+    it "warns about using an unknown directive" do
+      -> { "abcdefgh".unpack("a R" + unpack_format) }.should complain(/unknown unpack directive 'R' in 'a R#{unpack_format}'/)
+      -> { "abcdefgh".unpack("a 0" + unpack_format) }.should complain(/unknown unpack directive '0' in 'a 0#{unpack_format}'/)
+      -> { "abcdefgh".unpack("a :" + unpack_format) }.should complain(/unknown unpack directive ':' in 'a :#{unpack_format}'/)
+    end
+  end
+
   ruby_version_is "3.3" do
-    # https://bugs.ruby-lang.org/issues/19150
-    it 'raise ArgumentError when a directive is unknown' do
-      -> { "abcdefgh".unpack("a R" + unpack_format) }.should raise_error(ArgumentError, /unknown unpack directive 'R'/)
-      -> { "abcdefgh".unpack("a 0" + unpack_format) }.should raise_error(ArgumentError, /unknown unpack directive '0'/)
-      -> { "abcdefgh".unpack("a :" + unpack_format) }.should raise_error(ArgumentError, /unknown unpack directive ':'/)
+    it "raises ArgumentError when a directive is unknown" do
+      -> { "abcdefgh".unpack("a R" + unpack_format) }.should raise_error(ArgumentError, "unknown unpack directive 'R' in 'a R#{unpack_format}'")
+      -> { "abcdefgh".unpack("a 0" + unpack_format) }.should raise_error(ArgumentError, "unknown unpack directive '0' in 'a 0#{unpack_format}'")
+      -> { "abcdefgh".unpack("a :" + unpack_format) }.should raise_error(ArgumentError, "unknown unpack directive ':' in 'a :#{unpack_format}'")
     end
   end
 end


### PR DESCRIPTION
From #1216

> Array#pack now raises ArgumentError for unknown directives. [[Bug #19150](https://bugs.ruby-lang.org/issues/19150)]

> String#unpack now raises ArgumentError for unknown directives. [[Bug #19150](https://bugs.ruby-lang.org/issues/19150)]

Previously, 69634ef9c423726d6702711609f9b04d0756bc62 added tests, but the messages weren't full, and there was no test for a warning in `String#unpack`.

I've removed the comments, as the errors are no longer a future plan.