### PR TITLE
Add specs for Method#/UnboundMethod#original_name through three-alias chain

### DIFF
--- a/core/method/fixtures/classes.rb
+++ b/core/method/fixtures/classes.rb
@@ -27,6 +27,7 @@ module MethodSpecs
 
     alias bar foo
     alias baz bar
+    alias qux baz
 
     def same_as_foo
       true

--- a/core/method/original_name_spec.rb
+++ b/core/method/original_name_spec.rb
@@ -20,6 +20,12 @@ describe "Method#original_name" do
     obj.method(:baz).unbind.bind(obj).original_name.should == :foo
   end
 
+  it "returns the original name even when aliased thrice" do
+    obj = MethodSpecs::Methods.new
+    obj.method(:qux).original_name.should == :foo
+    obj.method(:qux).unbind.bind(obj).original_name.should == :foo
+  end
+
   it "returns the source UnboundMethod's name (not the name given to define_method)" do
     klass = Class.new { define_method(:my_inspect, ::Kernel.instance_method(:inspect)) }
     klass.new.method(:my_inspect).original_name.should == :inspect

--- a/core/unboundmethod/fixtures/classes.rb
+++ b/core/unboundmethod/fixtures/classes.rb
@@ -36,6 +36,7 @@ module UnboundMethodSpecs
 
     alias bar foo
     alias baz bar
+    alias qux baz
     alias alias_1 foo
     alias alias_2 foo
 

--- a/core/unboundmethod/original_name_spec.rb
+++ b/core/unboundmethod/original_name_spec.rb
@@ -20,6 +20,12 @@ describe "UnboundMethod#original_name" do
     UnboundMethodSpecs::Methods.instance_method(:baz).original_name.should == :foo
   end
 
+  it "returns the original name even when aliased thrice" do
+    obj = UnboundMethodSpecs::Methods.new
+    obj.method(:qux).unbind.original_name.should == :foo
+    UnboundMethodSpecs::Methods.instance_method(:qux).original_name.should == :foo
+  end
+
   it "returns the source UnboundMethod's name (not the name given to define_method)" do
     klass = Class.new { define_method(:my_inspect, ::Kernel.instance_method(:inspect)) }
     klass.instance_method(:my_inspect).original_name.should == :inspect


### PR DESCRIPTION
Extend MethodSpecs::Methods and UnboundMethodSpecs::Methods with a third alias hop (alias qux baz), and add examples verifying that Method#original_name and UnboundMethod#original_name still return :foo when reached through three levels of aliasing.

The current two step one can be passed by an implementation does not walk the full chain. 

Noticed that the two step test passes on JRuby master and fails if you add a third step when working on adding https://github.com/ruby/spec/pull/1353. 