### PR TITLE
Match error messages for TypeError in File specs

### DIFF
--- a/core/file/basename_spec.rb
+++ b/core/file/basename_spec.rb
@@ -105,10 +105,10 @@ describe "File.basename" do
   end
 
   it "raises a TypeError if the arguments are not String types" do
-    -> { File.basename(nil)          }.should raise_error(TypeError)
-    -> { File.basename(1)            }.should raise_error(TypeError)
-    -> { File.basename("bar.txt", 1) }.should raise_error(TypeError)
-    -> { File.basename(true)         }.should raise_error(TypeError)
+    -> { File.basename(nil)          }.should raise_error(TypeError, "no implicit conversion of nil into String")
+    -> { File.basename(1)            }.should raise_error(TypeError, "no implicit conversion of Integer into String")
+    -> { File.basename("bar.txt", 1) }.should raise_error(TypeError, "no implicit conversion of Integer into String")
+    -> { File.basename(true)         }.should raise_error(TypeError, "no implicit conversion of true into String")
   end
 
   it "accepts an object that has a #to_path method" do

--- a/core/file/chmod_spec.rb
+++ b/core/file/chmod_spec.rb
@@ -106,7 +106,8 @@ describe "File.chmod" do
   end
 
   it "throws a TypeError if the given path is not coercible into a string" do
-    -> { File.chmod(0, []) }.should raise_error(TypeError)
+    -> { File.chmod(0, [])    }.should raise_error(TypeError, "no implicit conversion of Array into String")
+    -> { File.chmod(0, false) }.should raise_error(TypeError, "no implicit conversion of false into String")
   end
 
   it "raises an error for a non existent path" do

--- a/core/file/dirname_spec.rb
+++ b/core/file/dirname_spec.rb
@@ -134,10 +134,10 @@ describe "File.dirname" do
   end
 
   it "raises a TypeError if not passed a String type" do
-    -> { File.dirname(nil)   }.should raise_error(TypeError)
-    -> { File.dirname(0)     }.should raise_error(TypeError)
-    -> { File.dirname(true)  }.should raise_error(TypeError)
-    -> { File.dirname(false) }.should raise_error(TypeError)
+    -> { File.dirname(nil)   }.should raise_error(TypeError, "no implicit conversion of nil into String")
+    -> { File.dirname(0)     }.should raise_error(TypeError, "no implicit conversion of Integer into String")
+    -> { File.dirname(true)  }.should raise_error(TypeError, "no implicit conversion of true into String")
+    -> { File.dirname(false) }.should raise_error(TypeError, "no implicit conversion of false into String")
   end
 
   # Windows specific tests

--- a/core/file/expand_path_spec.rb
+++ b/core/file/expand_path_spec.rb
@@ -117,9 +117,9 @@ describe "File.expand_path" do
   end
 
   it "raises a TypeError if not passed a String type" do
-    -> { File.expand_path(1)    }.should raise_error(TypeError)
-    -> { File.expand_path(nil)  }.should raise_error(TypeError)
-    -> { File.expand_path(true) }.should raise_error(TypeError)
+    -> { File.expand_path(1)    }.should raise_error(TypeError, "no implicit conversion of Integer into String")
+    -> { File.expand_path(nil)  }.should raise_error(TypeError, "no implicit conversion of nil into String")
+    -> { File.expand_path(true) }.should raise_error(TypeError, "no implicit conversion of true into String")
   end
 
   platform_is_not :windows do

--- a/core/file/extname_spec.rb
+++ b/core/file/extname_spec.rb
@@ -57,10 +57,10 @@ describe "File.extname" do
   end
 
   it "raises a TypeError if not passed a String type" do
-    -> { File.extname(nil)   }.should raise_error(TypeError)
-    -> { File.extname(0)     }.should raise_error(TypeError)
-    -> { File.extname(true)  }.should raise_error(TypeError)
-    -> { File.extname(false) }.should raise_error(TypeError)
+    -> { File.extname(nil)   }.should raise_error(TypeError, "no implicit conversion of nil into String")
+    -> { File.extname(0)     }.should raise_error(TypeError, "no implicit conversion of Integer into String")
+    -> { File.extname(true)  }.should raise_error(TypeError, "no implicit conversion of true into String")
+    -> { File.extname(false) }.should raise_error(TypeError, "no implicit conversion of false into String")
   end
 
   it "raises an ArgumentError if not passed one argument" do

--- a/core/file/join_spec.rb
+++ b/core/file/join_spec.rb
@@ -108,11 +108,11 @@ describe "File.join" do
   end
 
   it "raises a TypeError exception when args are nil" do
-    -> { File.join nil }.should raise_error(TypeError)
+    -> { File.join nil }.should raise_error(TypeError, "no implicit conversion of nil into String")
   end
 
   it "calls #to_str" do
-    -> { File.join(mock('x')) }.should raise_error(TypeError)
+    -> { File.join(mock('x')) }.should raise_error(TypeError, "no implicit conversion of MockObject into String")
 
     bin = mock("bin")
     bin.should_receive(:to_str).exactly(:twice).and_return("bin")
@@ -129,7 +129,7 @@ describe "File.join" do
   end
 
   it "calls #to_path" do
-    -> { File.join(mock('x')) }.should raise_error(TypeError)
+    -> { File.join(mock('x')) }.should raise_error(TypeError, "no implicit conversion of MockObject into String")
 
     bin = mock("bin")
     bin.should_receive(:to_path).exactly(:twice).and_return("bin")

--- a/core/file/link_spec.rb
+++ b/core/file/link_spec.rb
@@ -32,8 +32,8 @@ describe "File.link" do
     end
 
     it "raises a TypeError if not passed String types" do
-      -> { File.link(@file, nil) }.should raise_error(TypeError)
-      -> { File.link(@file, 1)   }.should raise_error(TypeError)
+      -> { File.link(@file, nil) }.should raise_error(TypeError, "no implicit conversion of nil into String")
+      -> { File.link(@file, 1)   }.should raise_error(TypeError, "no implicit conversion of Integer into String")
     end
   end
 end

--- a/core/file/mkfifo_spec.rb
+++ b/core/file/mkfifo_spec.rb
@@ -19,7 +19,8 @@ describe "File.mkfifo" do
 
     context "when path passed is not a String value" do
       it "raises a TypeError" do
-        -> { File.mkfifo(:"/tmp/fifo") }.should raise_error(TypeError)
+        -> { File.mkfifo(:"/tmp/fifo") }.should raise_error(TypeError, "no implicit conversion of Symbol into String")
+        -> { File.mkfifo(false)        }.should raise_error(TypeError, "no implicit conversion of false into String")
       end
     end
 

--- a/core/file/new_spec.rb
+++ b/core/file/new_spec.rb
@@ -195,12 +195,13 @@ describe "File.new" do
   end
 
   it "raises a TypeError if the first parameter can't be coerced to a string" do
-    -> { File.new(true) }.should raise_error(TypeError)
-    -> { File.new(false) }.should raise_error(TypeError)
+    -> { File.new(true) }.should raise_error(TypeError, "no implicit conversion of true into String")
+    -> { File.new(false) }.should raise_error(TypeError, "no implicit conversion of false into String")
+    -> { File.new([]) }.should raise_error(TypeError, "no implicit conversion of Array into String")
   end
 
   it "raises a TypeError if the first parameter is nil" do
-    -> { File.new(nil) }.should raise_error(TypeError)
+    -> { File.new(nil) }.should raise_error(TypeError, "no implicit conversion of nil into String")
   end
 
   it "raises an Errno::EBADF if the first parameter is an invalid file descriptor" do

--- a/core/file/open_spec.rb
+++ b/core/file/open_spec.rb
@@ -543,9 +543,10 @@ describe "File.open" do
   end
 
   it "raises a TypeError if passed a filename that is not a String or Integer type" do
-    -> { File.open(true)  }.should raise_error(TypeError)
-    -> { File.open(false) }.should raise_error(TypeError)
-    -> { File.open(nil)   }.should raise_error(TypeError)
+    -> { File.open(true)  }.should raise_error(TypeError, "no implicit conversion of true into String")
+    -> { File.open(false) }.should raise_error(TypeError, "no implicit conversion of false into String")
+    -> { File.open(nil)   }.should raise_error(TypeError, "no implicit conversion of nil into String")
+    -> { File.open([])    }.should raise_error(TypeError, "no implicit conversion of Array into String")
   end
 
   it "raises a SystemCallError if passed an invalid Integer type" do

--- a/core/file/path_spec.rb
+++ b/core/file/path_spec.rb
@@ -41,11 +41,11 @@ describe "File.path" do
   it "raises TypeError when #to_path result is not a string" do
     path = mock("path")
     path.should_receive(:to_path).and_return(nil)
-    -> { File.path(path) }.should raise_error TypeError
+    -> { File.path(path) }.should raise_error(TypeError, "no implicit conversion of nil into String")
 
     path = mock("path")
     path.should_receive(:to_path).and_return(42)
-    -> { File.path(path) }.should raise_error TypeError
+    -> { File.path(path) }.should raise_error(TypeError, "no implicit conversion of Integer into String")
   end
 
   it "raises ArgumentError for string argument contains NUL character" do

--- a/core/file/shared/unlink.rb
+++ b/core/file/shared/unlink.rb
@@ -31,7 +31,8 @@ describe :file_unlink, shared: true do
   end
 
   it "raises a TypeError if not passed a String type" do
-    -> { File.send(@method, 1) }.should raise_error(TypeError)
+    -> { File.send(@method, 1) }.should raise_error(TypeError, "no implicit conversion of Integer into String")
+    -> { File.send(@method, nil) }.should raise_error(TypeError, "no implicit conversion of nil into String")
   end
 
   it "raises an Errno::ENOENT when the given file doesn't exist" do

--- a/core/file/split_spec.rb
+++ b/core/file/split_spec.rb
@@ -49,7 +49,8 @@ describe "File.split" do
   end
 
   it "raises a TypeError if the argument is not a String type" do
-    -> { File.split(1) }.should raise_error(TypeError)
+    -> { File.split(1) }.should raise_error(TypeError, "no implicit conversion of Integer into String")
+    -> { File.split(false) }.should raise_error(TypeError, "no implicit conversion of false into String")
   end
 
   it "coerces the argument with to_str if it is not a String type" do

--- a/core/file/symlink_spec.rb
+++ b/core/file/symlink_spec.rb
@@ -41,9 +41,9 @@ describe "File.symlink" do
     end
 
     it "raises a TypeError if not called with String types" do
-      -> { File.symlink(@file, nil) }.should raise_error(TypeError)
-      -> { File.symlink(@file, 1)   }.should raise_error(TypeError)
-      -> { File.symlink(1, 1)       }.should raise_error(TypeError)
+      -> { File.symlink(@file, nil) }.should raise_error(TypeError, "no implicit conversion of nil into String")
+      -> { File.symlink(@file, 1)   }.should raise_error(TypeError, "no implicit conversion of Integer into String")
+      -> { File.symlink(1, 1)       }.should raise_error(TypeError, "no implicit conversion of Integer into String")
     end
   end
 end

--- a/core/file/truncate_spec.rb
+++ b/core/file/truncate_spec.rb
@@ -72,11 +72,13 @@ describe "File.truncate" do
   end
 
   it "raises a TypeError if not passed a String type for the first argument" do
-    -> { File.truncate(1, 1) }.should raise_error(TypeError)
+    -> { File.truncate(1, 1) }.should raise_error(TypeError, "no implicit conversion of Integer into String")
+    -> { File.truncate(false, 1) }.should raise_error(TypeError, "no implicit conversion of false into String")
   end
 
   it "raises a TypeError if not passed an Integer type for the second argument" do
-    -> { File.truncate(@name, nil) }.should raise_error(TypeError)
+    -> { File.truncate(@name, nil) }.should raise_error(TypeError, /no implicit conversion from nil( to integer)?/)
+    -> { File.truncate(@name, "") }.should raise_error(TypeError, /no implicit conversion (of String into Integer|from string)/)
   end
 
   it "accepts an object that has a #to_path method" do
@@ -172,6 +174,7 @@ describe "File#truncate" do
   end
 
   it "raises a TypeError if not passed an Integer type for the for the argument" do
-    -> { @file.truncate(nil) }.should raise_error(TypeError)
+    -> { @file.truncate(nil) }.should raise_error(TypeError, /no implicit conversion from nil( to integer)?/)
+    -> { @file.truncate([]) }.should raise_error(TypeError, "no implicit conversion of Array into Integer")
   end
 end


### PR DESCRIPTION
There are two different code paths: true/false/nil uses the default inspect string in the error message, other objects use the class name.

The conversion into Integer is even more inconsistent, where it's sometimes "from X to integer" and sometimes "of X into Integer".