### PR TITLE
Ensure hard reference for frozen strings

### DIFF
--- a/language/fixtures/freeze_magic_comment_across_files.rb
+++ b/language/fixtures/freeze_magic_comment_across_files.rb
@@ -2,4 +2,5 @@
 
 require_relative 'freeze_magic_comment_required'
 
-p "abc".object_id == $second_literal_id
+p "abc".equal?($second_literal)
+$second_literal = nil

--- a/language/fixtures/freeze_magic_comment_across_files_diff_enc.rb
+++ b/language/fixtures/freeze_magic_comment_across_files_diff_enc.rb
@@ -2,4 +2,5 @@
 
 require_relative 'freeze_magic_comment_required_diff_enc'
 
-p "abc".object_id != $second_literal_id
+p !"abc".equal?($second_literal)
+$second_literal = nil

--- a/language/fixtures/freeze_magic_comment_across_files_no_comment.rb
+++ b/language/fixtures/freeze_magic_comment_across_files_no_comment.rb
@@ -2,4 +2,5 @@
 
 require_relative 'freeze_magic_comment_required_no_comment'
 
-p "abc".object_id != $second_literal_id
+p !"abc".equal?($second_literal)
+$second_literal = nil

--- a/language/fixtures/freeze_magic_comment_one_literal.rb
+++ b/language/fixtures/freeze_magic_comment_one_literal.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-ids = Array.new(2) { "abc".object_id }
-p ids.first == ids.last
+objs = Array.new(2) { "abc" }
+p objs.first.equal?(objs.last)

--- a/language/fixtures/freeze_magic_comment_required.rb
+++ b/language/fixtures/freeze_magic_comment_required.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-$second_literal_id = "abc".object_id
+$second_literal = "abc"

--- a/language/fixtures/freeze_magic_comment_required_diff_enc.rb
+++ b/language/fixtures/freeze_magic_comment_required_diff_enc.rb
@@ -1,4 +1,4 @@
 # encoding: euc-jp # built-in for old regexp option
 # frozen_string_literal: true
 
-$second_literal_id = "abc".object_id
+$second_literal = "abc"

--- a/language/fixtures/freeze_magic_comment_required_no_comment.rb
+++ b/language/fixtures/freeze_magic_comment_required_no_comment.rb
@@ -1,1 +1,1 @@
-$second_literal_id = "abc".object_id
+$second_literal = "abc"


### PR DESCRIPTION
These frozen strings must be hard referenced until the identity has been tested, or an intervening GC could cause them to get collected and improperly fail the test. The cross-require global now points at the string in question and is cleared after the identity test.