### PR TITLE
File.dirname: add a spec for Shift JIS handling

### DIFF
--- a/core/file/dirname_spec.rb
+++ b/core/file/dirname_spec.rb
@@ -122,7 +122,7 @@ describe "File.dirname" do
     end
 
     it "handles Shift JIS 0x5C (\\) as second byte of a multi-byte sequence (windows)" do
-      # dir/fileソname.txt
+      # dir\fileソname.txt
       path = "dir\\file\x83\x5cname.txt".b.force_encoding(Encoding::SHIFT_JIS)
       path.valid_encoding?.should be_true
       File.dirname(path).should == "dir"


### PR DESCRIPTION
While trying to speedup various `File.*` methods, I realized they were way slower and complicated than they should for no apparent reason. However after asking Nobu he explained that Shift JIS encoded text can contain `0x5C` (ASCII backslash) as the second byte of a two byte character sequence.

Since on Windows `0x5C` is `File::ALT_SEPARATOR`, this can easily break naive path related algorithms searching for directory separators.

cc @eregon what do you think of that spec? I think it would have helped me figure things out way sooner, so would have been valuable. If you agree I can generalize it to more "path handling" methods.