### PR TITLE
Add more tests for reopening classes and modules

### DIFF
--- a/core/module/fixtures/classes.rb
+++ b/core/module/fixtures/classes.rb
@@ -1,6 +1,6 @@
 module ModuleSpecs
   def self.without_test_modules(modules)
-    ignore = %w[MSpecRSpecAdapter PP::ObjectMixin ModuleSpecs::IncludedInObject MainSpecs::Module ConstantSpecs::ModuleA]
+    ignore = %w[MSpecRSpecAdapter PP::ObjectMixin MainSpecs::Module ConstantSpecs::ModuleA]
     modules.reject { |k| ignore.include?(k.name) }
   end
 

--- a/language/class_spec.rb
+++ b/language/class_spec.rb
@@ -46,7 +46,14 @@ describe "A class definition" do
     -> {
       class ClassSpecsNumber
       end
-    }.should raise_error(TypeError)
+    }.should raise_error(TypeError, /\AClassSpecsNumber is not a class/)
+  end
+
+  it "raises TypeError if constant given as class name exists and is a Module but not a Class" do
+    -> {
+      class ClassSpecs
+      end
+    }.should raise_error(TypeError, /\AClassSpecs is not a class/)
   end
 
   # test case known to be detecting bugs (JRuby, MRI)
@@ -345,6 +352,39 @@ describe "Reopening a class" do
     end
     ClassSpecs::M.m.should == 1
     ClassSpecs::L.singleton_class.send(:remove_method, :m)
+  end
+
+  it "does not reopen a class included in Object" do
+    ruby_exe(<<~RUBY).should == "false"
+      module IncludedInObject
+        class IncludedClass
+        end
+      end
+      class Object
+        include IncludedInObject
+      end
+      class IncludedClass
+      end
+      print IncludedInObject::IncludedClass == Object::IncludedClass
+    RUBY
+  end
+
+  it "does not reopen a class included in non-Object modules" do
+    ruby_exe(<<~RUBY).should == "false/false"
+      module Included
+        module IncludedClass; end
+      end
+      module M
+        include Included
+        module IncludedClass; end
+      end
+      class C
+        include Included
+        module IncludedClass; end
+      end
+      print Included::IncludedClass == M::IncludedClass, "/",
+            Included::IncludedClass == C::IncludedClass
+    RUBY
   end
 end
 

--- a/language/fixtures/module.rb
+++ b/language/fixtures/module.rb
@@ -12,13 +12,4 @@ module ModuleSpecs
 
   module Anonymous
   end
-
-  module IncludedInObject
-    module IncludedModuleSpecs
-    end
-  end
-end
-
-class Object
-  include ModuleSpecs::IncludedInObject
 end

--- a/language/module_spec.rb
+++ b/language/module_spec.rb
@@ -31,10 +31,34 @@ describe "The module keyword" do
   end
 
   it "does not reopen a module included in Object" do
-    module IncludedModuleSpecs; Reopened = true; end
-    ModuleSpecs::IncludedInObject::IncludedModuleSpecs.should_not == Object::IncludedModuleSpecs
-  ensure
-    IncludedModuleSpecs.send(:remove_const, :Reopened)
+    ruby_exe(<<~RUBY).should == "false"
+      module IncludedInObject
+        module IncludedModule; end
+      end
+      class Object
+        include IncludedInObject
+      end
+      module IncludedModule; end
+      print IncludedInObject::IncludedModule == Object::IncludedModule
+    RUBY
+  end
+
+  it "does not reopen a module included in non-Object modules" do
+    ruby_exe(<<~RUBY).should == "false/false"
+      module Included
+        module IncludedModule; end
+      end
+      module M
+        include Included
+        module IncludedModule; end
+      end
+      class C
+        include Included
+        module IncludedModule; end
+      end
+      print Included::IncludedModule == M::IncludedModule, "/",
+            Included::IncludedModule == C::IncludedModule
+    RUBY
   end
 
   it "raises a TypeError if the constant is a Class" do


### PR DESCRIPTION
From #1016
> When defining a class/module directly under the Object class by class/module
statement, if there is already a class/module defined by Module#include
with the same name, the statement was handled as "open class" in Ruby 3.1 or before.
Since Ruby 3.2, a new class is defined instead. [[Feature #18832](https://bugs.ruby-lang.org/issues/18832)]

3fe67474e809822ab9aeb7fa1190c2459837a26c added tests for not reopening a Module, but not a Class.

This PR adds two missing tests:
- not reopening an included Class,
- `class` raising when constant is a Module (similar test exists in module_spec).

Update: also tests for reopening modules and classes inside other modules and classes.
