### PR TITLE
Add value packing specs for more Enumerable and Enumerator::Lazy methods

### DIFF
--- a/core/enumerable/compact_spec.rb
+++ b/core/enumerable/compact_spec.rb
@@ -2,6 +2,18 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
 describe "Enumerable#compact" do
+  describe "value packing of source yields" do
+    it "packs a multi-argument source yield into an Array" do
+      e = Enumerator.new { |y| y.yield 1, 2 }
+      e.compact.should == [[1, 2]]
+    end
+
+    it "removes a zero-argument source yield like nil" do
+      e = Enumerator.new { |y| y.yield; y.yield :v }
+      e.compact.should == [:v]
+    end
+  end
+
   it 'returns array without nil elements' do
     arr = EnumerableSpecs::Numerous.new(nil, 1, 2, nil, true)
     arr.compact.should == [1, 2, true]

--- a/core/enumerable/drop_spec.rb
+++ b/core/enumerable/drop_spec.rb
@@ -1,7 +1,15 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative 'shared/value_packing'
 
 describe "Enumerable#drop" do
+  describe "value packing of source yields" do
+    before :each do
+      @take = -> e { e.drop(0) }
+    end
+    it_behaves_like :enumerable_value_packing, nil
+  end
+
   before :each do
     @enum = EnumerableSpecs::Numerous.new(3, 2, 1, :go)
   end

--- a/core/enumerable/drop_while_spec.rb
+++ b/core/enumerable/drop_while_spec.rb
@@ -1,8 +1,16 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/enumerable_enumeratorized'
+require_relative 'shared/value_packing'
 
 describe "Enumerable#drop_while" do
+  describe "value packing of source yields" do
+    before :each do
+      @take = -> e { e.drop_while { false } }
+    end
+    it_behaves_like :enumerable_value_packing, nil
+  end
+
   before :each do
     @enum = EnumerableSpecs::Numerous.new(3, 2, 1, :go)
   end

--- a/core/enumerable/reject_spec.rb
+++ b/core/enumerable/reject_spec.rb
@@ -1,8 +1,16 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/enumerable_enumeratorized'
+require_relative 'shared/value_packing'
 
 describe "Enumerable#reject" do
+  describe "value packing of source yields" do
+    before :each do
+      @take = -> e { e.reject { false } }
+    end
+    it_behaves_like :enumerable_value_packing, nil
+  end
+
   it "returns an array of the elements for which block is false" do
     EnumerableSpecs::Numerous.new.reject { |i| i > 3 }.should == [2, 3, 1]
     entries = (1..10).to_a

--- a/core/enumerable/select_spec.rb
+++ b/core/enumerable/select_spec.rb
@@ -1,8 +1,16 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/enumerable_enumeratorized'
+require_relative 'shared/value_packing'
 
 describe "Enumerable#select" do
+  describe "value packing of source yields" do
+    before :each do
+      @take = -> e { e.select { true } }
+    end
+    it_behaves_like :enumerable_value_packing, nil
+  end
+
   before :each do
     ScratchPad.record []
     @elements = (1..10).to_a

--- a/core/enumerable/take_while_spec.rb
+++ b/core/enumerable/take_while_spec.rb
@@ -1,8 +1,16 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/enumerable_enumeratorized'
+require_relative 'shared/value_packing'
 
 describe "Enumerable#take_while" do
+  describe "value packing of source yields" do
+    before :each do
+      @take = -> e { e.take_while { true } }
+    end
+    it_behaves_like :enumerable_value_packing, nil
+  end
+
   before :each do
     @enum = EnumerableSpecs::Numerous.new(3, 2, 1, :go)
   end

--- a/core/enumerable/uniq_spec.rb
+++ b/core/enumerable/uniq_spec.rb
@@ -1,7 +1,15 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative 'shared/value_packing'
 
 describe 'Enumerable#uniq' do
+  describe "value packing of source yields" do
+    before :each do
+      @take = -> e { e.uniq }
+    end
+    it_behaves_like :enumerable_value_packing, nil
+  end
+
   it 'returns an array that contains only unique elements' do
     [0, 1, 2, 3].to_enum.uniq { |n| n.even? }.should == [0, 1]
   end

--- a/core/enumerator/lazy/compact_spec.rb
+++ b/core/enumerator/lazy/compact_spec.rb
@@ -2,6 +2,23 @@ require_relative '../../../spec_helper'
 require_relative 'fixtures/classes'
 
 describe "Enumerator::Lazy#compact" do
+  # Cannot use shared/value_packing.rb examples: the packed nil is removed by #compact.
+  describe "value packing of source yields" do
+    it "packs a multi-argument source yield into an Array" do
+      e = Enumerator.new { |y| y.yield 1, 2 }
+      args = nil
+      e.lazy.compact.each { |*a| args = a }
+      args.should == [[1, 2]]
+    end
+
+    it "removes a zero-argument source yield like nil" do
+      e = Enumerator.new { |y| y.yield; y.yield :v }
+      collected = []
+      e.lazy.compact.each { |*a| collected << a }
+      collected.should == [[:v]]
+    end
+  end
+
   it 'returns array without nil elements' do
     arr = [1, nil, 3, false, 5].to_enum.lazy.compact
     arr.should.instance_of?(Enumerator::Lazy)

--- a/core/enumerator/lazy/drop_spec.rb
+++ b/core/enumerator/lazy/drop_spec.rb
@@ -2,8 +2,16 @@
 
 require_relative '../../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative '../../enumerable/shared/value_packing'
 
 describe "Enumerator::Lazy#drop" do
+  describe "value packing of source yields (matches Enumerable#drop)" do
+    before :each do
+      @take = -> e { e.lazy.drop(0) }
+    end
+    it_behaves_like :enumerable_value_packing, nil
+  end
+
   before :each do
     @yieldsmixed = EnumeratorLazySpecs::YieldsMixed.new.to_enum.lazy
     @eventsmixed = EnumeratorLazySpecs::EventsMixed.new.to_enum.lazy

--- a/core/enumerator/lazy/drop_while_spec.rb
+++ b/core/enumerator/lazy/drop_while_spec.rb
@@ -2,8 +2,16 @@
 
 require_relative '../../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative '../../enumerable/shared/value_packing'
 
 describe "Enumerator::Lazy#drop_while" do
+  describe "value packing of source yields (matches Enumerable#drop_while)" do
+    before :each do
+      @take = -> e { e.lazy.drop_while { false } }
+    end
+    it_behaves_like :enumerable_value_packing, nil
+  end
+
   before :each do
     @yieldsmixed = EnumeratorLazySpecs::YieldsMixed.new.to_enum.lazy
     @eventsmixed = EnumeratorLazySpecs::EventsMixed.new.to_enum.lazy

--- a/core/enumerator/lazy/reject_spec.rb
+++ b/core/enumerator/lazy/reject_spec.rb
@@ -2,8 +2,16 @@
 
 require_relative '../../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative '../../enumerable/shared/value_packing'
 
 describe "Enumerator::Lazy#reject" do
+  describe "value packing of source yields (matches Enumerable#reject)" do
+    before :each do
+      @take = -> e { e.lazy.reject { false } }
+    end
+    it_behaves_like :enumerable_value_packing, nil
+  end
+
   before :each do
     @yieldsmixed = EnumeratorLazySpecs::YieldsMixed.new.to_enum.lazy
     @eventsmixed = EnumeratorLazySpecs::EventsMixed.new.to_enum.lazy

--- a/core/enumerator/lazy/select_spec.rb
+++ b/core/enumerator/lazy/select_spec.rb
@@ -1,7 +1,15 @@
 require_relative '../../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative '../../enumerable/shared/value_packing'
 
 describe "Enumerator::Lazy#select" do
+  describe "value packing of source yields (matches Enumerable#select)" do
+    before :each do
+      @take = -> e { e.lazy.select { true } }
+    end
+    it_behaves_like :enumerable_value_packing, nil
+  end
+
   before :each do
     @yieldsmixed = EnumeratorLazySpecs::YieldsMixed.new.to_enum.lazy
     @eventsmixed = EnumeratorLazySpecs::EventsMixed.new.to_enum.lazy

--- a/core/enumerator/lazy/take_while_spec.rb
+++ b/core/enumerator/lazy/take_while_spec.rb
@@ -2,8 +2,16 @@
 
 require_relative '../../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative '../../enumerable/shared/value_packing'
 
 describe "Enumerator::Lazy#take_while" do
+  describe "value packing of source yields (matches Enumerable#take_while)" do
+    before :each do
+      @take = -> e { e.lazy.take_while { true } }
+    end
+    it_behaves_like :enumerable_value_packing, nil
+  end
+
   before :each do
     @yieldsmixed = EnumeratorLazySpecs::YieldsMixed.new.to_enum.lazy
     @eventsmixed = EnumeratorLazySpecs::EventsMixed.new.to_enum.lazy

--- a/core/enumerator/lazy/uniq_spec.rb
+++ b/core/enumerator/lazy/uniq_spec.rb
@@ -1,7 +1,15 @@
 require_relative '../../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative '../../enumerable/shared/value_packing'
 
 describe 'Enumerator::Lazy#uniq' do
+  describe "value packing of source yields (matches Enumerable#uniq)" do
+    before :each do
+      @take = -> e { e.lazy.uniq }
+    end
+    it_behaves_like :enumerable_value_packing, nil
+  end
+
   context 'without block' do
     before :each do
       @lazy = [0, 1, 0, 1].to_enum.lazy.uniq

--- a/core/enumerator/lazy/with_index_spec.rb
+++ b/core/enumerator/lazy/with_index_spec.rb
@@ -4,6 +4,29 @@ require_relative '../../../spec_helper'
 require_relative 'fixtures/classes'
 
 describe "Enumerator::Lazy#with_index" do
+  describe "value packing of source yields" do
+    it "pairs a packed Array with the index for a multi-argument source yield" do
+      e = Enumerator.new { |y| y.yield 1, 2 }
+      args = nil
+      e.lazy.with_index.each { |*a| args = a }
+      args.should == [[[1, 2], 0]]
+    end
+
+    it "pairs nil with the index for a zero-argument source yield" do
+      e = Enumerator.new { |y| y.yield }
+      args = nil
+      e.lazy.with_index.each { |*a| args = a }
+      args.should == [[nil, 0]]
+    end
+
+    it "calls the block with the packed value and the index" do
+      e = Enumerator.new { |y| y.yield 1, 2 }
+      seen = []
+      e.lazy.with_index { |v, i| seen << [v, i] }.force
+      seen.should == [[[1, 2], 0]]
+    end
+  end
+
   it "enumerates with an index" do
     (0..Float::INFINITY).lazy.with_index.map { |i, idx| [i, idx] }.first(3).should == [[0, 0], [1, 1], [2, 2]]
   end


### PR DESCRIPTION
Reuse the :enumerable_value_packing shared examples from #1363 for drop, take_while, drop_while, select, reject and uniq, on both the eager Enumerable methods and their Enumerator::Lazy counterparts.

compact and Enumerator::Lazy#with_index get dedicated examples since their output shape differs from the shared examples: compact removes the nil that a zero-argument yield packs to, and with_index pairs the packed value with the index ([packed_value, index]).