### PR TITLE
Add Time.new specs for strings ending where a colon is expected

### DIFF
--- a/core/time/new_spec.rb
+++ b/core/time/new_spec.rb
@@ -570,6 +570,23 @@ describe "Time.new with a timezone argument" do
       }.should.raise(ArgumentError, /missing min part: 00 |can't parse:/)
     end
 
+    # These strings end exactly at the byte where the parser expects a ':', so
+    # the message has no offending byte to append. The other error cases here
+    # all carry a trailing zone, which left that boundary unexercised.
+    it "raises ArgumentError if the time string ends where a ':' is expected" do
+      -> {
+        Time.new("2020-12-25 00:56")
+      }.should.raise(ArgumentError, /\Amissing sec part: 00:56\z|can't parse:/)
+
+      -> {
+        Time.new("2020-12-25T00:56")
+      }.should.raise(ArgumentError, /\Amissing sec part: 00:56\z|can't parse:/)
+
+      -> {
+        Time.new("2020-12-25 00")
+      }.should.raise(ArgumentError, /\Amissing min part: 00\z|can't parse:/)
+    end
+
     it "raises ArgumentError if the time part is missing" do
       -> {
         Time.new("2020-12-25")


### PR DESCRIPTION
`core/time/new_spec.rb` covers the `Time.new(String)` parse errors thoroughly, but
every error-case string in it ends with a trailing zone suffix — ` +09:00`, ` +0900`
or `Z`. CRuby's own `TestTime#test_new_from_string` does the same. So no test
exercises a string that ends *exactly* at the byte where the parser expects a `:`.

That byte matters. These messages are formatted with `%.*s` and a length of one past
the consumed region, so they normally include the byte that failed the check —
`"missing sec part: 00:56 "` keeps its trailing space, `"fraction min is not
supported: 00:56."` keeps its dot. When the string ends at that position there is no
such byte, the precision runs into the string's terminator, and the message stops
short: `"missing sec part: 00:56"`. That form was untested.

Three examples for it:

| input | bytes | message |
| --- | --- | --- |
| `"2020-12-25 00:56"` | 16 | `missing sec part: 00:56` |
| `"2020-12-25T00:56"` | 16 | `missing sec part: 00:56` |
| `"2020-12-25 00"` | 13 | `missing min part: 00` |

One byte shorter (`"2020-12-25 00:5"`) and the two-digit check fires first; one byte
longer (`"2020-12-25 00:56Z"`) and there is a byte to report. The boundary is exact.

The expectations are anchored with `\A...\z`, as several neighbouring examples in the
file already are, so they genuinely distinguish the truncated message from the form
that carries a trailing byte. They keep the usual `|can't parse:` alternative for
implementations that raise the generic error.

CRuby raises exactly these messages today. JRuby 10 does not — it reads one byte past
the end of the string while building the message, and an
`ArrayIndexOutOfBoundsException` escapes in place of the `ArgumentError`. Reported as
jruby/jruby#9623, fix in jruby/jruby#9624; until that ships, JRuby will need to tag
this example.

The omission was spotted by @sampokuokkanen while reviewing jruby/jruby#9624 — thanks
for noticing that everything in the existing set carries a zone suffix.
