### PR TITLE
Add a CI job to run specs with LC_ALL=C

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
         ruby: [ 3.3.10, 3.4.8, 4.0.1 ]
         mspecopt: [""]
         rubyopt: [""]
+        locale: [""]
         include:
+          - { os: ubuntu, ruby: 4.0.1, locale: "LC_ALL=C" }
           - { os: ubuntu, ruby: 4.0.1, mspecopt: "--repeat 2" }
           - { os: ubuntu, ruby: 4.0.1, rubyopt: "--enable-frozen-string-literal" }
           - { os: ubuntu, ruby: 4.0.1, rubyopt: "--parser=parse.y" }
@@ -39,7 +41,7 @@ jobs:
       env:
         CHECK_LEAKS: true
         RUBYOPT: "${{ matrix.rubyopt }}"
-      run: ../mspec/bin/mspec -j --timeout 30 ${{ matrix.mspecopt }}
+      run: ${{ matrix.locale }} ../mspec/bin/mspec -j --timeout 30 ${{ matrix.mspecopt }}
 
     - name: Run specs (macOS)
       if: matrix.os == 'macos'


### PR DESCRIPTION
* Which simulates having no locale set and using the "default" locale.
* To catch failures earlier rather than in https://rubyci.org/
* See https://github.com/ruby/spec/pull/1305#issuecomment-3816470202