### PR TITLE
Add tests for Kernel#respond_to? without #respond_to_missing?

### DIFF
--- a/core/kernel/fixtures/classes.rb
+++ b/core/kernel/fixtures/classes.rb
@@ -180,6 +180,25 @@ module KernelSpecs
     alias aliased_pub_method pub_method
   end
 
+  class BasicA < BasicObject
+    define_method(:respond_to?, ::Kernel.instance_method(:respond_to?))
+
+    def pub_method; :public_method; end
+
+    def undefed_method; :undefed_method; end
+    undef_method :undefed_method
+
+    protected
+    def protected_method; :protected_method; end
+
+    private
+    def private_method; :private_method; end
+  end
+
+  class MissingA < A
+    undef :respond_to_missing?
+  end
+
   class VisibilityChange
     class << self
       private :new

--- a/core/kernel/respond_to_spec.rb
+++ b/core/kernel/respond_to_spec.rb
@@ -69,4 +69,31 @@ describe "Kernel#respond_to?" do
     KernelSpecs::Foo.new.respond_to?(:bar).should == true
     KernelSpecs::Foo.new.respond_to?(:invalid_and_silly_method_name).should == false
   end
+
+  context "if object does not have #respond_to_missing?" do
+    it "returns true if object responds to the given public method" do
+      KernelSpecs::BasicA.new.respond_to?(:pub_method).should == true
+      KernelSpecs::MissingA.new.respond_to?(:pub_method).should == true
+    end
+
+    it "returns false if object responds to the given protected method" do
+      KernelSpecs::BasicA.new.respond_to?(:protected_method).should == false
+      KernelSpecs::MissingA.new.respond_to?(:protected_method).should == false
+    end
+
+    it "returns false if object responds to the given private method" do
+      KernelSpecs::BasicA.new.respond_to?(:private_method).should == false
+      KernelSpecs::MissingA.new.respond_to?(:private_method).should == false
+    end
+
+    it "returns false if the given method was undefined" do
+      KernelSpecs::BasicA.new.respond_to?(:undefed_method).should == false
+      KernelSpecs::MissingA.new.respond_to?(:undefed_method).should == false
+    end
+
+    it "returns false if the given method never existed" do
+      KernelSpecs::BasicA.new.respond_to?(:invalid_and_silly_method_name).should == false
+      KernelSpecs::MissingA.new.respond_to?(:invalid_and_silly_method_name).should == false
+    end
+  end
 end


### PR DESCRIPTION
`#respond_to?` should work with unknown names even if `#respond_to_missing?` is not defined.