### PR TITLE
Remove RUBY_VERSION_IS_3_3 guards from C code

### DIFF
--- a/optional/capi/ext/io_spec.c
+++ b/optional/capi/ext/io_spec.c
@@ -319,13 +319,7 @@ static VALUE io_spec_errno_set(VALUE self, VALUE val) {
 
 VALUE io_spec_mode_sync_flag(VALUE self, VALUE io) {
   int mode;
-#ifdef RUBY_VERSION_IS_3_3
   mode = rb_io_mode(io);
-#else
-  rb_io_t *fp;
-  GetOpenFile(io, fp);
-  mode = fp->mode;
-#endif
   if (mode & FMODE_SYNC) {
     return Qtrue;
   } else {
@@ -333,7 +327,6 @@ VALUE io_spec_mode_sync_flag(VALUE self, VALUE io) {
   }
 }
 
-#if defined(RUBY_VERSION_IS_3_3) || defined(TRUFFLERUBY)
 static VALUE io_spec_rb_io_mode(VALUE self, VALUE io) {
   return INT2FIX(rb_io_mode(io));
 }
@@ -360,7 +353,6 @@ static VALUE io_spec_rb_io_open_descriptor(VALUE self, VALUE klass, VALUE descri
 static VALUE io_spec_rb_io_open_descriptor_without_encoding(VALUE self, VALUE klass, VALUE descriptor, VALUE mode, VALUE path, VALUE timeout) {
   return rb_io_open_descriptor(klass, FIX2INT(descriptor), FIX2INT(mode), path, timeout, NULL);
 }
-#endif
 
 void Init_io_spec(void) {
   VALUE cls = rb_define_class("CApiIOSpecs", rb_cObject);
@@ -393,7 +385,6 @@ void Init_io_spec(void) {
   rb_define_method(cls, "rb_cloexec_open", io_spec_rb_cloexec_open, 3);
   rb_define_method(cls, "errno=", io_spec_errno_set, 1);
   rb_define_method(cls, "rb_io_mode_sync_flag", io_spec_mode_sync_flag, 1);
-#if defined(RUBY_VERSION_IS_3_3) || defined(TRUFFLERUBY)
   rb_define_method(cls, "rb_io_mode", io_spec_rb_io_mode, 1);
   rb_define_method(cls, "rb_io_path", io_spec_rb_io_path, 1);
   rb_define_method(cls, "rb_io_closed_p", io_spec_rb_io_closed_p, 1);
@@ -404,7 +395,6 @@ void Init_io_spec(void) {
   rb_define_const(cls, "FMODE_BINMODE", INT2FIX(FMODE_BINMODE));
   rb_define_const(cls, "FMODE_TEXTMODE", INT2FIX(FMODE_TEXTMODE));
   rb_define_const(cls, "ECONV_UNIVERSAL_NEWLINE_DECORATOR", INT2FIX(ECONV_UNIVERSAL_NEWLINE_DECORATOR));
-#endif
 }
 
 #ifdef __cplusplus

--- a/optional/capi/ext/rubyspec.h
+++ b/optional/capi/ext/rubyspec.h
@@ -43,8 +43,4 @@
 #define RUBY_VERSION_IS_3_4
 #endif
 
-#if RUBY_VERSION_SINCE(3, 3)
-#define RUBY_VERSION_IS_3_3
-#endif
-
 #endif

--- a/optional/capi/ext/struct_spec.c
+++ b/optional/capi/ext/struct_spec.c
@@ -66,7 +66,6 @@ static VALUE struct_spec_rb_struct_initialize(VALUE self, VALUE st, VALUE values
   return rb_struct_initialize(st, values);
 }
 
-#if defined(RUBY_VERSION_IS_3_3)
 /* Only allow setting three attributes, should be sufficient for testing. */
 static VALUE struct_spec_rb_data_define(VALUE self, VALUE superclass,
   VALUE attr1, VALUE attr2, VALUE attr3) {
@@ -81,7 +80,6 @@ static VALUE struct_spec_rb_data_define(VALUE self, VALUE superclass,
 
   return rb_data_define(superclass, a1, a2, a3, NULL);
 }
-#endif
 
 void Init_struct_spec(void) {
   VALUE cls = rb_define_class("CApiStructSpecs", rb_cObject);
@@ -95,9 +93,7 @@ void Init_struct_spec(void) {
   rb_define_method(cls, "rb_struct_new", struct_spec_rb_struct_new, 4);
   rb_define_method(cls, "rb_struct_size", struct_spec_rb_struct_size, 1);
   rb_define_method(cls, "rb_struct_initialize", struct_spec_rb_struct_initialize, 2);
-#if defined(RUBY_VERSION_IS_3_3)
   rb_define_method(cls, "rb_data_define", struct_spec_rb_data_define, 4);
-#endif
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
These guards were missed in #1335.

Support for Ruby 3.2 was dropped in 77f1d3b7df7d4d842eb40ec7f989c59221f28c14 and guards in Ruby were removed in 1c0dea67a7ed74eec3113b5f238567670c06239e.