### PR TITLE
Add a spec for Enumerator#size of zero

### DIFF
--- a/core/enumerator/size_spec.rb
+++ b/core/enumerator/size_spec.rb
@@ -5,6 +5,10 @@ describe "Enumerator#size" do
     Enumerator.new(100) {}.size.should == 100
   end
 
+  it "returns 0 if set size is 0" do
+    Enumerator.new(0) {}.size.should == 0
+  end
+
   it "returns nil if set size is nil" do
     Enumerator.new(nil) {}.size.should == nil
   end


### PR DESCRIPTION
👋🏾 Found this when doing some work on `garnetjs`. After doing some digging verified it was a potential issue and impacted Opal in the same way. `Enumerator#size` returns the size of the enumerator, or nil when the size cannot be determined without iterating. 'core/enumerator/size_spec.rb' pins an Integer size (100), nil, and a Proc, but never zero.

The case cannot fail on CRuby, where 0 is truthy and INT2FIX(0) is a nonzero VALUE distinct from Qnil. It can fail on implementations hosted in a language where 0 is falsy: Opal returns nil for Enumerator.new(0) {}.size, because `opal/corelib/enumerator.rb` assigns the size with `arguments[0] || nil` and JS || collapses a size of 0 to nil. The neighbouring Enumerator.new(100) example passes there, so nothing in the suite currently detects this.

Matchers follow the existing examples in the file.

## Reproduction steps

Reproducing the Opal failure (requires Node, since Opal compiles to JS):
```
$ gem install opal          # tested with 1.8.3

$ opal --no-exit -e 'p Enumerator.new(100) {}.size; p Enumerator.new(0) {}.size' 
100
nil

$ ruby --disable-gems -e 'p Enumerator.new(100) {}.size; p Enumerator.new(0) {}.size'
100
0
```
The existing `Enumerator.new(100)` example passes on Opal. Only the new case will fail.

Cause — `opal/corelib/enumerator.rb:33`, inside `Enumerator#initialize`:

```ruby
@size = `arguments[0] || nil`
```
That's inline JavaScript. 0 || nil evaluates to nil because 0 is falsy in JS, so a known size of zero becomes "size unknown." Nothing downstream can recover it — `#size` (line 56) just returns `@size`:

```ruby
def size
  @size.respond_to?(:call) ? @size.call(*@args) : @size
end
```