### PR TITLE
Add specs for IO.select with other Float special values as timeout

### DIFF
--- a/core/io/select_spec.rb
+++ b/core/io/select_spec.rb
@@ -121,6 +121,10 @@ describe "IO.select" do
     end
   end
 
+  it "raises an RangeError when passed NaN as timeout" do
+    -> { IO.select(nil, nil, nil, Float::NAN)}.should raise_error(RangeError, "NaN out of Time range")
+  end
+
   describe "returns the available descriptors when the file descriptor" do
     it "is in both read and error arrays" do
       @wr.write("foobar")


### PR DESCRIPTION
`Float::INIFINITY` is now supported, but `-Float::INFINITY` and `Float::NAN` are other special values.

The negative infinity value overlaps with the regular negative values, but it does cover the scenario where a Ruby implementation would just check for `float.infinity?` in a boolean context for no timeout.