### PR TITLE
Spec: no verbose warning for inner block params

### DIFF
--- a/language/block_spec.rb
+++ b/language/block_spec.rb
@@ -1136,3 +1136,13 @@ describe "if `it` is defined as a variable" do
     proc { it = 5; it }.call(0).should == 5
   end
 end
+
+describe "Block-parameter destructuring" do
+  it "does not warn about unused inner names in verbose mode" do
+    -> {
+      eval <<~RUBY, binding, __FILE__, __LINE__ + 1
+        proc { |key, (val1, val2)| [key, val2] }
+      RUBY
+    }.should_not complain(verbose: true)
+  end
+end


### PR DESCRIPTION
Add a spec to ensure block-parameter destructuring does not emit unused variable warnings in verbose mode. The test evals a proc with parameters |key, (val1, val2)| and asserts it should_not complain(verbose: true), preventing false-positive warnings for inner destructured names.

This came up while working on https://github.com/jruby/jruby/pull/9400. There is an MRI test for the method-definition case, but no test for destructured block arguments. 