### PR TITLE
Add specs for Method#original_name and #inspect with Kernel methods

### DIFF
--- a/core/method/inspect_spec.rb
+++ b/core/method/inspect_spec.rb
@@ -1,6 +1,8 @@
 require_relative '../../spec_helper'
 require_relative 'shared/to_s'
+require_relative 'shared/aliased_inspect'
 
 describe "Method#inspect" do
   it_behaves_like :method_to_s, :inspect
+  it_behaves_like :method_to_s_aliased, :inspect, -> meth { meth }
 end

--- a/core/method/original_name_spec.rb
+++ b/core/method/original_name_spec.rb
@@ -40,4 +40,20 @@ describe "Method#original_name" do
     klass.new.method(:renamed).original_name.should == :my_method
     klass.new.method(:aliased).original_name.should == :my_method
   end
+
+  it "returns the source UnboundMethod's name for Kernel#is_a? and Kernel#kind_of?" do
+    klass = Class.new { define_method(:my_is_a?, ::Kernel.instance_method(:is_a?)) }
+    klass.new.method(:my_is_a?).original_name.should == :is_a?
+
+    klass = Class.new { define_method(:my_kind_of?, ::Kernel.instance_method(:kind_of?)) }
+    klass.new.method(:my_kind_of?).original_name.should == :kind_of?
+  end
+
+  it "preserves the source name when aliasing a define_method'd Kernel method" do
+    klass = Class.new do
+      define_method(:my_is_a?, ::Kernel.instance_method(:is_a?))
+      alias_method :renamed_is_a?, :my_is_a?
+    end
+    klass.new.method(:renamed_is_a?).original_name.should == :is_a?
+  end
 end

--- a/core/method/shared/aliased_inspect.rb
+++ b/core/method/shared/aliased_inspect.rb
@@ -1,0 +1,31 @@
+describe :method_to_s_aliased, shared: true do
+  # @object converts a bound Method to either a Method (identity) or an
+  # UnboundMethod (-> meth { meth.unbind }), so these expectations cover both
+  # Method#to_s/#inspect and UnboundMethod#to_s/#inspect.
+
+  it "shows the original name in parentheses for an aliased method" do
+    klass = Class.new do
+      def original_method; end
+      alias_method :renamed_method, :original_method
+    end
+    @object.call(klass.new.method(:renamed_method)).send(@method).should.include? '#renamed_method(original_method)'
+  end
+
+  it "shows the source UnboundMethod's name in parentheses for a define_method'd method" do
+    klass = Class.new { define_method(:renamed_is_a?, ::Kernel.instance_method(:is_a?)) }
+    @object.call(klass.new.method(:renamed_is_a?)).send(@method).should.include? '#renamed_is_a?(is_a?)'
+  end
+
+  it "does not annotate a directly looked-up Kernel method with a shared internal name" do
+    @object.call(Object.new.method(:is_a?)).send(@method).should_not.include? '(kind_of?)'
+    @object.call(Object.new.method(:kind_of?)).send(@method).should_not.include? '(is_a?)'
+  end
+
+  it "shows the source name when aliasing a define_method'd Kernel method" do
+    klass = Class.new do
+      define_method(:my_is_a?, ::Kernel.instance_method(:is_a?))
+      alias_method :renamed_is_a?, :my_is_a?
+    end
+    @object.call(klass.new.method(:renamed_is_a?)).send(@method).should.include? '#renamed_is_a?(is_a?)'
+  end
+end

--- a/core/method/to_s_spec.rb
+++ b/core/method/to_s_spec.rb
@@ -1,6 +1,8 @@
 require_relative '../../spec_helper'
 require_relative 'shared/to_s'
+require_relative 'shared/aliased_inspect'
 
 describe "Method#to_s" do
   it_behaves_like :method_to_s, :to_s
+  it_behaves_like :method_to_s_aliased, :to_s, -> meth { meth }
 end

--- a/core/unboundmethod/inspect_spec.rb
+++ b/core/unboundmethod/inspect_spec.rb
@@ -1,7 +1,9 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/to_s'
+require_relative '../method/shared/aliased_inspect'
 
 describe "UnboundMethod#inspect" do
   it_behaves_like :unboundmethod_to_s, :inspect
+  it_behaves_like :method_to_s_aliased, :inspect, -> meth { meth.unbind }
 end

--- a/core/unboundmethod/original_name_spec.rb
+++ b/core/unboundmethod/original_name_spec.rb
@@ -40,4 +40,20 @@ describe "UnboundMethod#original_name" do
     klass.instance_method(:renamed).original_name.should == :my_method
     klass.instance_method(:aliased).original_name.should == :my_method
   end
+
+  it "returns the source UnboundMethod's name for Kernel#is_a? and Kernel#kind_of?" do
+    klass = Class.new { define_method(:my_is_a?, ::Kernel.instance_method(:is_a?)) }
+    klass.instance_method(:my_is_a?).original_name.should == :is_a?
+
+    klass = Class.new { define_method(:my_kind_of?, ::Kernel.instance_method(:kind_of?)) }
+    klass.instance_method(:my_kind_of?).original_name.should == :kind_of?
+  end
+
+  it "preserves the source name when aliasing a define_method'd Kernel method" do
+    klass = Class.new do
+      define_method(:my_is_a?, ::Kernel.instance_method(:is_a?))
+      alias_method :renamed_is_a?, :my_is_a?
+    end
+    klass.instance_method(:renamed_is_a?).original_name.should == :is_a?
+  end
 end

--- a/core/unboundmethod/to_s_spec.rb
+++ b/core/unboundmethod/to_s_spec.rb
@@ -1,7 +1,9 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/to_s'
+require_relative '../method/shared/aliased_inspect'
 
 describe "UnboundMethod#to_s" do
   it_behaves_like :unboundmethod_to_s, :to_s
+  it_behaves_like :method_to_s_aliased, :to_s, -> meth { meth.unbind }
 end


### PR DESCRIPTION
Adds specs for Method#original_name and #inspect when define_method or alias is used with Kernel#is_a? / Kernel#kind_of? methods that can share an internal implementation in some Ruby implementations. Existing specs didn't catch when introspection leaked the shared internal name.

Also documents inspect's behavior on aliased methods, which wasn't previously covered.

Continuing the work started in https://github.com/ruby/spec/pull/1353 and adding specs that fail at least on JRuby. (the specs added in that PR now pass on JRuby master though!) 