### PR TITLE
Specify that `->` is not sugar for `Kernel#lambda`

### DIFF
--- a/language/lambda_spec.rb
+++ b/language/lambda_spec.rb
@@ -14,6 +14,12 @@ describe "A lambda literal -> () { }" do
     klass.new.create_lambda.should.instance_of?(Proc)
   end
 
+  it "is not just syntactic sugar for Kernel#lambda" do
+    should_not_receive(:lambda)
+
+    -> {}
+  end
+
   it "does not execute the block" do
     -> { fail }.should.instance_of?(Proc)
   end


### PR DESCRIPTION
I.e. you can't hook the behaviour of `->`, like you can with `lambda {}` and `proc {}`.

Here's the [relevant code](https://github.com/Shopify/ruby/blob/5ba44d6a10da049ac8b4607245dc4651d3f40578/prism_compile.c#L9778-L9779) in cruby, which calls `#lambda` on the hidden and unpatchable `RubyVM::FrozenCore` class.
