### PR TITLE
Add specs for original_name with define_method

### DIFF
--- a/core/method/original_name_spec.rb
+++ b/core/method/original_name_spec.rb
@@ -19,4 +19,19 @@ describe "Method#original_name" do
     obj.method(:baz).original_name.should == :foo
     obj.method(:baz).unbind.bind(obj).original_name.should == :foo
   end
+
+  it "returns the source UnboundMethod's name (not the name given to define_method)" do
+    klass = Class.new { define_method(:my_inspect, ::Kernel.instance_method(:inspect)) }
+    klass.new.method(:my_inspect).original_name.should == :inspect
+  end
+
+  it "preserves the source method's name through define_method and alias" do
+    source = Class.new { def my_method; end }
+    klass = Class.new(source) do
+      define_method(:renamed, source.instance_method(:my_method))
+      alias aliased renamed
+    end
+    klass.new.method(:renamed).original_name.should == :my_method
+    klass.new.method(:aliased).original_name.should == :my_method
+  end
 end

--- a/core/unboundmethod/original_name_spec.rb
+++ b/core/unboundmethod/original_name_spec.rb
@@ -19,4 +19,19 @@ describe "UnboundMethod#original_name" do
     obj.method(:baz).unbind.original_name.should == :foo
     UnboundMethodSpecs::Methods.instance_method(:baz).original_name.should == :foo
   end
+
+  it "returns the source UnboundMethod's name (not the name given to define_method)" do
+    klass = Class.new { define_method(:my_inspect, ::Kernel.instance_method(:inspect)) }
+    klass.instance_method(:my_inspect).original_name.should == :inspect
+  end
+
+  it "preserves the source method's name through define_method and alias" do
+    source = Class.new { def my_method; end }
+    klass = Class.new(source) do
+      define_method(:renamed, source.instance_method(:my_method))
+      alias aliased renamed
+    end
+    klass.instance_method(:renamed).original_name.should == :my_method
+    klass.instance_method(:aliased).original_name.should == :my_method
+  end
 end


### PR DESCRIPTION
Verify that Method#original_name and UnboundMethod#original_name return the source UnboundMethod's name when a method is created via define_method, and that the original name is preserved through define_method and aliasing.

Reason for the PR: 
Noticed that this behavior did not have test coverage when looking at https://github.com/jruby/jruby/issues/9257. 