### PR TITLE
Match error messages in specs of Array#fetch

### DIFF
--- a/core/array/fetch_spec.rb
+++ b/core/array/fetch_spec.rb
@@ -12,9 +12,9 @@ describe "Array#fetch" do
   end
 
   it "raises an IndexError if there is no element at index" do
-    -> { [1, 2, 3].fetch(3) }.should raise_error(IndexError)
-    -> { [1, 2, 3].fetch(-4) }.should raise_error(IndexError)
-    -> { [].fetch(0) }.should raise_error(IndexError)
+    -> { [1, 2, 3].fetch(3) }.should raise_error(IndexError, "index 3 outside of array bounds: -3...3")
+    -> { [1, 2, 3].fetch(-4) }.should raise_error(IndexError, "index -4 outside of array bounds: -3...3")
+    -> { [].fetch(0) }.should raise_error(IndexError, "index 0 outside of array bounds: 0...0")
   end
 
   it "returns default if there is no element at index if passed a default value" do
@@ -50,6 +50,6 @@ describe "Array#fetch" do
   end
 
   it "raises a TypeError when the passed argument can't be coerced to Integer" do
-    -> { [].fetch("cat") }.should raise_error(TypeError)
+    -> { [].fetch("cat") }.should raise_error(TypeError, "no implicit conversion of String into Integer")
   end
 end


### PR DESCRIPTION
These were matched in the specs of Array#fetch_values, they have been added here for consistency and to make it easier to implement Array#fetch_values as a map over Array#fetch.