### PR TITLE
Add specs for Fiber.current_scheduler after a Fiber terminates

### DIFF
--- a/core/fiber/current_scheduler_spec.rb
+++ b/core/fiber/current_scheduler_spec.rb
@@ -63,5 +63,23 @@ describe "Fiber.current_scheduler" do
       end.resume
       seen.should.equal?(@scheduler)
     end
+
+    it "returns nil on the root Fiber after a blocking Fiber has finished" do
+      Fiber.new(blocking: true) { }.resume
+      Fiber.current_scheduler.should == nil
+    end
+
+    it "returns nil on the root Fiber after a blocking Fiber has raised" do
+      fiber = Fiber.new(blocking: true) { raise "from the fiber" }
+      -> { fiber.resume }.should.raise(RuntimeError)
+      Fiber.current_scheduler.should == nil
+    end
+
+    it "returns nil on the root Fiber after a blocking Fiber has been killed" do
+      fiber = Fiber.new(blocking: true) { Fiber.yield }
+      fiber.resume
+      fiber.kill
+      Fiber.current_scheduler.should == nil
+    end
   end
 end


### PR DESCRIPTION
The existing examples all check what a Fiber sees while it is running, so nothing covered the root Fiber once a blocking Fiber has gone away. Cover normal completion, an exception propagating out of resume, and Fiber#kill.