### PR TITLE
Add specs for case/when with out-of-int-range Integer literals

### DIFF
--- a/language/case_spec.rb
+++ b/language/case_spec.rb
@@ -27,6 +27,41 @@ describe "The 'case'-construct" do
     @calls.should == [:foo, :bar]
   end
 
+  it "matches an Integer literal whose value does not fit in a 32-bit int" do
+    big = 10_000_000_000
+    case big
+    when 10_000_000_000; true
+    else                 false
+    end.should == true
+
+    case -3_000_000_000
+    when -3_000_000_000; true
+    else                 false
+    end.should == true
+  end
+
+  it "matches an arbitrary-precision Integer literal" do
+    huge = 1267650600228229401496703205376
+    case huge
+    when 1267650600228229401496703205376; true
+    else                                  false
+    end.should == true
+  end
+
+  it "dispatches correctly with mixed small and large Integer literals" do
+    pick = -> x {
+      case x
+      when 1267650600228229401496703205376 then :beyond_long
+      when 10_000_000_000                  then :beyond_int
+      when 1                               then :fits_int
+      else                                      :other
+      end
+    }
+
+    [1267650600228229401496703205376, 10_000_000_000, 1, :nope].map(&pick).should ==
+      [:beyond_long, :beyond_int, :fits_int, :other]
+  end
+
   it "evaluates the body of the when clause whose range expression includes the case target expression" do
     case 5
     when 21..30; false


### PR DESCRIPTION
Add specs covering case/when and if with Integer literals outside 32-bit int range (10_000_000_000, -3_000_000_000) and beyond 64-bit long range (1 << 100).

Existing case/when specs only exercised small Integers, so optimized implementations whose codepaths diverge at the int/long boundary were not covered.

Found coverage missing when looking at https://github.com/jruby/jruby/issues/9320. 