### PR TITLE
Add specs for IO::Buffer's bitwise operations

### DIFF
--- a/core/io/buffer/and_spec.rb
+++ b/core/io/buffer/and_spec.rb
@@ -1,0 +1,62 @@
+require_relative '../../../spec_helper'
+
+describe :io_buffer_and, shared: true do
+  it "applies the argument buffer as an AND bit mask across the whole buffer" do
+    IO::Buffer.for(+"12345") do |buffer|
+      IO::Buffer.for(+"\xF8\x8F") do |mask|
+        result = buffer.send(@method, mask)
+        result.get_string.should == "\x30\x02\x30\x04\x30".b
+        result.free
+      end
+    end
+  end
+
+  it "ignores extra parts of mask if it is longer than source buffer" do
+    IO::Buffer.for(+"12345") do |buffer|
+      IO::Buffer.for(+"\xF8\x8F\x00\x00\x00\xFF\xFF") do |mask|
+        result = buffer.send(@method, mask)
+        result.get_string.should == "\x30\x02\x00\x00\x00".b
+        result.free
+      end
+    end
+  end
+
+  it "raises TypeError if mask is not an IO::Buffer" do
+    IO::Buffer.for(+"12345") do |buffer|
+      -> { buffer.send(@method, "\xF8\x8F") }.should raise_error(TypeError, "wrong argument type String (expected IO::Buffer)")
+      -> { buffer.send(@method, 0xF8) }.should raise_error(TypeError, "wrong argument type Integer (expected IO::Buffer)")
+      -> { buffer.send(@method, nil) }.should raise_error(TypeError, "wrong argument type nil (expected IO::Buffer)")
+    end
+  end
+end
+
+describe "IO::Buffer#&" do
+  it_behaves_like :io_buffer_and, :&
+
+  it "creates a new internal buffer of the same size" do
+    IO::Buffer.for(+"12345") do |buffer|
+      IO::Buffer.for(+"\xF8\x8F") do |mask|
+        result = buffer & mask
+        result.should_not.equal? buffer
+        result.should.internal?
+        result.size.should == buffer.size
+        result.free
+        buffer.get_string.should == "12345".b
+      end
+    end
+  end
+end
+
+describe "IO::Buffer#and!" do
+  it_behaves_like :io_buffer_and, :and!
+
+  it "modifies the buffer in place" do
+    IO::Buffer.for(+"12345") do |buffer|
+      IO::Buffer.for(+"\xF8\x8F") do |mask|
+        result = buffer.and!(mask)
+        result.should.equal? buffer
+        result.should.external?
+      end
+    end
+  end
+end

--- a/core/io/buffer/not_spec.rb
+++ b/core/io/buffer/not_spec.rb
@@ -1,0 +1,37 @@
+require_relative '../../../spec_helper'
+
+describe :io_buffer_not, shared: true do
+  it "inverts every bit of the buffer" do
+    IO::Buffer.for(+"12345") do |buffer|
+      result = buffer.send(@method)
+      result.get_string.should == "\xCE\xCD\xCC\xCB\xCA".b
+      result.free
+    end
+  end
+end
+
+describe "IO::Buffer#~" do
+  it_behaves_like :io_buffer_not, :~
+
+  it "creates a new internal buffer of the same size" do
+    IO::Buffer.for(+"12345") do |buffer|
+      result = ~buffer
+      result.should_not.equal? buffer
+      result.should.internal?
+      result.size.should == buffer.size
+      result.free
+    end
+  end
+end
+
+describe "IO::Buffer#not!" do
+  it_behaves_like :io_buffer_not, :not!
+
+  it "modifies the buffer in place" do
+    IO::Buffer.for(+"12345") do |buffer|
+      result = buffer.not!
+      result.should.equal? buffer
+      result.should.external?
+    end
+  end
+end

--- a/core/io/buffer/or_spec.rb
+++ b/core/io/buffer/or_spec.rb
@@ -1,0 +1,62 @@
+require_relative '../../../spec_helper'
+
+describe :io_buffer_or, shared: true do
+  it "applies the argument buffer as an OR bit mask across the whole buffer" do
+    IO::Buffer.for(+"12345") do |buffer|
+      IO::Buffer.for(+"\xF8\x8F") do |mask|
+        result = buffer.send(@method, mask)
+        result.get_string.should == "\xF9\xBF\xFB\xBF\xFD".b
+        result.free
+      end
+    end
+  end
+
+  it "ignores extra parts of mask if it is longer than source buffer" do
+    IO::Buffer.for(+"12345") do |buffer|
+      IO::Buffer.for(+"\xF8\x8F\x00\x00\x00\xFF\xFF") do |mask|
+        result = buffer.send(@method, mask)
+        result.get_string.should == "\xF9\xBF345".b
+        result.free
+      end
+    end
+  end
+
+  it "raises TypeError if mask is not an IO::Buffer" do
+    IO::Buffer.for(+"12345") do |buffer|
+      -> { buffer.send(@method, "\xF8\x8F") }.should raise_error(TypeError, "wrong argument type String (expected IO::Buffer)")
+      -> { buffer.send(@method, 0xF8) }.should raise_error(TypeError, "wrong argument type Integer (expected IO::Buffer)")
+      -> { buffer.send(@method, nil) }.should raise_error(TypeError, "wrong argument type nil (expected IO::Buffer)")
+    end
+  end
+end
+
+describe "IO::Buffer#|" do
+  it_behaves_like :io_buffer_or, :|
+
+  it "creates a new internal buffer of the same size" do
+    IO::Buffer.for(+"12345") do |buffer|
+      IO::Buffer.for(+"\xF8\x8F") do |mask|
+        result = buffer | mask
+        result.should_not.equal? buffer
+        result.should.internal?
+        result.size.should == buffer.size
+        result.free
+        buffer.get_string.should == "12345".b
+      end
+    end
+  end
+end
+
+describe "IO::Buffer#or!" do
+  it_behaves_like :io_buffer_or, :or!
+
+  it "modifies the buffer in place" do
+    IO::Buffer.for(+"12345") do |buffer|
+      IO::Buffer.for(+"\xF8\x8F") do |mask|
+        result = buffer.or!(mask)
+        result.should.equal? buffer
+        result.should.external?
+      end
+    end
+  end
+end

--- a/core/io/buffer/xor_spec.rb
+++ b/core/io/buffer/xor_spec.rb
@@ -1,0 +1,62 @@
+require_relative '../../../spec_helper'
+
+describe :io_buffer_xor, shared: true do
+  it "applies the argument buffer as an XOR bit mask across the whole buffer" do
+    IO::Buffer.for(+"12345") do |buffer|
+      IO::Buffer.for(+"\xF8\x8F") do |mask|
+        result = buffer.send(@method, mask)
+        result.get_string.should == "\xC9\xBD\xCB\xBB\xCD".b
+        result.free
+      end
+    end
+  end
+
+  it "ignores extra parts of mask if it is longer than source buffer" do
+    IO::Buffer.for(+"12345") do |buffer|
+      IO::Buffer.for(+"\xF8\x8F\x00\x00\x00\xFF\xFF") do |mask|
+        result = buffer.send(@method, mask)
+        result.get_string.should == "\xC9\xBD345".b
+        result.free
+      end
+    end
+  end
+
+  it "raises TypeError if mask is not an IO::Buffer" do
+    IO::Buffer.for(+"12345") do |buffer|
+      -> { buffer.send(@method, "\xF8\x8F") }.should raise_error(TypeError, "wrong argument type String (expected IO::Buffer)")
+      -> { buffer.send(@method, 0xF8) }.should raise_error(TypeError, "wrong argument type Integer (expected IO::Buffer)")
+      -> { buffer.send(@method, nil) }.should raise_error(TypeError, "wrong argument type nil (expected IO::Buffer)")
+    end
+  end
+end
+
+describe "IO::Buffer#^" do
+  it_behaves_like :io_buffer_xor, :^
+
+  it "creates a new internal buffer of the same size" do
+    IO::Buffer.for(+"12345") do |buffer|
+      IO::Buffer.for(+"\xF8\x8F") do |mask|
+        result = buffer ^ mask
+        result.should_not.equal? buffer
+        result.should.internal?
+        result.size.should == buffer.size
+        result.free
+        buffer.get_string.should == "12345".b
+      end
+    end
+  end
+end
+
+describe "IO::Buffer#xor!" do
+  it_behaves_like :io_buffer_xor, :xor!
+
+  it "modifies the buffer in place" do
+    IO::Buffer.for(+"12345") do |buffer|
+      IO::Buffer.for(+"\xF8\x8F") do |mask|
+        result = buffer.xor!(mask)
+        result.should.equal? buffer
+        result.should.external?
+      end
+    end
+  end
+end


### PR DESCRIPTION
Contrinuing from #1305 

Added specs for `#&`, `#and!`, `#|`, `#or!`, `#^`, `#xor!`, `#~`, `#not!`. They are all basically copies of each other, only the NOT is different as it is unary.