### PR TITLE
Add specs for singleton class handling in Proc#dup and Proc#clone

### DIFF
--- a/core/proc/clone_spec.rb
+++ b/core/proc/clone_spec.rb
@@ -5,6 +5,15 @@ require_relative 'shared/dup'
 describe "Proc#clone" do
   it_behaves_like :proc_dup, :clone
 
+  it "copies the singleton class" do
+    obj = proc { }
+    def obj.tag; :tag; end
+
+    clone = obj.clone
+    clone.should.respond_to?(:tag)
+    clone.tag.should == :tag
+  end
+
   ruby_bug "cloning a frozen proc is broken on Ruby 3.3", ""..."3.4" do
     it "preserves frozen status" do
       proc = Proc.new { }

--- a/core/proc/dup_spec.rb
+++ b/core/proc/dup_spec.rb
@@ -5,6 +5,13 @@ require_relative 'shared/dup'
 describe "Proc#dup" do
   it_behaves_like :proc_dup, :dup
 
+  it "does not copy the singleton class" do
+    obj = proc { }
+    def obj.tag; end
+
+    obj.dup.should_not.respond_to?(:tag)
+  end
+
   it "resets frozen status" do
     proc = Proc.new { }
     proc.freeze


### PR DESCRIPTION
Proc#dup should not copy the singleton class, but it does in JRuby, so I've fixed it: https://github.com/jruby/jruby/pull/9523

This PR adds a spec for it.