### PR TITLE
Add specs for defined? on protected methods

### DIFF
--- a/language/defined_spec.rb
+++ b/language/defined_spec.rb
@@ -211,6 +211,22 @@ describe "The defined? keyword when called with a method name" do
       }.should complain(/warning: possibly useless use of defined\? in void context/, verbose: true)
     end
   end
+
+  describe "for a protected method" do
+    it "returns 'method' when the receiver is a subclass instance" do
+      DefinedSpecs::ProtectedBase.new.defined_on(DefinedSpecs::ProtectedSubclass.new).should == "method"
+    end
+
+    it "returns 'method' when the receiver is the base class instance" do
+      DefinedSpecs::ProtectedSubclass.new.defined_on(DefinedSpecs::ProtectedBase.new).should == "method"
+    end
+
+    ruby_bug "#22076", ""..."4.1" do
+      it "returns 'method' when the receiver is a sibling class instance via a shared included module" do
+        DefinedSpecs::ProtectedIncluderA.new.defined_on(DefinedSpecs::ProtectedIncluderB.new).should == "method"
+      end
+    end
+  end
 end
 
 describe "The defined? keyword for an expression" do

--- a/language/fixtures/defined.rb
+++ b/language/fixtures/defined.rb
@@ -299,6 +299,33 @@ module DefinedSpecs
       super
     end
   end
+
+  class ProtectedBase
+    def m; end
+    protected :m
+    def defined_on(o)
+      defined?(o.m)
+    end
+  end
+
+  class ProtectedSubclass < ProtectedBase
+  end
+
+  module ProtectedInModule
+    def m; end
+    protected :m
+    def defined_on(o)
+      defined?(o.m)
+    end
+  end
+
+  class ProtectedIncluderA
+    include ProtectedInModule
+  end
+
+  class ProtectedIncluderB
+    include ProtectedInModule
+  end
 end
 
 class Object


### PR DESCRIPTION
Covers protected methods accessed via subclass receiver, base-class receiver, and a shared included module. The module case is guarded by ruby_bug "#22076" until 4.1. MRI's defined? returned nil when the call would have succeeded. Fix is in master with backports marked as required for 3.3, 3.4, 4.0.

MRI fix: https://github.com/ruby/ruby/pull/17069
[Bug #22076](https://bugs.ruby-lang.org/issues/22076)

Hopefully I used `ruby_bug` correctly. 