### PR TITLE
[Ruby 3.2] Add test for no extra escaping in error messages

### DIFF
--- a/command_line/error_message_spec.rb
+++ b/command_line/error_message_spec.rb
@@ -8,4 +8,9 @@ describe "The error message caused by an exception" do
     out = ruby_exe("end #syntax error", args: "2> #{File::NULL}", exit_status: 1)
     out.chomp.should.empty?
   end
+
+  it "is not modified with extra escaping of control characters and backslashes" do
+    out = ruby_exe('raise "\e[31mRed\e[0m error\\\\message"', args: "2>&1", exit_status: 1)
+    out.chomp.should include("\e[31mRed\e[0m error\\message")
+  end
 end


### PR DESCRIPTION
From #1016 

> Ruby no longer escapes control characters and backslashes in an error message. [Feature #18367]