### PR TITLE
Deduplicate and reorganize specs for Kernel#raise

### DIFF
--- a/core/fiber/raise_spec.rb
+++ b/core/fiber/raise_spec.rb
@@ -3,11 +3,16 @@ require_relative 'fixtures/classes'
 require_relative '../../shared/kernel/raise'
 
 describe "Fiber#raise" do
+  it "is a public method" do
+    Fiber.public_instance_methods.should include(:raise)
+  end
+
   it_behaves_like :kernel_raise, :raise, FiberSpecs::NewFiberToRaise
   it_behaves_like :kernel_raise_across_contexts, :raise, FiberSpecs::NewFiberToRaise
-end
+  ruby_version_is "4.0" do
+    it_behaves_like :kernel_raise_with_cause, :raise, FiberSpecs::NewFiberToRaise
+  end
 
-describe "Fiber#raise" do
   it 'raises RuntimeError by default' do
     -> { FiberSpecs::NewFiberToRaise.raise }.should raise_error(RuntimeError)
   end
@@ -126,10 +131,7 @@ describe "Fiber#raise" do
       end.should raise_error(RuntimeError, "Expected error")
     end
   end
-end
 
-
-describe "Fiber#raise" do
   it "transfers and raises on a transferring fiber" do
     root = Fiber.current
     fiber = Fiber.new { root.transfer }

--- a/core/kernel/raise_spec.rb
+++ b/core/kernel/raise_spec.rb
@@ -4,9 +4,19 @@ require_relative '../../shared/kernel/raise'
 
 describe "Kernel#raise" do
   it "is a private method" do
-    Kernel.should have_private_instance_method(:raise)
+    Kernel.private_instance_methods.should include(:raise)
   end
 
+  # Shared specs expect a public #raise method.
+  public_raiser = Object.new
+  class << public_raiser
+    public :raise
+  end
+  it_behaves_like :kernel_raise, :raise, public_raiser
+  it_behaves_like :kernel_raise_with_cause, :raise, public_raiser
+end
+
+describe "Kernel#raise with previously rescued exception" do
   it "re-raises the previously rescued exception if no exception is specified" do
     ScratchPad.record nil
 
@@ -26,87 +36,6 @@ describe "Kernel#raise" do
     end.should raise_error(Exception, "outer")
 
     ScratchPad.recorded.should be_nil
-  end
-
-  it "accepts a cause keyword argument that sets the cause" do
-    cause = StandardError.new
-    -> { raise("error", cause: cause) }.should raise_error(RuntimeError) { |e| e.cause.should == cause }
-  end
-
-  it "accepts a cause keyword argument that overrides the last exception" do
-    begin
-      raise "first raise"
-    rescue => ignored
-      cause = StandardError.new
-      -> { raise("error", cause: cause) }.should raise_error(RuntimeError) { |e| e.cause.should == cause }
-    end
-  end
-
-  it "raises an ArgumentError when only cause is given" do
-    cause = StandardError.new
-    -> { raise(cause: cause) }.should raise_error(ArgumentError, "only cause is given with no arguments")
-  end
-
-  it "raises an ArgumentError when only cause is given even if it has nil value" do
-    -> { raise(cause: nil) }.should raise_error(ArgumentError, "only cause is given with no arguments")
-  end
-
-  it "raises a TypeError when given cause is not an instance of Exception" do
-    -> { raise "message", cause: Object.new }.should raise_error(TypeError, "exception object expected")
-  end
-
-  it "doesn't raise a TypeError when given cause is nil" do
-    -> { raise "message", cause: nil }.should raise_error(RuntimeError, "message")
-  end
-
-  it "allows cause equal an exception" do
-    e = RuntimeError.new("message")
-    -> { raise e, cause: e }.should raise_error(e)
-  end
-
-  it "doesn't set given cause when it equals an exception" do
-    e = RuntimeError.new("message")
-
-    begin
-      raise e, cause: e
-    rescue
-    end
-
-    e.cause.should == nil
-  end
-
-  it "raises ArgumentError when exception is part of the cause chain" do
-    -> {
-      begin
-        raise "Error 1"
-      rescue => e1
-        begin
-          raise "Error 2"
-        rescue => e2
-          begin
-            raise "Error 3"
-          rescue => e3
-            raise e1, cause: e3
-          end
-        end
-      end
-    }.should raise_error(ArgumentError, "circular causes")
-  end
-
-  it "re-raises a rescued exception" do
-    -> do
-      begin
-        raise StandardError, "aaa"
-      rescue Exception
-        begin
-          raise ArgumentError
-        rescue ArgumentError
-        end
-
-        # should raise StandardError "aaa"
-        raise
-      end
-    end.should raise_error(StandardError, "aaa")
   end
 
   it "re-raises a previously rescued exception without overwriting the cause" do
@@ -283,10 +212,11 @@ describe "Kernel#raise" do
   end
 end
 
-describe "Kernel#raise" do
-  it_behaves_like :kernel_raise, :raise, Kernel
-end
-
 describe "Kernel.raise" do
-  it "needs to be reviewed for spec completeness"
+  it "is a public method" do
+    Kernel.singleton_class.should.public_method_defined?(:raise)
+  end
+
+  it_behaves_like :kernel_raise, :raise, Kernel
+  it_behaves_like :kernel_raise_with_cause, :raise, Kernel
 end

--- a/core/thread/raise_spec.rb
+++ b/core/thread/raise_spec.rb
@@ -3,8 +3,15 @@ require_relative 'fixtures/classes'
 require_relative '../../shared/kernel/raise'
 
 describe "Thread#raise" do
+  it "is a public method" do
+    Thread.public_instance_methods.should include(:raise)
+  end
+
   it_behaves_like :kernel_raise, :raise, ThreadSpecs::NewThreadToRaise
   it_behaves_like :kernel_raise_across_contexts, :raise, ThreadSpecs::NewThreadToRaise
+  ruby_version_is "4.0" do
+    it_behaves_like :kernel_raise_with_cause, :raise, ThreadSpecs::NewThreadToRaise
+  end
 
   it "ignores dead threads and returns nil" do
     t = Thread.new { :dead }


### PR DESCRIPTION
- Include shared spec which has better descriptions and more tests.
- Test Kernel#raise, not Kernel.raise (Kernel.raise has separate tests).
- Remove duplicated tests.

There is more work to be done in organizing the tests:
- Fiber and Thread seem to have some generic tests that are already included in the shared spec.
- Tests for intricacies of re-raising exceptions could also be moved to the shared spec probably.