### PR TITLE
Add specs for Kernel#p return values

### DIFF
--- a/core/kernel/p_spec.rb
+++ b/core/kernel/p_spec.rb
@@ -69,11 +69,32 @@ describe "Kernel#p" do
   end
 
   it "prints nothing if no argument is given" do
-    -> { p }.should output("")
+    -> { p.should == nil }.should output("")
   end
 
   it "prints nothing if called splatting an empty Array" do
-    -> { p(*[]) }.should output("")
+    -> { p(*[]).should == nil }.should output("")
+  end
+
+  it "returns the argument if a single argument is given" do
+    o = mock("Inspector Gadget")
+    o.should_receive(:inspect).any_number_of_times.and_return "Next time, Gadget, NEXT TIME!"
+
+    -> { p(o).should.equal?(o) }.should output("Next time, Gadget, NEXT TIME!\n")
+  end
+
+  it "returns the argument if called splatting a single-element Array" do
+    o = mock("Inspector Gadget")
+    o.should_receive(:inspect).any_number_of_times.and_return "Next time, Gadget, NEXT TIME!"
+
+    -> { p(*[o]).should.equal?(o) }.should output("Next time, Gadget, NEXT TIME!\n")
+  end
+
+  it "returns an Array of the arguments if multiple arguments are given" do
+    o = mock("Inspector Gadget")
+    o.should_receive(:inspect).any_number_of_times.and_return "Next time, Gadget, NEXT TIME!"
+
+    -> { p(o, o).should == [o, o] }.should output("Next time, Gadget, NEXT TIME!\nNext time, Gadget, NEXT TIME!\n")
   end
 
   # Not sure how to spec this, but wanted to note the behavior here


### PR DESCRIPTION
### 👋🏾 
Found this implementing `Kernel#p` for [garnet-js](https://github.com/camertron/garnet-js/pull/57). The three-branch return had to be derived from MRI by hand since nothing in the suite pins it.

### 🔧

`Kernel#p`'s return value had no coverage for 3 scenarios:

- nil for no arguments
- the argument itself (not a 1-element Array) for a single argument
- a new Array for multiple arguments

That passthrough is what lets `p` be used inline where `puts` cannot, since `puts` always returns nil. An implementation that simply returned the collected arguments would pass every existing example while returning `[]` for no arguments and `[x]` for one.

The nil cases are asserted on the existing "prints nothing" examples, as `core/io/puts_spec.rb` does for `IO#puts`. The passthrough cases get their own examples, as `core/io/output_spec.rb` does for IO#<<. Specs are under `Kernel#p` only, following a1f57e8f.

Matchers follow #1350 (`.should == nil`, `.should.equal?`).