### PR TITLE
Fewer duplicate specs for `Kernel` methods

### DIFF
--- a/core/kernel/Array_spec.rb
+++ b/core/kernel/Array_spec.rb
@@ -1,20 +1,18 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-describe "Kernel" do
-  it "has private instance method Array()" do
-    Kernel.private_instance_methods(false).should.include?(:Array)
-  end
-end
-
-describe :kernel_Array, shared: true do
+describe "Kernel#Array" do
   before :each do
     @array = [1, 2, 3]
   end
 
+  it "is a private method" do
+    Kernel.private_instance_methods(false).should.include?(:Array)
+  end
+
   it "does not call #to_ary on an Array" do
     @array.should_not_receive(:to_ary)
-    @object.send(@method, @array).should == @array
+    Array(@array).should == @array
   end
 
   it "calls #to_ary to convert the argument to an Array" do
@@ -22,19 +20,19 @@ describe :kernel_Array, shared: true do
     obj.should_receive(:to_ary).and_return(@array)
     obj.should_not_receive(:to_a)
 
-    @object.send(@method, obj).should == @array
+    Array(obj).should == @array
   end
 
   it "does not call #to_a on an Array" do
     @array.should_not_receive(:to_a)
-    @object.send(@method, @array).should == @array
+    Array(@array).should == @array
   end
 
   it "calls #to_a if the argument does not respond to #to_ary" do
     obj = mock("Array([1,2,3])")
     obj.should_receive(:to_a).and_return(@array)
 
-    @object.send(@method, obj).should == @array
+    Array(obj).should == @array
   end
 
   it "calls #to_a if #to_ary returns nil" do
@@ -42,56 +40,54 @@ describe :kernel_Array, shared: true do
     obj.should_receive(:to_ary).and_return(nil)
     obj.should_receive(:to_a).and_return(@array)
 
-    @object.send(@method, obj).should == @array
+    Array(obj).should == @array
   end
 
   it "returns an Array containing the argument if #to_a returns nil" do
     obj = mock("Array([1,2,3])")
     obj.should_receive(:to_a).and_return(nil)
 
-    @object.send(@method, obj).should == [obj]
+    Array(obj).should == [obj]
   end
 
   it "calls #to_ary first, even if it's private" do
     obj = KernelSpecs::PrivateToAry.new
 
-    @object.send(@method, obj).should == [1, 2]
+    Array(obj).should == [1, 2]
   end
 
   it "calls #to_a if #to_ary is not defined, even if it's private" do
     obj = KernelSpecs::PrivateToA.new
 
-    @object.send(@method, obj).should == [3, 4]
+    Array(obj).should == [3, 4]
   end
 
   it "returns an Array containing the argument if it responds to neither #to_ary nor #to_a" do
     obj = mock("Array(x)")
-    @object.send(@method, obj).should == [obj]
+    Array(obj).should == [obj]
   end
 
   it "returns an empty Array when passed nil" do
-    @object.send(@method, nil).should == []
+    Array(nil).should == []
   end
 
   it "raises a TypeError if #to_ary does not return an Array" do
     obj = mock("Array() string")
     obj.should_receive(:to_ary).and_return("string")
 
-    -> { @object.send(@method, obj) }.should.raise(TypeError)
+    -> { Array(obj) }.should.raise(TypeError)
   end
 
   it "raises a TypeError if #to_a does not return an Array" do
     obj = mock("Array() string")
     obj.should_receive(:to_a).and_return("string")
 
-    -> { @object.send(@method, obj) }.should.raise(TypeError)
+    -> { Array(obj) }.should.raise(TypeError)
   end
 end
 
 describe "Kernel.Array" do
-  it_behaves_like :kernel_Array, :Array_method, KernelSpecs
-end
-
-describe "Kernel#Array" do
-  it_behaves_like :kernel_Array, :Array_function, KernelSpecs
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:Array)
+  end
 end

--- a/core/kernel/Complex_spec.rb
+++ b/core/kernel/Complex_spec.rb
@@ -2,7 +2,11 @@ require_relative '../../spec_helper'
 require_relative '../../shared/kernel/complex'
 require_relative 'fixtures/Complex'
 
-describe "Kernel.Complex()" do
+describe "Kernel#Complex" do
+  it "is a private method" do
+    Kernel.private_instance_methods(false).should.include?(:Complex)
+  end
+
   describe "when passed [Complex, Complex]" do
     it "returns a new Complex number based on the two given numbers" do
       Complex(Complex(3, 4), Complex(5, 6)).should == Complex(3 - 6, 4 + 5)
@@ -272,5 +276,11 @@ describe "Kernel.Complex()" do
 
   it "freezes its result" do
     Complex(1).frozen?.should == true
+  end
+end
+
+describe "Kernel.Complex" do
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:Complex)
   end
 end

--- a/core/kernel/Float_spec.rb
+++ b/core/kernel/Float_spec.rb
@@ -1,41 +1,45 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-describe :kernel_float, shared: true do
+describe "Kernel#Float" do
+  it "is a instance method" do
+    Kernel.private_instance_methods(false).should.include?(:Float)
+  end
+
   it "returns the identical Float for numeric Floats" do
     float = 1.12
-    float2 = @object.send(:Float, float)
+    float2 = Float(float)
     float2.should == float
     float2.should.equal? float
   end
 
   it "returns a Float for Fixnums" do
-    @object.send(:Float, 1).should == 1.0
+    Float(1).should == 1.0
   end
 
   it "returns a Float for Complex with only a real part" do
-    @object.send(:Float, Complex(1)).should == 1.0
+    Float(Complex(1)).should == 1.0
   end
 
   it "returns a Float for Bignums" do
-    @object.send(:Float, 1000000000000).should == 1000000000000.0
+    Float(1000000000000).should == 1000000000000.0
   end
 
   it "raises an ArgumentError for nil" do
-    -> { @object.send(:Float, nil) }.should.raise(TypeError)
+    -> { Float(nil) }.should.raise(TypeError)
   end
 
   it "returns the identical NaN for NaN" do
     nan = nan_value
     nan.nan?.should == true
-    nan2 = @object.send(:Float, nan)
+    nan2 = Float(nan)
     nan2.nan?.should == true
     nan2.should.equal?(nan)
   end
 
   it "returns the same Infinity for Infinity" do
     infinity = infinity_value
-    infinity2 = @object.send(:Float, infinity)
+    infinity2 = Float(infinity)
     infinity2.should == infinity_value
     infinity.should.equal?(infinity2)
   end
@@ -43,38 +47,38 @@ describe :kernel_float, shared: true do
   it "converts Strings to floats without calling #to_f" do
     string = +"10"
     string.should_not_receive(:to_f)
-    @object.send(:Float, string).should == 10.0
+    Float(string).should == 10.0
   end
 
   it "converts Strings with decimal points into Floats" do
-    @object.send(:Float, "10.0").should == 10.0
+    Float("10.0").should == 10.0
   end
 
   it "raises an ArgumentError for a String of word characters" do
-    -> { @object.send(:Float, "float") }.should.raise(ArgumentError)
+    -> { Float("float") }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError for a String with string in error message" do
-    -> { @object.send(:Float, "foo") }.should.raise(ArgumentError) { |e|
+    -> { Float("foo") }.should.raise(ArgumentError) { |e|
       e.message.should == 'invalid value for Float(): "foo"'
     }
   end
 
   it "raises an ArgumentError if there are two decimal points in the String" do
-    -> { @object.send(:Float, "10.0.0") }.should.raise(ArgumentError)
+    -> { Float("10.0.0") }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError for a String of numbers followed by word characters" do
-    -> { @object.send(:Float, "10D") }.should.raise(ArgumentError)
+    -> { Float("10D") }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError for a String of word characters followed by numbers" do
-    -> { @object.send(:Float, "D10") }.should.raise(ArgumentError)
+    -> { Float("D10") }.should.raise(ArgumentError)
   end
 
   it "is strict about the string form even across newlines" do
-    -> { @object.send(:Float, "not a number\n10") }.should.raise(ArgumentError)
-    -> { @object.send(:Float, "10\nnot a number") }.should.raise(ArgumentError)
+    -> { Float("not a number\n10") }.should.raise(ArgumentError)
+    -> { Float("10\nnot a number") }.should.raise(ArgumentError)
   end
 
   it "converts String subclasses to floats without calling #to_f" do
@@ -82,268 +86,268 @@ describe :kernel_float, shared: true do
       def to_f() 1.2 end
     end
 
-    @object.send(:Float, my_string.new("10")).should == 10.0
+    Float(my_string.new("10")).should == 10.0
   end
 
   it "returns a positive Float if the string is prefixed with +" do
-    @object.send(:Float, "+10").should == 10.0
-    @object.send(:Float, " +10").should == 10.0
+    Float("+10").should == 10.0
+    Float(" +10").should == 10.0
   end
 
   it "returns a negative Float if the string is prefixed with +" do
-    @object.send(:Float, "-10").should == -10.0
-    @object.send(:Float, " -10").should == -10.0
+    Float("-10").should == -10.0
+    Float(" -10").should == -10.0
   end
 
   it "raises an ArgumentError if a + or - is embedded in a String" do
-    -> { @object.send(:Float, "1+1") }.should.raise(ArgumentError)
-    -> { @object.send(:Float, "1-1") }.should.raise(ArgumentError)
+    -> { Float("1+1") }.should.raise(ArgumentError)
+    -> { Float("1-1") }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError if a String has a trailing + or -" do
-    -> { @object.send(:Float, "11+") }.should.raise(ArgumentError)
-    -> { @object.send(:Float, "11-") }.should.raise(ArgumentError)
+    -> { Float("11+") }.should.raise(ArgumentError)
+    -> { Float("11-") }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError for a String with a leading _" do
-    -> { @object.send(:Float, "_1") }.should.raise(ArgumentError)
+    -> { Float("_1") }.should.raise(ArgumentError)
   end
 
   it "returns a value for a String with an embedded _" do
-    @object.send(:Float, "1_000").should == 1000.0
+    Float("1_000").should == 1000.0
   end
 
   it "raises an ArgumentError for a String with a trailing _" do
-    -> { @object.send(:Float, "10_") }.should.raise(ArgumentError)
+    -> { Float("10_") }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError for a String of \\0" do
-    -> { @object.send(:Float, "\0") }.should.raise(ArgumentError)
+    -> { Float("\0") }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError for a String with a leading \\0" do
-    -> { @object.send(:Float, "\01") }.should.raise(ArgumentError)
+    -> { Float("\01") }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError for a String with an embedded \\0" do
-    -> { @object.send(:Float, "1\01") }.should.raise(ArgumentError)
+    -> { Float("1\01") }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError for a String with a trailing \\0" do
-    -> { @object.send(:Float, "1\0") }.should.raise(ArgumentError)
+    -> { Float("1\0") }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError for a String that is just an empty space" do
-    -> { @object.send(:Float, " ") }.should.raise(ArgumentError)
+    -> { Float(" ") }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError for a String that with an embedded space" do
-    -> { @object.send(:Float, "1 2") }.should.raise(ArgumentError)
+    -> { Float("1 2") }.should.raise(ArgumentError)
   end
 
   it "returns a value for a String with a leading space" do
-    @object.send(:Float, " 1").should == 1.0
+    Float(" 1").should == 1.0
   end
 
   it "returns a value for a String with a trailing space" do
-    @object.send(:Float, "1 ").should == 1.0
+    Float("1 ").should == 1.0
   end
 
   it "returns a value for a String with any leading whitespace" do
-    @object.send(:Float, "\t\n1").should == 1.0
+    Float("\t\n1").should == 1.0
   end
 
   it "returns a value for a String with any trailing whitespace" do
-    @object.send(:Float, "1\t\n").should == 1.0
+    Float("1\t\n").should == 1.0
   end
 
   ruby_version_is ""..."3.4" do
     it "raises ArgumentError if a fractional part is missing" do
-      -> { @object.send(:Float, "1.") }.should.raise(ArgumentError)
-      -> { @object.send(:Float, "+1.") }.should.raise(ArgumentError)
-      -> { @object.send(:Float, "-1.") }.should.raise(ArgumentError)
-      -> { @object.send(:Float, "1.e+0") }.should.raise(ArgumentError)
-      -> { @object.send(:Float, "1.e-2") }.should.raise(ArgumentError)
+      -> { Float("1.") }.should.raise(ArgumentError)
+      -> { Float("+1.") }.should.raise(ArgumentError)
+      -> { Float("-1.") }.should.raise(ArgumentError)
+      -> { Float("1.e+0") }.should.raise(ArgumentError)
+      -> { Float("1.e-2") }.should.raise(ArgumentError)
     end
   end
 
   ruby_version_is "3.4" do
     it "allows String representation without a fractional part" do
-      @object.send(:Float, "1.").should == 1.0
-      @object.send(:Float, "+1.").should == 1.0
-      @object.send(:Float, "-1.").should == -1.0
-      @object.send(:Float, "1.e+0").should == 1.0
-      @object.send(:Float, "1.e-2").should be_close(0.01, TOLERANCE)
+      Float("1.").should == 1.0
+      Float("+1.").should == 1.0
+      Float("-1.").should == -1.0
+      Float("1.e+0").should == 1.0
+      Float("1.e-2").should be_close(0.01, TOLERANCE)
     end
   end
 
   %w(e E).each do |e|
     it "raises an ArgumentError if #{e} is the trailing character" do
-      -> { @object.send(:Float, "2#{e}") }.should.raise(ArgumentError)
+      -> { Float("2#{e}") }.should.raise(ArgumentError)
     end
 
     it "raises an ArgumentError if #{e} is the leading character" do
-      -> { @object.send(:Float, "#{e}2") }.should.raise(ArgumentError)
+      -> { Float("#{e}2") }.should.raise(ArgumentError)
     end
 
     it "returns Infinity for '2#{e}1000'" do
-      @object.send(:Float, "2#{e}1000").should == Float::INFINITY
+      Float("2#{e}1000").should == Float::INFINITY
     end
 
     it "returns 0 for '2#{e}-1000'" do
-      @object.send(:Float, "2#{e}-1000").should == 0
+      Float("2#{e}-1000").should == 0
     end
 
     it "allows embedded _ in a number on either side of the #{e}" do
-      @object.send(:Float, "2_0#{e}100").should == 20e100
-      @object.send(:Float, "20#{e}1_00").should == 20e100
-      @object.send(:Float, "2_0#{e}1_00").should == 20e100
+      Float("2_0#{e}100").should == 20e100
+      Float("20#{e}1_00").should == 20e100
+      Float("2_0#{e}1_00").should == 20e100
     end
 
     it "raises an exception if a space is embedded on either side of the '#{e}'" do
-      -> { @object.send(:Float, "2 0#{e}100") }.should.raise(ArgumentError)
-      -> { @object.send(:Float, "20#{e}1 00") }.should.raise(ArgumentError)
+      -> { Float("2 0#{e}100") }.should.raise(ArgumentError)
+      -> { Float("20#{e}1 00") }.should.raise(ArgumentError)
     end
 
     it "raises an exception if there's a leading _ on either side of the '#{e}'" do
-      -> { @object.send(:Float, "_20#{e}100") }.should.raise(ArgumentError)
-      -> { @object.send(:Float, "20#{e}_100") }.should.raise(ArgumentError)
+      -> { Float("_20#{e}100") }.should.raise(ArgumentError)
+      -> { Float("20#{e}_100") }.should.raise(ArgumentError)
     end
 
     it "raises an exception if there's a trailing _ on either side of the '#{e}'" do
-      -> { @object.send(:Float, "20_#{e}100") }.should.raise(ArgumentError)
-      -> { @object.send(:Float, "20#{e}100_") }.should.raise(ArgumentError)
+      -> { Float("20_#{e}100") }.should.raise(ArgumentError)
+      -> { Float("20#{e}100_") }.should.raise(ArgumentError)
     end
 
     it "allows decimal points on the left side of the '#{e}'" do
-      @object.send(:Float, "2.0#{e}2").should == 2e2
+      Float("2.0#{e}2").should == 2e2
     end
 
     it "raises an ArgumentError if there's a decimal point on the right side of the '#{e}'" do
-      -> { @object.send(:Float, "20#{e}2.0") }.should.raise(ArgumentError)
+      -> { Float("20#{e}2.0") }.should.raise(ArgumentError)
     end
   end
 
   context "for hexadecimal literals" do
     it "interprets the 0x prefix as hexadecimal" do
-      @object.send(:Float, "0x10").should == 16.0
-      @object.send(:Float, "0x0F").should == 15.0
-      @object.send(:Float, "0x0f").should == 15.0
+      Float("0x10").should == 16.0
+      Float("0x0F").should == 15.0
+      Float("0x0f").should == 15.0
     end
 
     it "interprets negative hex value" do
-      @object.send(:Float, "-0x10").should == -16.0
+      Float("-0x10").should == -16.0
     end
 
     it "accepts embedded _ if the number does not contain a-f" do
-      @object.send(:Float, "0x1_0").should == 16.0
+      Float("0x1_0").should == 16.0
     end
 
     ruby_version_is ""..."3.4.3" do
       it "does not accept embedded _ if the number contains a-f" do
-        -> { @object.send(:Float, "0x1_0a") }.should.raise(ArgumentError)
-        @object.send(:Float, "0x1_0a", exception: false).should == nil
+        -> { Float("0x1_0a") }.should.raise(ArgumentError)
+        Float("0x1_0a", exception: false).should == nil
       end
     end
 
     ruby_version_is "3.4.3" do
       it "accepts embedded _ if the number contains a-f" do
-        @object.send(:Float, "0x1_0a").should == 0x10a.to_f
+        Float("0x1_0a").should == 0x10a.to_f
       end
     end
 
     it "does not accept _ before, after or inside the 0x prefix" do
-      -> { @object.send(:Float, "_0x10") }.should.raise(ArgumentError)
-      -> { @object.send(:Float, "0_x10") }.should.raise(ArgumentError)
-      -> { @object.send(:Float, "0x_10") }.should.raise(ArgumentError)
-      @object.send(:Float, "_0x10", exception: false).should == nil
-      @object.send(:Float, "0_x10", exception: false).should == nil
-      @object.send(:Float, "0x_10", exception: false).should == nil
+      -> { Float("_0x10") }.should.raise(ArgumentError)
+      -> { Float("0_x10") }.should.raise(ArgumentError)
+      -> { Float("0x_10") }.should.raise(ArgumentError)
+      Float("_0x10", exception: false).should == nil
+      Float("0_x10", exception: false).should == nil
+      Float("0x_10", exception: false).should == nil
     end
 
     it "parses negative hexadecimal string as negative float" do
-      @object.send(:Float, "-0x7b").should == -123.0
+      Float("-0x7b").should == -123.0
     end
 
     ruby_version_is "3.4" do
       it "accepts a fractional part" do
-        @object.send(:Float, "0x0.8").should == 0.5
+        Float("0x0.8").should == 0.5
       end
     end
 
     describe "with binary exponent" do
       %w(p P).each do |p|
         it "interprets the fractional part (on the left side of '#{p}') in hexadecimal" do
-          @object.send(:Float, "0x10#{p}0").should == 16.0
+          Float("0x10#{p}0").should == 16.0
         end
 
         it "interprets the exponent (on the right of '#{p}') in decimal" do
-          @object.send(:Float, "0x1#{p}10").should == 1024.0
+          Float("0x1#{p}10").should == 1024.0
         end
 
         it "raises an ArgumentError if #{p} is the trailing character" do
-          -> { @object.send(:Float, "0x1#{p}") }.should.raise(ArgumentError)
+          -> { Float("0x1#{p}") }.should.raise(ArgumentError)
         end
 
         it "raises an ArgumentError if #{p} is the leading character" do
-          -> { @object.send(:Float, "0x#{p}1") }.should.raise(ArgumentError)
+          -> { Float("0x#{p}1") }.should.raise(ArgumentError)
         end
 
         it "returns Infinity for '0x1#{p}10000'" do
-          @object.send(:Float, "0x1#{p}10000").should == Float::INFINITY
+          Float("0x1#{p}10000").should == Float::INFINITY
         end
 
         it "returns 0 for '0x1#{p}-10000'" do
-          @object.send(:Float, "0x1#{p}-10000").should == 0
+          Float("0x1#{p}-10000").should == 0
         end
 
         it "allows embedded _ in a number on either side of the #{p}" do
-          @object.send(:Float, "0x1_0#{p}10").should == 16384.0
-          @object.send(:Float, "0x10#{p}1_0").should == 16384.0
-          @object.send(:Float, "0x1_0#{p}1_0").should == 16384.0
+          Float("0x1_0#{p}10").should == 16384.0
+          Float("0x10#{p}1_0").should == 16384.0
+          Float("0x1_0#{p}1_0").should == 16384.0
         end
 
         it "raises an exception if a space is embedded on either side of the '#{p}'" do
-          -> { @object.send(:Float, "0x1 0#{p}10") }.should.raise(ArgumentError)
-          -> { @object.send(:Float, "0x10#{p}1 0") }.should.raise(ArgumentError)
+          -> { Float("0x1 0#{p}10") }.should.raise(ArgumentError)
+          -> { Float("0x10#{p}1 0") }.should.raise(ArgumentError)
         end
 
         it "raises an exception if there's a leading _ on either side of the '#{p}'" do
-          -> { @object.send(:Float, "0x_10#{p}10") }.should.raise(ArgumentError)
-          -> { @object.send(:Float, "0x10#{p}_10") }.should.raise(ArgumentError)
+          -> { Float("0x_10#{p}10") }.should.raise(ArgumentError)
+          -> { Float("0x10#{p}_10") }.should.raise(ArgumentError)
         end
 
         it "raises an exception if there's a trailing _ on either side of the '#{p}'" do
-          -> { @object.send(:Float, "0x10_#{p}10") }.should.raise(ArgumentError)
-          -> { @object.send(:Float, "0x10#{p}10_") }.should.raise(ArgumentError)
+          -> { Float("0x10_#{p}10") }.should.raise(ArgumentError)
+          -> { Float("0x10#{p}10_") }.should.raise(ArgumentError)
         end
 
         it "allows hexadecimal points on the left side of the '#{p}'" do
-          @object.send(:Float, "0x1.8#{p}0").should == 1.5
+          Float("0x1.8#{p}0").should == 1.5
         end
 
         it "raises an ArgumentError if there's a decimal point on the right side of the '#{p}'" do
-          -> { @object.send(:Float, "0x1#{p}1.0") }.should.raise(ArgumentError)
+          -> { Float("0x1#{p}1.0") }.should.raise(ArgumentError)
         end
       end
     end
   end
 
   it "returns a Float that can be a parameter to #Float again" do
-    float = @object.send(:Float, "10")
-    @object.send(:Float, float).should == 10.0
+    float = Float("10")
+    Float(float).should == 10.0
   end
 
   it "otherwise, converts the given argument to a Float by calling #to_f" do
     (obj = mock('1.2')).should_receive(:to_f).once.and_return(1.2)
     obj.should_not_receive(:to_i)
-    @object.send(:Float, obj).should == 1.2
+    Float(obj).should == 1.2
   end
 
   it "returns the identical NaN if to_f is called and it returns NaN" do
     nan = nan_value
     (nan_to_f = mock('NaN')).should_receive(:to_f).once.and_return(nan)
-    nan2 = @object.send(:Float, nan_to_f)
+    nan2 = Float(nan_to_f)
     nan2.nan?.should == true
     nan2.should.equal?(nan)
   end
@@ -351,63 +355,55 @@ describe :kernel_float, shared: true do
   it "returns the identical Infinity if #to_f is called and it returns Infinity" do
     infinity = infinity_value
     (infinity_to_f = mock('Infinity')).should_receive(:to_f).once.and_return(infinity)
-    infinity2 = @object.send(:Float, infinity_to_f)
+    infinity2 = Float(infinity_to_f)
     infinity2.should.equal?(infinity)
   end
 
   it "raises a TypeError if #to_f is not provided" do
-    -> { @object.send(:Float, mock('x')) }.should.raise(TypeError)
+    -> { Float(mock('x')) }.should.raise(TypeError)
   end
 
   it "raises a TypeError if #to_f returns a String" do
     (obj = mock('ha!')).should_receive(:to_f).once.and_return('ha!')
-    -> { @object.send(:Float, obj) }.should.raise(TypeError)
+    -> { Float(obj) }.should.raise(TypeError)
   end
 
   it "raises a TypeError if #to_f returns an Integer" do
     (obj = mock('123')).should_receive(:to_f).once.and_return(123)
-    -> { @object.send(:Float, obj) }.should.raise(TypeError)
+    -> { Float(obj) }.should.raise(TypeError)
   end
 
   it "raises a RangeError when passed a Complex argument" do
     c = Complex(2, 3)
-    -> { @object.send(:Float, c) }.should.raise(RangeError)
+    -> { Float(c) }.should.raise(RangeError)
   end
 
   describe "when passed exception: false" do
     describe "and valid input" do
       it "returns a Float number" do
-        @object.send(:Float, 1, exception: false).should == 1.0
-        @object.send(:Float, "1", exception: false).should == 1.0
-        @object.send(:Float, "1.23", exception: false).should == 1.23
+        Float(1, exception: false).should == 1.0
+        Float("1", exception: false).should == 1.0
+        Float("1.23", exception: false).should == 1.23
       end
     end
 
     describe "and invalid input" do
       it "swallows an error" do
-        @object.send(:Float, "abc", exception: false).should == nil
-        @object.send(:Float, :sym, exception: false).should == nil
+        Float("abc", exception: false).should == nil
+        Float(:sym, exception: false).should == nil
       end
     end
 
     describe "and nil" do
       it "swallows it" do
-        @object.send(:Float, nil, exception: false).should == nil
+        Float(nil, exception: false).should == nil
       end
     end
   end
 end
 
 describe "Kernel.Float" do
-  it_behaves_like :kernel_float, :Float, Kernel
-end
-
-describe "Kernel#Float" do
-  it_behaves_like :kernel_float, :Float, Object.new
-end
-
-describe "Kernel#Float" do
-  it "is a private method" do
-    Kernel.private_instance_methods(false).should.include?(:Float)
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:Float)
   end
 end

--- a/core/kernel/Hash_spec.rb
+++ b/core/kernel/Hash_spec.rb
@@ -11,53 +11,49 @@ describe "Kernel#hash" do
   end
 end
 
-describe "Kernel" do
-  it "has private instance method Hash()" do
-    Kernel.private_instance_methods(false).should.include?(:Hash)
-  end
-end
-
-describe :kernel_Hash, shared: true do
+describe "Kernel#Hash" do
   before :each do
     @hash = { a: 1}
   end
 
+  it "is a private method" do
+    Kernel.private_instance_methods(false).should.include?(:Hash)
+  end
+
   it "converts nil to a Hash" do
-    @object.send(@method, nil).should == {}
+    Hash(nil).should == {}
   end
 
   it "converts an empty array to a Hash" do
-    @object.send(@method, []).should == {}
+    Hash([]).should == {}
   end
 
   it "does not call #to_hash on an Hash" do
     @hash.should_not_receive(:to_hash)
-    @object.send(@method, @hash).should == @hash
+    Hash(@hash).should == @hash
   end
 
   it "calls #to_hash to convert the argument to an Hash" do
     obj = mock("Hash(a: 1)")
     obj.should_receive(:to_hash).and_return(@hash)
 
-    @object.send(@method, obj).should == @hash
+    Hash(obj).should == @hash
   end
 
   it "raises a TypeError if it doesn't respond to #to_hash" do
-    -> { @object.send(@method, mock("")) }.should.raise(TypeError)
+    -> { Hash(mock("")) }.should.raise(TypeError)
   end
 
   it "raises a TypeError if #to_hash does not return an Hash" do
     obj = mock("Hash() string")
     obj.should_receive(:to_hash).and_return("string")
 
-    -> { @object.send(@method, obj) }.should.raise(TypeError)
+    -> { Hash(obj) }.should.raise(TypeError)
   end
 end
 
 describe "Kernel.Hash" do
-  it_behaves_like :kernel_Hash, :Hash_method, KernelSpecs
-end
-
-describe "Kernel#Hash" do
-  it_behaves_like :kernel_Hash, :Hash_function, KernelSpecs
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:Hash)
+  end
 end

--- a/core/kernel/Integer_spec.rb
+++ b/core/kernel/Integer_spec.rb
@@ -1,7 +1,11 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-describe :kernel_integer, shared: true do
+describe "Kernel#Integer" do
+  it "is a private method" do
+    Kernel.private_instance_methods(false).should.include?(:Integer)
+  end
+
   it "returns a Bignum for a Bignum" do
     Integer(2e100).should == 2e100
   end
@@ -174,9 +178,7 @@ describe :kernel_integer, shared: true do
       end
     end
   end
-end
 
-describe :kernel_integer_string, shared: true do
   it "raises an ArgumentError if the String is a null byte" do
     -> { Integer("\0") }.should.raise(ArgumentError)
   end
@@ -377,9 +379,7 @@ describe :kernel_integer_string, shared: true do
       -> { Integer("0#{d}a") }.should.raise(ArgumentError)
     end
   end
-end
 
-describe :kernel_integer_string_base, shared: true do
   it "raises an ArgumentError if the String is a null byte" do
     -> { Integer("\0", 2) }.should.raise(ArgumentError)
   end
@@ -638,208 +638,184 @@ describe :kernel_integer_string_base, shared: true do
       end
     end
   end
-end
 
-describe :kernel_Integer, shared: true do
   it "raises an ArgumentError when the String contains digits out of range of radix 2" do
     str = "23456789abcdefghijklmnopqrstuvwxyz"
-    -> { @object.send(@method, str, 2) }.should.raise(ArgumentError)
+    -> { Integer(str, 2) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 3" do
     str = "3456789abcdefghijklmnopqrstuvwxyz"
-    -> { @object.send(@method, str, 3) }.should.raise(ArgumentError)
+    -> { Integer(str, 3) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 4" do
     str = "456789abcdefghijklmnopqrstuvwxyz"
-    -> { @object.send(@method, str, 4) }.should.raise(ArgumentError)
+    -> { Integer(str, 4) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 5" do
     str = "56789abcdefghijklmnopqrstuvwxyz"
-    -> { @object.send(@method, str, 5) }.should.raise(ArgumentError)
+    -> { Integer(str, 5) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 6" do
     str = "6789abcdefghijklmnopqrstuvwxyz"
-    -> { @object.send(@method, str, 6) }.should.raise(ArgumentError)
+    -> { Integer(str, 6) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 7" do
     str = "789abcdefghijklmnopqrstuvwxyz"
-    -> { @object.send(@method, str, 7) }.should.raise(ArgumentError)
+    -> { Integer(str, 7) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 8" do
     str = "89abcdefghijklmnopqrstuvwxyz"
-    -> { @object.send(@method, str, 8) }.should.raise(ArgumentError)
+    -> { Integer(str, 8) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 9" do
     str = "9abcdefghijklmnopqrstuvwxyz"
-    -> { @object.send(@method, str, 9) }.should.raise(ArgumentError)
+    -> { Integer(str, 9) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 10" do
     str = "abcdefghijklmnopqrstuvwxyz"
-    -> { @object.send(@method, str, 10) }.should.raise(ArgumentError)
+    -> { Integer(str, 10) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 11" do
     str = "bcdefghijklmnopqrstuvwxyz"
-    -> { @object.send(@method, str, 11) }.should.raise(ArgumentError)
+    -> { Integer(str, 11) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 12" do
     str = "cdefghijklmnopqrstuvwxyz"
-    -> { @object.send(@method, str, 12) }.should.raise(ArgumentError)
+    -> { Integer(str, 12) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 13" do
     str = "defghijklmnopqrstuvwxyz"
-    -> { @object.send(@method, str, 13) }.should.raise(ArgumentError)
+    -> { Integer(str, 13) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 14" do
     str = "efghijklmnopqrstuvwxyz"
-    -> { @object.send(@method, str, 14) }.should.raise(ArgumentError)
+    -> { Integer(str, 14) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 15" do
     str = "fghijklmnopqrstuvwxyz"
-    -> { @object.send(@method, str, 15) }.should.raise(ArgumentError)
+    -> { Integer(str, 15) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 16" do
     str = "ghijklmnopqrstuvwxyz"
-    -> { @object.send(@method, str, 16) }.should.raise(ArgumentError)
+    -> { Integer(str, 16) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 17" do
     str = "hijklmnopqrstuvwxyz"
-    -> { @object.send(@method, str, 17) }.should.raise(ArgumentError)
+    -> { Integer(str, 17) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 18" do
     str = "ijklmnopqrstuvwxyz"
-    -> { @object.send(@method, str, 18) }.should.raise(ArgumentError)
+    -> { Integer(str, 18) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 19" do
     str = "jklmnopqrstuvwxyz"
-    -> { @object.send(@method, str, 19) }.should.raise(ArgumentError)
+    -> { Integer(str, 19) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 20" do
     str = "klmnopqrstuvwxyz"
-    -> { @object.send(@method, str, 20) }.should.raise(ArgumentError)
+    -> { Integer(str, 20) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 21" do
     str = "lmnopqrstuvwxyz"
-    -> { @object.send(@method, str, 21) }.should.raise(ArgumentError)
+    -> { Integer(str, 21) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 22" do
     str = "mnopqrstuvwxyz"
-    -> { @object.send(@method, str, 22) }.should.raise(ArgumentError)
+    -> { Integer(str, 22) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 23" do
     str = "nopqrstuvwxyz"
-    -> { @object.send(@method, str, 23) }.should.raise(ArgumentError)
+    -> { Integer(str, 23) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 24" do
     str = "opqrstuvwxyz"
-    -> { @object.send(@method, str, 24) }.should.raise(ArgumentError)
+    -> { Integer(str, 24) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 25" do
     str = "pqrstuvwxyz"
-    -> { @object.send(@method, str, 25) }.should.raise(ArgumentError)
+    -> { Integer(str, 25) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 26" do
     str = "qrstuvwxyz"
-    -> { @object.send(@method, str, 26) }.should.raise(ArgumentError)
+    -> { Integer(str, 26) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 27" do
     str = "rstuvwxyz"
-    -> { @object.send(@method, str, 27) }.should.raise(ArgumentError)
+    -> { Integer(str, 27) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 28" do
     str = "stuvwxyz"
-    -> { @object.send(@method, str, 28) }.should.raise(ArgumentError)
+    -> { Integer(str, 28) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 29" do
     str = "tuvwxyz"
-    -> { @object.send(@method, str, 29) }.should.raise(ArgumentError)
+    -> { Integer(str, 29) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 30" do
     str = "uvwxyz"
-    -> { @object.send(@method, str, 30) }.should.raise(ArgumentError)
+    -> { Integer(str, 30) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 31" do
     str = "vwxyz"
-    -> { @object.send(@method, str, 31) }.should.raise(ArgumentError)
+    -> { Integer(str, 31) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 32" do
     str = "wxyz"
-    -> { @object.send(@method, str, 32) }.should.raise(ArgumentError)
+    -> { Integer(str, 32) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 33" do
     str = "xyz"
-    -> { @object.send(@method, str, 33) }.should.raise(ArgumentError)
+    -> { Integer(str, 33) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 34" do
     str = "yz"
-    -> { @object.send(@method, str, 34) }.should.raise(ArgumentError)
+    -> { Integer(str, 34) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 35" do
     str = "z"
-    -> { @object.send(@method, str, 35) }.should.raise(ArgumentError)
+    -> { Integer(str, 35) }.should.raise(ArgumentError)
   end
 
   it "raises an ArgumentError when the String contains digits out of range of radix 36" do
-    -> { @object.send(@method, "{", 36) }.should.raise(ArgumentError)
+    -> { Integer("{", 36) }.should.raise(ArgumentError)
   end
 end
 
 describe "Kernel.Integer" do
-  it_behaves_like :kernel_Integer, :Integer_method, KernelSpecs
-
-  # TODO: fix these specs
-  it_behaves_like :kernel_integer, :Integer, Kernel
-  it_behaves_like :kernel_integer_string, :Integer
-
-  it_behaves_like :kernel_integer_string_base, :Integer
-
   it "is a public method" do
-    Kernel.Integer(10).should == 10
-  end
-end
-
-describe "Kernel#Integer" do
-  it_behaves_like :kernel_Integer, :Integer_function, KernelSpecs
-
-  # TODO: fix these specs
-  it_behaves_like :kernel_integer, :Integer, Object.new
-  it_behaves_like :kernel_integer_string, :Integer
-
-  it_behaves_like :kernel_integer_string_base, :Integer
-
-  it "is a private method" do
-    Kernel.private_instance_methods(false).should.include?(:Integer)
+    Kernel.public_methods(false).should.include?(:Integer)
   end
 end

--- a/core/kernel/Rational_spec.rb
+++ b/core/kernel/Rational_spec.rb
@@ -1,7 +1,11 @@
 require_relative '../../spec_helper'
 require_relative '../rational/fixtures/rational'
 
-describe "Kernel.Rational" do
+describe "Kernel#Rational" do
+  it "is a private method" do
+    Kernel.private_instance_methods(false).should.include?(:Rational)
+  end
+
   describe "passed Integer" do
     # Guard against the Mathn library
     guard -> { !defined?(Math.rsqrt) } do
@@ -232,5 +236,11 @@ describe "Kernel.Rational" do
 
   it "freezes its result" do
     Rational(1).frozen?.should == true
+  end
+end
+
+describe "Kernel.Rational" do
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:Rational)
   end
 end

--- a/core/kernel/String_spec.rb
+++ b/core/kernel/String_spec.rb
@@ -1,29 +1,33 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-describe :kernel_String, shared: true do
+describe "Kernel#String" do
+  it "is a private method" do
+    Kernel.private_instance_methods(false).should.include?(:String)
+  end
+
   it "converts nil to a String" do
-    @object.send(@method, nil).should == ""
+    String(nil).should == ""
   end
 
   it "converts a Float to a String" do
-    @object.send(@method, 1.12).should == "1.12"
+    String(1.12).should == "1.12"
   end
 
   it "converts a boolean to a String" do
-    @object.send(@method, false).should == "false"
-    @object.send(@method, true).should == "true"
+    String(false).should == "false"
+    String(true).should == "true"
   end
 
   it "converts a constant to a String" do
-    @object.send(@method, Object).should == "Object"
+    String(Object).should == "Object"
   end
 
   it "calls #to_s to convert an arbitrary object to a String" do
     obj = mock('test')
     obj.should_receive(:to_s).and_return("test")
 
-    @object.send(@method, obj).should == "test"
+    String(obj).should == "test"
   end
 
   it "raises a TypeError if #to_s does not exist" do
@@ -32,7 +36,7 @@ describe :kernel_String, shared: true do
       undef_method :to_s
     end
 
-    -> { @object.send(@method, obj) }.should.raise(TypeError)
+    -> { String(obj) }.should.raise(TypeError)
   end
 
   # #5158
@@ -44,7 +48,7 @@ describe :kernel_String, shared: true do
       end
     end
 
-    -> { @object.send(@method, obj) }.should.raise(TypeError)
+    -> { String(obj) }.should.raise(TypeError)
   end
 
   it "raises a TypeError if #to_s is not defined, even though #respond_to?(:to_s) returns true" do
@@ -57,7 +61,7 @@ describe :kernel_String, shared: true do
       end
     end
 
-    -> { @object.send(@method, obj) }.should.raise(TypeError)
+    -> { String(obj) }.should.raise(TypeError)
   end
 
   it "calls #to_s if #respond_to?(:to_s) returns true" do
@@ -69,18 +73,18 @@ describe :kernel_String, shared: true do
       end
     end
 
-    @object.send(@method, obj).should == "test"
+    String(obj).should == "test"
   end
 
   it "raises a TypeError if #to_s does not return a String" do
     (obj = mock('123')).should_receive(:to_s).and_return(123)
-    -> { @object.send(@method, obj) }.should.raise(TypeError)
+    -> { String(obj) }.should.raise(TypeError)
   end
 
   it "returns the same object if it is already a String" do
     string = +"Hello"
     string.should_not_receive(:to_s)
-    string2 = @object.send(@method, string)
+    string2 = String(string)
     string.should.equal?(string2)
   end
 
@@ -88,19 +92,13 @@ describe :kernel_String, shared: true do
     subklass = Class.new(String)
     string = subklass.new("Hello")
     string.should_not_receive(:to_s)
-    string2 = @object.send(@method, string)
+    string2 = String(string)
     string.should.equal?(string2)
   end
 end
 
 describe "Kernel.String" do
-  it_behaves_like :kernel_String, :String, Kernel
-end
-
-describe "Kernel#String" do
-  it_behaves_like :kernel_String, :String, Object.new
-
-  it "is a private method" do
-    Kernel.private_instance_methods(false).should.include?(:String)
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:String)
   end
 end

--- a/core/kernel/__callee___spec.rb
+++ b/core/kernel/__callee___spec.rb
@@ -1,7 +1,11 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/__callee__'
 
-describe "Kernel.__callee__" do
+describe "Kernel#__callee__" do
+  it "is a private method" do
+    Kernel.private_instance_methods(false).should.include?(:__callee__)
+  end
+
   it "returns the current method, even when aliased" do
     KernelSpecs::CalleeTest.new.f.should == :f
   end
@@ -44,5 +48,11 @@ describe "Kernel.__callee__" do
       def g; f end
     end
     c.new.g.should == :f
+  end
+end
+
+describe "Kernel.__callee__" do
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:__callee__)
   end
 end

--- a/core/kernel/__dir___spec.rb
+++ b/core/kernel/__dir___spec.rb
@@ -1,6 +1,10 @@
 require_relative '../../spec_helper'
 
 describe "Kernel#__dir__" do
+  it "is a private method" do
+    Kernel.private_instance_methods(false).should.include?(:__dir__)
+  end
+
   it "returns the real name of the directory containing the currently-executing file" do
     __dir__.should == File.realpath(File.dirname(__FILE__))
   end
@@ -23,5 +27,11 @@ describe "Kernel#__dir__" do
     it "returns nil" do
       eval("__dir__", binding).should == nil
     end
+  end
+end
+
+describe "Kernel.__dir__" do
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:__dir__)
   end
 end

--- a/core/kernel/__method___spec.rb
+++ b/core/kernel/__method___spec.rb
@@ -1,7 +1,11 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/__method__'
 
-describe "Kernel.__method__" do
+describe "Kernel#__method__" do
+  it "is a private method" do
+    Kernel.private_instance_methods(false).should.include?(:__method__)
+  end
+
   it "returns the current method, even when aliased" do
     KernelSpecs::MethodTest.new.f.should == :f
   end
@@ -36,5 +40,11 @@ describe "Kernel.__method__" do
 
   it "returns nil when not called from a method" do
     __method__.should == nil
+  end
+end
+
+describe "Kernel.__method__" do
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:__method__)
   end
 end

--- a/core/kernel/abort_spec.rb
+++ b/core/kernel/abort_spec.rb
@@ -11,5 +11,7 @@ describe "Kernel#abort" do
 end
 
 describe "Kernel.abort" do
-  it_behaves_like :process_abort, :abort, Kernel
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:abort)
+  end
 end

--- a/core/kernel/at_exit_spec.rb
+++ b/core/kernel/at_exit_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative '../../shared/kernel/at_exit'
 
-describe "Kernel.at_exit" do
+describe "Kernel#at_exit" do
   it_behaves_like :kernel_at_exit, :at_exit
 
   it "is a private method" do
@@ -14,6 +14,8 @@ describe "Kernel.at_exit" do
   end
 end
 
-describe "Kernel#at_exit" do
-  it "needs to be reviewed for spec completeness"
+describe "Kernel.at_exit" do
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:at_exit)
+  end
 end

--- a/core/kernel/autoload_relative_spec.rb
+++ b/core/kernel/autoload_relative_spec.rb
@@ -1,8 +1,6 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-# Specs for Kernel#autoload_relative
-
 ruby_version_is "4.1" do
   describe "Kernel#autoload_relative" do
     before :each do
@@ -109,6 +107,12 @@ ruby_version_is "4.1" do
           end
         RUBY
       end
+    end
+  end
+
+  describe "Kernel.autoload_relative" do
+    it "is a public method" do
+      Kernel.public_methods(false).should.include?(:autoload_relative)
     end
   end
 end

--- a/core/kernel/autoload_spec.rb
+++ b/core/kernel/autoload_spec.rb
@@ -131,6 +131,10 @@ describe "Kernel.autoload" do
     $".replace @loaded_features
   end
 
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:autoload)
+  end
+
   it "registers a file to load the first time the toplevel constant is accessed" do
     Kernel.autoload :KSAutoloadAA, @non_existent
     Kernel.autoload?(:KSAutoloadAA).should == @non_existent
@@ -167,6 +171,10 @@ describe "Kernel.autoload" do
 end
 
 describe "Kernel.autoload?" do
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:autoload?)
+  end
+
   it "returns the name of the file that will be autoloaded" do
     Kernel.autoload :KSAutoload, "autoload.rb"
     Kernel.autoload?(:KSAutoload).should == "autoload.rb"

--- a/core/kernel/binding_spec.rb
+++ b/core/kernel/binding_spec.rb
@@ -1,12 +1,6 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-describe "Kernel.binding" do
-  it "returns a binding for the caller" do
-    Kernel.binding.eval("self").should == self
-  end
-end
-
 describe "Kernel#binding" do
   it "is a private method" do
     Kernel.private_instance_methods(false).should.include?(:binding)
@@ -47,5 +41,15 @@ describe "Kernel#binding" do
     m = mock(:whatever)
     cls = Class.new { ScratchPad.record eval('self', m.send(:binding)) }
     ScratchPad.recorded.should == cls
+  end
+end
+
+describe "Kernel.binding" do
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:binding)
+  end
+
+  it "returns a binding for the caller" do
+    Kernel.binding.eval("self").should == self
   end
 end

--- a/core/kernel/block_given_spec.rb
+++ b/core/kernel/block_given_spec.rb
@@ -1,43 +1,37 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-describe :kernel_block_given, shared: true do
-  it "returns true if and only if a block is supplied" do
-    @object.accept_block {}.should == true
-    @object.accept_block_as_argument {}.should == true
-    @object.accept_block_inside_block {}.should == true
-    @object.accept_block_as_argument_inside_block {}.should == true
+describe "Kernel#block_given?" do
+  it "is a private method" do
+    Kernel.private_instance_methods(false).should.include?(:block_given?)
+  end
 
-    @object.accept_block.should == false
-    @object.accept_block_as_argument.should == false
-    @object.accept_block_inside_block.should == false
-    @object.accept_block_as_argument_inside_block.should == false
+  it "returns true if and only if a block is supplied" do
+    KernelSpecs::BlockGiven.accept_block {}.should == true
+    KernelSpecs::BlockGiven.accept_block_as_argument {}.should == true
+    KernelSpecs::BlockGiven.accept_block_inside_block {}.should == true
+    KernelSpecs::BlockGiven.accept_block_as_argument_inside_block {}.should == true
+
+    KernelSpecs::BlockGiven.accept_block.should == false
+    KernelSpecs::BlockGiven.accept_block_as_argument.should == false
+    KernelSpecs::BlockGiven.accept_block_inside_block.should == false
+    KernelSpecs::BlockGiven.accept_block_as_argument_inside_block.should == false
   end
 
   # Clarify: Based on http://www.ruby-forum.com/topic/137822 it appears
   # that Matz wanted this to be true in 1.9.
   it "returns false when a method defined by define_method is called with a block" do
-    @object.defined_block {}.should == false
-    @object.defined_block_inside_block {}.should == false
+    KernelSpecs::BlockGiven.defined_block {}.should == false
+    KernelSpecs::BlockGiven.defined_block_inside_block {}.should == false
   end
-end
-
-describe "Kernel#block_given?" do
-  it_behaves_like :kernel_block_given, :block_given?, KernelSpecs::BlockGiven
 
   it "returns false outside of a method" do
     block_given?.should == false
   end
-
-  it "is a private method" do
-    Kernel.private_instance_methods(false).should.include?(:block_given?)
-  end
 end
 
 describe "Kernel.block_given?" do
-  it_behaves_like :kernel_block_given, :block_given?, KernelSpecs::KernelBlockGiven
-end
-
-describe "self.send(:block_given?)" do
-  it_behaves_like :kernel_block_given, :block_given?, KernelSpecs::SelfBlockGiven
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:block_given?)
+  end
 end

--- a/core/kernel/caller_locations_spec.rb
+++ b/core/kernel/caller_locations_spec.rb
@@ -111,3 +111,9 @@ describe 'Kernel#caller_locations' do
     end
   end
 end
+
+describe "Kernel.caller_locations" do
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:caller_locations)
+  end
+end

--- a/core/kernel/caller_spec.rb
+++ b/core/kernel/caller_spec.rb
@@ -119,3 +119,9 @@ describe 'Kernel#caller' do
     end
   end
 end
+
+describe "Kernel.caller" do
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:caller)
+  end
+end

--- a/core/kernel/catch_spec.rb
+++ b/core/kernel/catch_spec.rb
@@ -1,9 +1,13 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-describe "Kernel.catch" do
+describe "Kernel#catch" do
   before :each do
     ScratchPad.clear
+  end
+
+  it "is a private method" do
+    Kernel.private_instance_methods(false).should.include?(:catch)
   end
 
   it "executes its block and catches a thrown value matching its argument" do
@@ -120,8 +124,8 @@ describe "Kernel.catch" do
   end
 end
 
-describe "Kernel#catch" do
-  it "is a private method" do
-    Kernel.private_instance_methods(false).should.include?(:catch)
+describe "Kernel.catch" do
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:catch)
   end
 end

--- a/core/kernel/chomp_spec.rb
+++ b/core/kernel/chomp_spec.rb
@@ -2,45 +2,34 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-describe :kernel_chomp, shared: true do
+describe "Kernel#chomp" do
+  it "is a private method only when -n is passed" do
+    Kernel.private_instance_methods(false).should_not.include?(:chomp)
+    KernelSpecs.private_instance_method_with_dash_n?(:chomp).should == true
+  end
+
   it "removes the final newline of $_" do
-    KernelSpecs.chomp("abc\n", @method).should == "abc"
+    KernelSpecs.chomp_with_dash_n("abc\n").should == "abc"
   end
 
   it "removes the final carriage return of $_" do
-    KernelSpecs.chomp("abc\r", @method).should == "abc"
+    KernelSpecs.chomp_with_dash_n("abc\r").should == "abc"
   end
 
   it "removes the final carriage return, newline of $_" do
-    KernelSpecs.chomp("abc\r\n", @method).should == "abc"
+    KernelSpecs.chomp_with_dash_n("abc\r\n").should == "abc"
   end
 
   it "removes only the final newline of $_" do
-    KernelSpecs.chomp("abc\n\n", @method).should == "abc\n"
+    KernelSpecs.chomp_with_dash_n("abc\n\n").should == "abc\n"
   end
 
   it "removes the value of $/ from the end of $_" do
-    KernelSpecs.chomp("abcde", @method, "cde").should == "ab"
+    KernelSpecs.chomp_with_dash_n("abcde", "cde").should == "ab"
   end
-end
-
-describe :kernel_chomp_private, shared: true do
-  it "is a private method" do
-    KernelSpecs.has_private_method(@method).should == true
-  end
-end
-
-describe "Kernel.chomp" do
-  it_behaves_like :kernel_chomp, "Kernel.chomp"
 end
 
 describe "Kernel#chomp" do
-  it_behaves_like :kernel_chomp, "chomp"
-
-  it_behaves_like :kernel_chomp_private, :chomp
-end
-
-describe :kernel_chomp_encoded, shared: true do
   before :each do
     @external = Encoding.default_external
     Encoding.default_external = Encoding::UTF_8
@@ -51,15 +40,14 @@ describe :kernel_chomp_encoded, shared: true do
   end
 
   it "removes the final carriage return, newline from a multi-byte $_" do
-    script = fixture __FILE__, "#{@method}.rb"
+    script = fixture __FILE__, "chomp.rb"
     KernelSpecs.run_with_dash_n(script).should == "あれ"
   end
 end
 
 describe "Kernel.chomp" do
-  it_behaves_like :kernel_chomp_encoded, "chomp"
-end
-
-describe "Kernel#chomp" do
-  it_behaves_like :kernel_chomp_encoded, "chomp_f"
+  it "is a public method only when -n is passed" do
+    Kernel.public_methods(false).should_not.include?(:chomp)
+    KernelSpecs.public_singleton_method_with_dash_n?(:chomp).should == true
+  end
 end

--- a/core/kernel/chop_spec.rb
+++ b/core/kernel/chop_spec.rb
@@ -2,33 +2,22 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-describe :kernel_chop, shared: true do
+describe "Kernel#chop" do
+  it "is a private method only when -n is passed" do
+    Kernel.private_instance_methods(false).should_not.include?(:chop)
+    KernelSpecs.private_instance_method_with_dash_n?(:chop).should == true
+  end
+
   it "removes the final character of $_" do
-    KernelSpecs.chop("abc", @method).should == "ab"
+    KernelSpecs.chop_with_dash_n("abc").should == "ab"
   end
 
   it "removes the final carriage return, newline of $_" do
-    KernelSpecs.chop("abc\r\n", @method).should == "abc"
+    KernelSpecs.chop_with_dash_n("abc\r\n").should == "abc"
   end
-end
-
-describe :kernel_chop_private, shared: true do
-  it "is a private method" do
-    KernelSpecs.has_private_method(@method).should == true
-  end
-end
-
-describe "Kernel.chop" do
-  it_behaves_like :kernel_chop, "Kernel.chop"
 end
 
 describe "Kernel#chop" do
-  it_behaves_like :kernel_chop_private, :chop
-
-  it_behaves_like :kernel_chop, "chop"
-end
-
-describe :kernel_chop_encoded, shared: true do
   before :each do
     @external = Encoding.default_external
     Encoding.default_external = Encoding::UTF_8
@@ -39,15 +28,14 @@ describe :kernel_chop_encoded, shared: true do
   end
 
   it "removes the final multi-byte character from $_" do
-    script = fixture __FILE__, "#{@method}.rb"
+    script = fixture __FILE__, "chop.rb"
     KernelSpecs.run_with_dash_n(script).should == "あ"
   end
 end
 
 describe "Kernel.chop" do
-  it_behaves_like :kernel_chop_encoded, "chop"
-end
-
-describe "Kernel#chop" do
-  it_behaves_like :kernel_chop_encoded, "chop_f"
+  it "is a public method only when -n is passed" do
+    Kernel.public_methods(false).should_not.include?(:chop)
+    KernelSpecs.public_singleton_method_with_dash_n?(:chop).should == true
+  end
 end

--- a/core/kernel/eval_spec.rb
+++ b/core/kernel/eval_spec.rb
@@ -8,10 +8,6 @@ describe "Kernel#eval" do
     Kernel.private_instance_methods(false).should.include?(:eval)
   end
 
-  it "is a module function" do
-    Kernel.respond_to?(:eval).should == true
-  end
-
   it "evaluates the code within" do
     eval("2 + 3").should == 5
   end
@@ -264,7 +260,6 @@ describe "Kernel#eval" do
   # See http://jira.codehaus.org/browse/JRUBY-5163
   it "uses the receiver as self inside the eval" do
     eval("self").should.equal?(self)
-    Kernel.eval("self").should.equal?(Kernel)
   end
 
   it "does not pass the block to the method being eval'ed" do
@@ -548,5 +543,15 @@ CODE
 
       result.should == "bar"
     end
+  end
+end
+
+describe "Kernel.eval" do
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:Array)
+  end
+
+  it "uses the receiver as self inside the eval" do
+    Kernel.eval("self").should.equal?(Kernel)
   end
 end

--- a/core/kernel/exec_spec.rb
+++ b/core/kernel/exec_spec.rb
@@ -12,7 +12,7 @@ describe "Kernel#exec" do
 end
 
 describe "Kernel.exec" do
-  it "runs the specified command, replacing current process" do
-    ruby_exe('Kernel.exec "echo hello"; puts "fail"').should == "hello\n"
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:exec)
   end
 end

--- a/core/kernel/exit_spec.rb
+++ b/core/kernel/exit_spec.rb
@@ -11,7 +11,9 @@ describe "Kernel#exit" do
 end
 
 describe "Kernel.exit" do
-  it_behaves_like :process_exit, :exit, Kernel
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:exit)
+  end
 end
 
 describe "Kernel#exit!" do
@@ -23,5 +25,7 @@ describe "Kernel#exit!" do
 end
 
 describe "Kernel.exit!" do
-  it_behaves_like :process_exit!, :exit!, "Kernel"
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:exit!)
+  end
 end

--- a/core/kernel/fixtures/chomp.rb
+++ b/core/kernel/fixtures/chomp.rb
@@ -1,4 +1,4 @@
 # -*- encoding: utf-8 -*-
 
 $_ = "あれ\r\n"
-print Kernel.chomp
+print chomp

--- a/core/kernel/fixtures/chomp_f.rb
+++ b/core/kernel/fixtures/chomp_f.rb
@@ -1,4 +1,0 @@
-# -*- encoding: utf-8 -*-
-
-$_ = "あれ\r\n"
-print chomp

--- a/core/kernel/fixtures/chop.rb
+++ b/core/kernel/fixtures/chop.rb
@@ -1,4 +1,4 @@
 # -*- encoding: utf-8 -*-
 
 $_ = "あれ"
-print Kernel.chop
+print chop

--- a/core/kernel/fixtures/chop_f.rb
+++ b/core/kernel/fixtures/chop_f.rb
@@ -1,4 +1,0 @@
-# -*- encoding: utf-8 -*-
-
-$_ = "あれ"
-print chop

--- a/core/kernel/fixtures/classes.rb
+++ b/core/kernel/fixtures/classes.rb
@@ -1,54 +1,30 @@
 module KernelSpecs
-  def self.Array_function(arg)
-    Array(arg)
-  end
-
-  def self.Array_method(arg)
-    Kernel.Array(arg)
-  end
-
-  def self.Hash_function(arg)
-    Hash(arg)
-  end
-
-  def self.Hash_method(arg)
-    Kernel.Hash(arg)
-  end
-
-  def self.Integer_function(arg)
-    Integer(arg)
-  end
-
-  def self.Integer_method(arg)
-    Kernel.Integer(arg)
-  end
-
-  def self.putc_function(arg)
-    putc arg
-  end
-
-  def self.putc_method(arg)
-    Kernel.putc arg
-  end
-
-  def self.has_private_method(name)
-    IO.popen([*ruby_exe, "-n", "-e", "print Kernel.private_method_defined?(#{name.inspect})"], "r+") do |io|
+  def self.private_instance_method_with_dash_n?(name)
+    IO.popen([*ruby_exe, "-n", "-e", "print Kernel.private_instance_methods(false).include?(#{name.inspect})"], "r+") do |io|
       io.puts
       io.close_write
       io.read
     end == "true"
   end
 
-  def self.chop(str, method)
-    IO.popen([*ruby_exe, "-n", "-e", "$_ = #{str.inspect}; #{method}; print $_"], "r+") do |io|
+  def self.public_singleton_method_with_dash_n?(name)
+    IO.popen([*ruby_exe, "-n", "-e", "print Kernel.public_methods(false).include?(#{name.inspect})"], "r+") do |io|
+      io.puts
+      io.close_write
+      io.read
+    end == "true"
+  end
+
+  def self.chop_with_dash_n(str)
+    IO.popen([*ruby_exe, "-n", "-e", "$_ = #{str.inspect}; chop; print $_"], "r+") do |io|
       io.puts
       io.close_write
       io.read
     end
   end
 
-  def self.chomp(str, method, sep="\n")
-    code = "$_ = #{str.inspect}; $/ = #{sep.inspect}; #{method}; print $_"
+  def self.chomp_with_dash_n(str, sep="\n")
+    code = "$_ = #{str.inspect}; $/ = #{sep.inspect}; chomp; print $_"
     IO.popen([*ruby_exe, "-W0", "-n", "-e", code], "r+") do |io|
       io.puts
       io.close_write
@@ -258,74 +234,6 @@ module KernelSpecs
       define_method(:defined_block_inside_block) do
         yield_self {
           block_given?
-        }
-      end
-    end
-  end
-
-  module SelfBlockGiven
-    def self.accept_block
-      self.send(:block_given?)
-    end
-
-    def self.accept_block_as_argument(&block)
-      self.send(:block_given?)
-    end
-
-    def self.accept_block_inside_block
-      yield_self {
-        self.send(:block_given?)
-      }
-    end
-
-    def self.accept_block_as_argument_inside_block(&block)
-      yield_self {
-        self.send(:block_given?)
-      }
-    end
-
-    class << self
-      define_method(:defined_block) do
-        self.send(:block_given?)
-      end
-
-      define_method(:defined_block_inside_block) do
-        yield_self {
-          self.send(:block_given?)
-        }
-      end
-    end
-  end
-
-  module KernelBlockGiven
-    def self.accept_block
-      Kernel.block_given?
-    end
-
-    def self.accept_block_as_argument(&block)
-      Kernel.block_given?
-    end
-
-    def self.accept_block_inside_block
-      yield_self {
-        Kernel.block_given?
-      }
-    end
-
-    def self.accept_block_as_argument_inside_block(&block)
-      yield_self {
-        Kernel.block_given?
-      }
-    end
-
-    class << self
-      define_method(:defined_block) do
-        Kernel.block_given?
-      end
-
-      define_method(:defined_block_inside_block) do
-        yield_self {
-          Kernel.block_given?
         }
       end
     end

--- a/core/kernel/fork_spec.rb
+++ b/core/kernel/fork_spec.rb
@@ -11,5 +11,7 @@ describe "Kernel#fork" do
 end
 
 describe "Kernel.fork" do
-  it_behaves_like :process_fork, :fork, Kernel
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:fork)
+  end
 end

--- a/core/kernel/gets_spec.rb
+++ b/core/kernel/gets_spec.rb
@@ -13,5 +13,7 @@ describe "Kernel#gets" do
 end
 
 describe "Kernel.gets" do
-  it "needs to be reviewed for spec completeness"
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:gets)
+  end
 end

--- a/core/kernel/global_variables_spec.rb
+++ b/core/kernel/global_variables_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-describe "Kernel.global_variables" do
+describe "Kernel#global_variables" do
   it "is a private method" do
     Kernel.private_instance_methods(false).should.include?(:global_variables)
   end
@@ -21,6 +21,8 @@ describe "Kernel.global_variables" do
   end
 end
 
-describe "Kernel#global_variables" do
-  it "needs to be reviewed for spec completeness"
+describe "Kernel.global_variables" do
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:global_variables)
+  end
 end

--- a/core/kernel/lambda_spec.rb
+++ b/core/kernel/lambda_spec.rb
@@ -4,7 +4,7 @@ require_relative 'shared/lambda'
 
 # The functionality of lambdas is specified in core/proc
 
-describe "Kernel.lambda" do
+describe "Kernel#lambda" do
   it_behaves_like :kernel_lambda, :lambda
 
   it "is a private method" do
@@ -106,5 +106,11 @@ describe "Kernel.lambda" do
     it "doesn't warn when proc is lambda" do
       -> { lambda(&lambda{}) }.should_not complain(verbose: true)
     end
+  end
+end
+
+describe "Kernel.lambda" do
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:lambda)
   end
 end

--- a/core/kernel/load_spec.rb
+++ b/core/kernel/load_spec.rb
@@ -24,17 +24,7 @@ describe "Kernel#load" do
 end
 
 describe "Kernel.load" do
-  before :each do
-    CodeLoadingSpecs.spec_setup
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:load)
   end
-
-  after :each do
-    CodeLoadingSpecs.spec_cleanup
-  end
-
-  it_behaves_like :kernel_require_basic, :load, Kernel
-end
-
-describe "Kernel.load" do
-  it_behaves_like :kernel_load, :load, Kernel
 end

--- a/core/kernel/local_variables_spec.rb
+++ b/core/kernel/local_variables_spec.rb
@@ -43,3 +43,9 @@ describe "Kernel#local_variables" do
     local_var_method.should == [:a]
   end
 end
+
+describe "Kernel.local_variables" do
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:local_variables)
+  end
+end

--- a/core/kernel/loop_spec.rb
+++ b/core/kernel/loop_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-describe "Kernel.loop" do
+describe "Kernel#loop" do
   it "is a private method" do
     Kernel.private_instance_methods(false).should.include?(:loop)
   end
@@ -75,5 +75,11 @@ describe "Kernel.loop" do
         end
       end
     end
+  end
+end
+
+describe "Kernel.loop" do
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:loop)
   end
 end

--- a/core/kernel/open_spec.rb
+++ b/core/kernel/open_spec.rb
@@ -188,5 +188,7 @@ describe "Kernel#open" do
 end
 
 describe "Kernel.open" do
-  it "needs to be reviewed for spec completeness"
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:open)
+  end
 end

--- a/core/kernel/p_spec.rb
+++ b/core/kernel/p_spec.rb
@@ -81,5 +81,7 @@ describe "Kernel#p" do
 end
 
 describe "Kernel.p" do
-  it "needs to be reviewed for spec completeness"
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:p)
+  end
 end

--- a/core/kernel/print_spec.rb
+++ b/core/kernel/print_spec.rb
@@ -20,5 +20,7 @@ describe "Kernel#print" do
 end
 
 describe "Kernel.print" do
-  it "needs to be reviewed for spec completeness"
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:print)
+  end
 end

--- a/core/kernel/printf_spec.rb
+++ b/core/kernel/printf_spec.rb
@@ -3,12 +3,6 @@ require_relative 'fixtures/classes'
 require_relative 'shared/sprintf'
 
 describe "Kernel#printf" do
-  it "is a private method" do
-    Kernel.private_instance_methods(false).should.include?(:printf)
-  end
-end
-
-describe "Kernel.printf" do
   before :each do
     @stdout = $stdout
     @name = tmp("kernel_puts.txt")
@@ -21,26 +15,30 @@ describe "Kernel.printf" do
     rm_r @name
   end
 
+  it "is a private method" do
+    Kernel.private_instance_methods(false).should.include?(:printf)
+  end
+
   it "writes to stdout when a string is the first argument" do
     $stdout.should_receive(:write).with("string")
-    Kernel.printf("%s", "string")
+    printf("%s", "string")
   end
 
   it "calls write on the first argument when it is not a string" do
     object = mock('io')
     object.should_receive(:write).with("string")
-    Kernel.printf(object, "%s", "string")
+    printf(object, "%s", "string")
   end
 
   it "calls #to_str to convert the format object to a String" do
     object = mock('format string')
     object.should_receive(:to_str).and_return("to_str: %i")
     $stdout.should_receive(:write).with("to_str: 42")
-    Kernel.printf($stdout, object, 42)
+    printf($stdout, object, 42)
   end
 end
 
-describe "Kernel.printf" do
+describe "Kernel#printf" do
   describe "formatting" do
     before :each do
       require "stringio"
@@ -49,7 +47,7 @@ describe "Kernel.printf" do
     context "io is specified" do
       it_behaves_like :kernel_sprintf, -> format, *args {
         io = StringIO.new(+"")
-        Kernel.printf(io, format, *args)
+        printf(io, format, *args)
         io.string
       }
     end
@@ -59,12 +57,18 @@ describe "Kernel.printf" do
         stdout = $stdout
         begin
           $stdout = io = StringIO.new(+"")
-          Kernel.printf(format, *args)
+          printf(format, *args)
           io.string
         ensure
           $stdout = stdout
         end
       }
     end
+  end
+end
+
+describe "Kernel.printf" do
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:printf)
   end
 end

--- a/core/kernel/proc_spec.rb
+++ b/core/kernel/proc_spec.rb
@@ -4,7 +4,7 @@ require_relative 'shared/lambda'
 
 # The functionality of Proc objects is specified in core/proc
 
-describe "Kernel.proc" do
+describe "Kernel#proc" do
   it "is a private method" do
     Kernel.private_instance_methods(false).should.include?(:proc)
   end
@@ -44,5 +44,11 @@ describe "Kernel#proc" do
     -> {
       some_method { "hello" }
     }.should.raise(ArgumentError, 'tried to create Proc object without a block')
+  end
+end
+
+describe "Kernel.proc" do
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:proc)
   end
 end

--- a/core/kernel/putc_spec.rb
+++ b/core/kernel/putc_spec.rb
@@ -3,37 +3,26 @@ require_relative 'fixtures/classes'
 require_relative '../../shared/io/putc'
 
 describe "Kernel#putc" do
-  it "is a private instance method" do
+  before :each do
+    @name = tmp("kernel_putc.txt")
+    @io = new_io @name
+    @io_object = @object
+    @stdout, $stdout = $stdout, @io
+  end
+
+  after :each do
+    $stdout = @stdout
+  end
+
+  it "is a private method" do
     Kernel.private_instance_methods(false).should.include?(:putc)
   end
+
+  it_behaves_like :io_putc, :putc, Object.new
 end
 
 describe "Kernel.putc" do
-  before :each do
-    @name = tmp("kernel_putc.txt")
-    @io = new_io @name
-    @io_object = @object
-    @stdout, $stdout = $stdout, @io
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:putc)
   end
-
-  after :each do
-    $stdout = @stdout
-  end
-
-  it_behaves_like :io_putc, :putc_method, KernelSpecs
-end
-
-describe "Kernel#putc" do
-  before :each do
-    @name = tmp("kernel_putc.txt")
-    @io = new_io @name
-    @io_object = @object
-    @stdout, $stdout = $stdout, @io
-  end
-
-  after :each do
-    $stdout = @stdout
-  end
-
-  it_behaves_like :io_putc, :putc_function, KernelSpecs
 end

--- a/core/kernel/puts_spec.rb
+++ b/core/kernel/puts_spec.rb
@@ -25,5 +25,7 @@ describe "Kernel#puts" do
 end
 
 describe "Kernel.puts" do
-  it "needs to be reviewed for spec completeness"
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:puts)
+  end
 end

--- a/core/kernel/raise_spec.rb
+++ b/core/kernel/raise_spec.rb
@@ -214,9 +214,6 @@ end
 
 describe "Kernel.raise" do
   it "is a public method" do
-    Kernel.singleton_class.should.public_method_defined?(:raise)
+    Kernel.public_methods(false).should.include?(:Array)
   end
-
-  it_behaves_like :kernel_raise, :raise, Kernel
-  it_behaves_like :kernel_raise_with_cause, :raise, Kernel
 end

--- a/core/kernel/rand_spec.rb
+++ b/core/kernel/rand_spec.rb
@@ -193,5 +193,7 @@ describe "Kernel#rand" do
 end
 
 describe "Kernel.rand" do
-  it "needs to be reviewed for spec completeness"
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:rand)
+  end
 end

--- a/core/kernel/readline_spec.rb
+++ b/core/kernel/readline_spec.rb
@@ -8,5 +8,7 @@ describe "Kernel#readline" do
 end
 
 describe "Kernel.readline" do
-  it "needs to be reviewed for spec completeness"
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:readline)
+  end
 end

--- a/core/kernel/readlines_spec.rb
+++ b/core/kernel/readlines_spec.rb
@@ -8,5 +8,7 @@ describe "Kernel#readlines" do
 end
 
 describe "Kernel.readlines" do
-  it "needs to be reviewed for spec completeness"
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:readlines)
+  end
 end

--- a/core/kernel/require_relative_spec.rb
+++ b/core/kernel/require_relative_spec.rb
@@ -14,6 +14,10 @@ describe "Kernel#require_relative with a relative path" do
     CodeLoadingSpecs.spec_cleanup
   end
 
+  it "is a private method" do
+    Kernel.private_instance_methods(false).should.include?(:require_relative)
+  end
+
   platform_is_not :windows do
     describe "when file is a symlink" do
       before :each do
@@ -433,5 +437,11 @@ describe "Kernel#require_relative with an absolute path" do
       $LOADED_FEATURES.should.include?(@abs_path)
       ScratchPad.recorded.should == [:loaded]
     end
+  end
+end
+
+describe "Kernel.require_relative" do
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:require_relative)
   end
 end

--- a/core/kernel/require_spec.rb
+++ b/core/kernel/require_spec.rb
@@ -54,14 +54,7 @@ describe "Kernel#require" do
 end
 
 describe "Kernel.require" do
-  before :each do
-    CodeLoadingSpecs.spec_setup
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:require)
   end
-
-  after :each do
-    CodeLoadingSpecs.spec_cleanup
-  end
-
-  it_behaves_like :kernel_require_basic, :require, Kernel
-  it_behaves_like :kernel_require, :require, Kernel
 end

--- a/core/kernel/select_spec.rb
+++ b/core/kernel/select_spec.rb
@@ -5,14 +5,18 @@ describe "Kernel#select" do
   it "is a private method" do
     Kernel.private_instance_methods(false).should.include?(:select)
   end
-end
 
-describe "Kernel.select" do
   it 'does not block when timeout is 0' do
     IO.pipe do |read, write|
       select([read], [], [], 0).should == nil
       write.write 'data'
       select([read], [], [], 0).should == [[read], [], []]
     end
+  end
+end
+
+describe "Kernel.select" do
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:select)
   end
 end

--- a/core/kernel/set_trace_func_spec.rb
+++ b/core/kernel/set_trace_func_spec.rb
@@ -8,5 +8,7 @@ describe "Kernel#set_trace_func" do
 end
 
 describe "Kernel.set_trace_func" do
-  it "needs to be reviewed for spec completeness"
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:set_trace_func)
+  end
 end

--- a/core/kernel/sleep_spec.rb
+++ b/core/kernel/sleep_spec.rb
@@ -78,7 +78,7 @@ describe "Kernel#sleep" do
     t.value.should == 5
   end
 
-  context "Kernel.sleep with Fiber scheduler" do
+  context "Kernel#sleep with Fiber scheduler" do
     before :each do
       Fiber.set_scheduler(FiberSpecs::LoggingScheduler.new)
     end
@@ -114,5 +114,7 @@ describe "Kernel#sleep" do
 end
 
 describe "Kernel.sleep" do
-  it "needs to be reviewed for spec completeness"
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:sleep)
+  end
 end

--- a/core/kernel/spawn_spec.rb
+++ b/core/kernel/spawn_spec.rb
@@ -17,9 +17,7 @@ describe "Kernel#spawn" do
 end
 
 describe "Kernel.spawn" do
-  it "executes the given command" do
-    -> {
-      Process.wait Kernel.spawn("echo spawn")
-    }.should output_to_fd("spawn\n")
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:spawn)
   end
 end

--- a/core/kernel/sprintf_spec.rb
+++ b/core/kernel/sprintf_spec.rb
@@ -3,14 +3,6 @@ require_relative 'fixtures/classes'
 require_relative 'shared/sprintf'
 require_relative 'shared/sprintf_encoding'
 
-describe :kernel_sprintf_to_str, shared: true do
-  it "calls #to_str to convert the format object to a String" do
-    obj = mock('format string')
-    obj.should_receive(:to_str).and_return("to_str: %i")
-    @method.call(obj, 42).should == "to_str: 42"
-  end
-end
-
 describe "Kernel#sprintf" do
   it_behaves_like :kernel_sprintf, -> format, *args {
     r = nil
@@ -28,37 +20,15 @@ describe "Kernel#sprintf" do
     r
   }
 
-  it_behaves_like :kernel_sprintf_to_str, -> format, *args {
-    r = nil
-    -> {
-      r = sprintf(format, *args)
-    }.should_not complain(verbose: true)
-    r
-  }
+  it "calls #to_str to convert the format object to a String" do
+    obj = mock('format string')
+    obj.should_receive(:to_str).and_return("to_str: %i")
+    @method.call(obj, 42).should == "to_str: 42"
+  end
 end
 
 describe "Kernel.sprintf" do
-  it_behaves_like :kernel_sprintf, -> format, *args {
-    r = nil
-    -> {
-      r = Kernel.sprintf(format, *args)
-    }.should_not complain(verbose: true)
-    r
-  }
-
-  it_behaves_like :kernel_sprintf_encoding, -> format, *args {
-    r = nil
-    -> {
-      r = Kernel.sprintf(format, *args)
-    }.should_not complain(verbose: true)
-    r
-  }
-
-  it_behaves_like :kernel_sprintf_to_str, -> format, *args {
-    r = nil
-    -> {
-      r = Kernel.sprintf(format, *args)
-    }.should_not complain(verbose: true)
-    r
-  }
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:sprintf)
+  end
 end

--- a/core/kernel/srand_spec.rb
+++ b/core/kernel/srand_spec.rb
@@ -69,5 +69,7 @@ describe "Kernel#srand" do
 end
 
 describe "Kernel.srand" do
-  it "needs to be reviewed for spec completeness"
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:srand)
+  end
 end

--- a/core/kernel/syscall_spec.rb
+++ b/core/kernel/syscall_spec.rb
@@ -8,5 +8,7 @@ describe "Kernel#syscall" do
 end
 
 describe "Kernel.syscall" do
-  it "needs to be reviewed for spec completeness"
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:syscall)
+  end
 end

--- a/core/kernel/system_spec.rb
+++ b/core/kernel/system_spec.rb
@@ -1,16 +1,20 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-describe :kernel_system, shared: true do
+describe "Kernel#system" do
+  it "is a private method" do
+    Kernel.private_instance_methods(false).should.include?(:system)
+  end
+
   it "executes the specified command in a subprocess" do
-    -> { @object.system("echo a") }.should output_to_fd("a\n")
+    -> { system("echo a") }.should output_to_fd("a\n")
 
     $?.should.instance_of? Process::Status
     $?.should.success?
   end
 
   it "returns true when the command exits with a zero exit status" do
-    @object.system(ruby_cmd('exit 0')).should == true
+    system(ruby_cmd('exit 0')).should == true
 
     $?.should.instance_of? Process::Status
     $?.should.success?
@@ -18,7 +22,7 @@ describe :kernel_system, shared: true do
   end
 
   it "returns false when the command exits with a non-zero exit status" do
-    @object.system(ruby_cmd('exit 1')).should == false
+    system(ruby_cmd('exit 1')).should == false
 
     $?.should.instance_of? Process::Status
     $?.should_not.success?
@@ -26,15 +30,15 @@ describe :kernel_system, shared: true do
   end
 
   it "raises RuntimeError when `exception: true` is given and the command exits with a non-zero exit status" do
-    -> { @object.system(ruby_cmd('exit 1'), exception: true) }.should.raise(RuntimeError)
+    -> { system(ruby_cmd('exit 1'), exception: true) }.should.raise(RuntimeError)
   end
 
   it "raises Errno::ENOENT when `exception: true` is given and the specified command does not exist" do
-    -> { @object.system('feature_14386', exception: true) }.should.raise(Errno::ENOENT)
+    -> { system('feature_14386', exception: true) }.should.raise(Errno::ENOENT)
   end
 
   it "returns nil when command execution fails" do
-    @object.system("sad").should == nil
+    system("sad").should == nil
 
     $?.should.instance_of? Process::Status
     $?.pid.should.is_a?(Integer)
@@ -42,7 +46,7 @@ describe :kernel_system, shared: true do
   end
 
   it "does not write to stderr when command execution fails" do
-    -> { @object.system("sad") }.should output_to_fd("", STDERR)
+    -> { system("sad") }.should output_to_fd("", STDERR)
   end
 
   platform_is_not :windows do
@@ -55,12 +59,12 @@ describe :kernel_system, shared: true do
     end
 
     it "executes with `sh` if the command contains shell characters" do
-      -> { @object.system("echo $0") }.should output_to_fd("sh\n")
+      -> { system("echo $0") }.should output_to_fd("sh\n")
     end
 
     it "ignores SHELL env var and always uses `sh`" do
       ENV['SHELL'] = "/bin/fakeshell"
-      -> { @object.system("echo $0") }.should output_to_fd("sh\n")
+      -> { system("echo $0") }.should output_to_fd("sh\n")
     end
   end
 
@@ -77,7 +81,7 @@ describe :kernel_system, shared: true do
     end
 
     it "executes with `sh` if the command is executable but not binary and there is no shebang" do
-      -> { @object.system(@shell_command) }.should output_to_fd(ENV['PATH'] + "\n")
+      -> { system(@shell_command) }.should output_to_fd(ENV['PATH'] + "\n")
     end
   end
 
@@ -94,39 +98,33 @@ describe :kernel_system, shared: true do
   end
 
   it "expands shell variables when given a single string argument" do
-    -> { @object.system("echo #{@shell_var}") }.should output_to_fd("foo\n")
+    -> { system("echo #{@shell_var}") }.should output_to_fd("foo\n")
   end
 
   platform_is_not :windows do
     it "does not expand shell variables when given multiples arguments" do
-      -> { @object.system("echo", @shell_var) }.should output_to_fd("#{@shell_var}\n")
+      -> { system("echo", @shell_var) }.should output_to_fd("#{@shell_var}\n")
     end
   end
 
   platform_is :windows do
     it "does expand shell variables when given multiples arguments" do
       # See https://bugs.ruby-lang.org/issues/12231
-      -> { @object.system("echo", @shell_var) }.should output_to_fd("foo\n")
+      -> { system("echo", @shell_var) }.should output_to_fd("foo\n")
     end
   end
 
   platform_is :windows do
     it "runs commands starting with any number of @ using shell" do
       `#{ruby_cmd("p system 'does_not_exist'")} 2>NUL`.chomp.should == "nil"
-      @object.system('@does_not_exist 2>NUL').should == false
-      @object.system("@@@#{ruby_cmd('exit 0')}").should == true
+      system('@does_not_exist 2>NUL').should == false
+      system("@@@#{ruby_cmd('exit 0')}").should == true
     end
   end
 end
 
-describe "Kernel#system" do
-  it "is a private method" do
-    Kernel.private_instance_methods(false).should.include?(:system)
-  end
-
-  it_behaves_like :kernel_system, :system, KernelSpecs::Method.new
-end
-
 describe "Kernel.system" do
-  it_behaves_like :kernel_system, :system, Kernel
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:system)
+  end
 end

--- a/core/kernel/test_spec.rb
+++ b/core/kernel/test_spec.rb
@@ -12,15 +12,15 @@ describe "Kernel#test" do
   end
 
   it "returns true when passed ?f if the argument is a regular file" do
-    Kernel.test(?f, @file).should == true
+    test(?f, @file).should == true
   end
 
   it "returns true when passed ?e if the argument is a file" do
-    Kernel.test(?e, @file).should == true
+    test(?e, @file).should == true
   end
 
   it "returns true when passed ?d if the argument is a directory" do
-    Kernel.test(?d, @dir).should == true
+    test(?d, @dir).should == true
   end
 
   platform_is_not :windows do
@@ -28,7 +28,7 @@ describe "Kernel#test" do
       link = tmp("file_symlink.lnk")
       File.symlink(@file, link)
       begin
-        Kernel.test(?l, link).should == true
+        test(?l, link).should == true
       ensure
         rm_r link
       end
@@ -36,11 +36,11 @@ describe "Kernel#test" do
   end
 
   it "returns true when passed ?r if the argument is readable by the effective uid" do
-    Kernel.test(?r, @file).should == true
+    test(?r, @file).should == true
   end
 
   it "returns true when passed ?R if the argument is readable by the real uid" do
-    Kernel.test(?R, @file).should == true
+    test(?R, @file).should == true
   end
 
   context "writable test" do
@@ -54,11 +54,11 @@ describe "Kernel#test" do
     end
 
     it "returns true when passed ?w if the argument is readable by the effective uid" do
-      Kernel.test(?w, @tmp_file).should == true
+      test(?w, @tmp_file).should == true
     end
 
     it "returns true when passed ?W if the argument is readable by the real uid" do
-      Kernel.test(?W, @tmp_file).should == true
+      test(?W, @tmp_file).should == true
     end
   end
 
@@ -73,37 +73,39 @@ describe "Kernel#test" do
     end
 
     it "returns the last access time for the provided file when passed ?A" do
-      Kernel.test(?A, @tmp_file).should == @tmp_file.atime
+      test(?A, @tmp_file).should == @tmp_file.atime
     end
 
     it "returns the time at which the file was created when passed ?C" do
-      Kernel.test(?C, @tmp_file).should == @tmp_file.ctime
+      test(?C, @tmp_file).should == @tmp_file.ctime
     end
 
     it "returns the time at which the file was modified when passed ?M" do
-      Kernel.test(?M, @tmp_file).should == @tmp_file.mtime
+      test(?M, @tmp_file).should == @tmp_file.mtime
     end
   end
 
   it "calls #to_path on second argument when passed ?f and a filename" do
     p = mock('path')
     p.should_receive(:to_path).and_return @file
-    Kernel.test(?f, p)
+    test(?f, p)
   end
 
   it "calls #to_path on second argument when passed ?e and a filename" do
     p = mock('path')
     p.should_receive(:to_path).and_return @file
-    Kernel.test(?e, p)
+    test(?e, p)
   end
 
   it "calls #to_path on second argument when passed ?d and a directory" do
     p = mock('path')
     p.should_receive(:to_path).and_return @dir
-    Kernel.test(?d, p)
+    test(?d, p)
   end
 end
 
 describe "Kernel.test" do
-  it "needs to be reviewed for spec completeness"
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:test)
+  end
 end

--- a/core/kernel/throw_spec.rb
+++ b/core/kernel/throw_spec.rb
@@ -1,7 +1,11 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
-describe "Kernel.throw" do
+describe "Kernel#throw" do
+  it "is a private method" do
+    Kernel.private_instance_methods(false).should.include?(:throw)
+  end
+
   it "transfers control to the end of the active catch block waiting for symbol" do
     catch(:blah) do
       :value
@@ -73,8 +77,8 @@ describe "Kernel.throw" do
   end
 end
 
-describe "Kernel#throw" do
-  it "is a private method" do
-    Kernel.private_instance_methods(false).should.include?(:throw)
+describe "Kernel.throw" do
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:throw)
   end
 end

--- a/core/kernel/trace_var_spec.rb
+++ b/core/kernel/trace_var_spec.rb
@@ -52,3 +52,9 @@ describe "Kernel#trace_var" do
     end.should.raise(ArgumentError)
   end
 end
+
+describe "Kernel.trace_var" do
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:trace_var)
+  end
+end

--- a/core/kernel/trap_spec.rb
+++ b/core/kernel/trap_spec.rb
@@ -7,3 +7,9 @@ describe "Kernel#trap" do
 
   # Behaviour is specified for Signal.trap
 end
+
+describe "Kernel.trap" do
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:trap)
+  end
+end

--- a/core/kernel/untrace_var_spec.rb
+++ b/core/kernel/untrace_var_spec.rb
@@ -8,5 +8,7 @@ describe "Kernel#untrace_var" do
 end
 
 describe "Kernel.untrace_var" do
-  it "needs to be reviewed for spec completeness"
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:untrace_var)
+  end
 end

--- a/core/kernel/warn_spec.rb
+++ b/core/kernel/warn_spec.rb
@@ -228,10 +228,10 @@ describe "Kernel#warn" do
 
     begin
       ScratchPad.clear
-      Kernel.warn("Chunky bacon!")
+      warn("Chunky bacon!")
       ScratchPad.recorded.should == "Chunky bacon!\n"
 
-      Kernel.warn("Deprecated bacon!", category: :deprecated)
+      warn("Deprecated bacon!", category: :deprecated)
       ScratchPad.recorded.should == "Deprecated bacon!\n"
     ensure
       class << Warning
@@ -248,7 +248,7 @@ describe "Kernel#warn" do
     verbose = $VERBOSE
     $VERBOSE = false
     begin
-      Kernel.warn("Chunky bacon!")
+      warn("Chunky bacon!")
     ensure
       $VERBOSE = verbose
     end
@@ -259,7 +259,7 @@ describe "Kernel#warn" do
     verbose = $VERBOSE
     $VERBOSE = false
     begin
-      Kernel.warn("Chunky bacon!", category: 'deprecated')
+      warn("Chunky bacon!", category: 'deprecated')
     ensure
       $VERBOSE = verbose
     end
@@ -294,5 +294,11 @@ describe "Kernel#warn" do
     out = ruby_exe(code, args: "2>&1", options: "--disable-gems")
     out.should == "avoid infinite recursion\n"
     $?.should.success?
+  end
+end
+
+describe "Kernel.warn" do
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:warn)
   end
 end

--- a/library/pathname/pathname_spec.rb
+++ b/library/pathname/pathname_spec.rb
@@ -2,12 +2,8 @@ require_relative '../../spec_helper'
 require 'pathname'
 
 describe "Kernel#Pathname" do
-  it "is a private instance method" do
+  it "is a private method" do
     Kernel.private_instance_methods(false).should.include?(:Pathname)
-  end
-
-  it "is also a public method" do
-    Kernel.should.respond_to?(:Pathname)
   end
 
   it "returns same argument when called with a pathname argument" do
@@ -15,5 +11,11 @@ describe "Kernel#Pathname" do
     new_path = Pathname(path)
 
     path.should.equal?(new_path)
+  end
+end
+
+describe "Kernel.Pathname" do
+  it "is a public method" do
+    Kernel.public_methods(false).should.include?(:Pathname)
   end
 end


### PR DESCRIPTION
Currently it checks that `Kernel.method` == `Object#method` by running specs twice. But the Kernel methods are just mixed into Object, so we should be able to assert that instead.

Draft for now. I think this still asserts the same thing, but do let me know if I should do the same for the other kernel methods/if I'm missing something/it can be asserted in a better way.