### PR TITLE
Set string length in string_spec_RSTRING_PTR_read

### DIFF
--- a/optional/capi/ext/string_spec.c
+++ b/optional/capi/ext/string_spec.c
@@ -393,6 +393,7 @@ VALUE string_spec_RSTRING_PTR_read(VALUE self, VALUE str, VALUE path) {
   if (read(fd, buffer, 30) < 0) {
     rb_syserr_fail(errno, "read");
   }
+  rb_str_set_len(str, 30);
 
   rb_str_modify_expand(str, 53);
   rb_ary_push(capacities, SIZET2NUM(rb_str_capacity(str)));


### PR DESCRIPTION
Since we do not set the length between the call to `read(fd, buffer, 30)` and `rb_str_modify_expand(str, 53)`, the length of the string is technically zero. If the call to `rb_str_modify_expand` actually expands the buffer, it will overwrite all the contents from the `read`.