### PR TITLE
[Ruby 3.3] Add more tests for Regexp.linear_time?

### DIFF
--- a/core/regexp/linear_time_spec.rb
+++ b/core/regexp/linear_time_spec.rb
@@ -33,19 +33,48 @@ describe "Regexp.linear_time?" do
     Regexp.linear_time?(/a*(?:(?<=a)a*)*b/).should == true
   end
 
-  it "returns true for negative lookahead" do
-    Regexp.linear_time?(/a*(?:(?!a*)a*)*b/).should == true
-  end
-
   it "returns true for negative lookbehind" do
     Regexp.linear_time?(/a*(?:(?<!a)a*)*b/).should == true
   end
 
-  it "returns true for atomic groups" do
-    Regexp.linear_time?(/a*(?:(?>a)a*)*b/).should == true
+  # There are two known ways to make Regexp linear:
+  # * Using a DFA (deterministic finite-state automaton) Regexp engine, which always matches in linear time (e.g. TruffleRuby with TRegex)
+  # * Caching position and state to avoid catastrophic backtracking (e.g. CRuby: https://bugs.ruby-lang.org/issues/19104)
+  #
+  # Both approach should be allowed and given that DFA Regexp engines
+  # are much faster there should be no specs preventing using them.
+  uses_regexp_caching = RUBY_ENGINE == 'ruby'
+  uses_dfa_regexp_engine = !uses_regexp_caching
+
+  # The following specs should not be relied upon,
+  # they are here only to illustrate differences between Regexp engines.
+  guard -> { uses_regexp_caching } do
+    it "returns true for negative lookahead" do
+      Regexp.linear_time?(/a*(?:(?!a*)a*)*b/).should == true
+    end
+
+    it "returns true for atomic groups" do
+      Regexp.linear_time?(/a*(?:(?>a)a*)*b/).should == true
+    end
+
+    it "returns true for possessive quantifiers" do
+      Regexp.linear_time?(/a*(?:(?:a)?+a*)*b/).should == true
+    end
+
+    it "returns true for positive lookbehind with capture group" do
+      Regexp.linear_time?(/.(?<=(a))/).should == true
+    end
   end
 
-  it "returns true for possessive quantifiers" do
-    Regexp.linear_time?(/a*(?:(?:a)?+a*)*b/).should == true
+  # The following specs should not be relied upon,
+  # they are here only to illustrate differences between Regexp engines.
+  guard -> { uses_dfa_regexp_engine } do
+    it "returns true for non-recursive subexpression call" do
+      Regexp.linear_time?(/(?<a>a){0}\g<a>/).should == true
+    end
+
+    it "returns true for positive lookahead with capture group" do
+      Regexp.linear_time?(/x+(?=(a))/).should == true
+    end
   end
 end


### PR DESCRIPTION
As #1223 was merged, let's do more of them.

From #1216 
> The cache-based optimization now supports lookarounds and atomic groupings. That is, match
for Regexp containing these extensions can now also be performed in linear time to the length of the input string. However, these cannot contain captures and cannot be nested. [Feature #19725]

Should negative cases be included? Not sure. Also, regexp with a capture group in a positive lookbehind is surprisingly linear.